### PR TITLE
feat: add nsenter-based command execution in tools sidecar with full test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 
 dependencies = [
     "dreadnode>=1.17.0",
+    "rigging @ git+https://github.com/dreadnode/rigging.git@5f9b33da3f5546ed2a65166b97b2f5efae824015",
     "cyclopts>=4.2.0",
     "loguru>=0.7.3",
     "httpx>=0.28.0,<1.0.0",
@@ -69,6 +70,9 @@ Documentation = "https://docs.dreadnode.io"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ares"]

--- a/src/ares/core/worker.py
+++ b/src/ares/core/worker.py
@@ -370,8 +370,48 @@ class RedisWorkerAgent:
         finally:
             self._current_task = None
 
+    def _find_tools_container_pid(self) -> int | None:
+        """Find the PID of the tools sidecar container.
+
+        With shareProcessNamespace: true, we can see all processes in the pod.
+        The tools container runs 'sleep infinity' as its main process.
+
+        Returns:
+            PID of tools container if found, None otherwise.
+        """
+        import subprocess
+
+        try:
+            result = subprocess.run(  # nosec B607
+                ["ps", "aux"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            for line in result.stdout.splitlines():
+                if "sleep infinity" in line and "grep" not in line:
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        try:
+                            pid = int(parts[1])
+                            logger.debug(f"Found tools container at PID {pid}")
+                            return pid
+                        except ValueError:
+                            continue
+        except Exception as e:
+            logger.warning(f"Failed to find tools container PID: {e}")
+
+        return None
+
     async def _execute_command_task(self, task: TaskMessage) -> None:
-        """Execute a command task directly via subprocess."""
+        """Execute a command task in the tools sidecar container.
+
+        Uses nsenter to execute commands in the tools container's mount namespace.
+        Requires:
+        - shareProcessNamespace: true (pod-level)
+        - CAP_SYS_ADMIN capability (ares-worker container)
+        """
         import subprocess
 
         payload = task.payload
@@ -382,15 +422,57 @@ class RedisWorkerAgent:
         logger.info(f"[{self.agent_name}] Executing command: {command[:100]}...")
 
         try:
-            result = subprocess.run(  # noqa: S602, ASYNC221  # nosec B602
-                command,
-                shell=True,  # nosec B602
+            if not hasattr(self, "_tools_pid"):
+                self._tools_pid = self._find_tools_container_pid()
+
+            if not self._tools_pid:
+                error_msg = (
+                    "Cannot find tools container. The pod must have shareProcessNamespace: true "
+                    "and the tools container must run 'sleep infinity'."
+                )
+                logger.error(error_msg)
+                await self.task_queue.send_result(
+                    task_id=task.task_id,
+                    success=False,
+                    error=error_msg,
+                    worker_pod=self.pod_name,
+                )
+                return
+
+            nsenter_cmd = [
+                "nsenter",
+                "-t",
+                str(self._tools_pid),
+                "-m",
+                "-w",
+                "/bin/bash",
+                "-c",
+                f"cd {working_dir} && {command}",
+            ]
+
+            logger.debug(f"Executing via nsenter into PID {self._tools_pid}")
+            result = subprocess.run(  # noqa: ASYNC221
+                nsenter_cmd,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
-                cwd=working_dir,
                 check=False,
             )
+
+            if result.returncode != 0 and "Operation not permitted" in result.stderr:
+                error_msg = (
+                    "nsenter failed: Operation not permitted. "
+                    "The ares-worker container needs CAP_SYS_ADMIN capability. "
+                    "Add to pod spec: securityContext.capabilities.add: [SYS_ADMIN]"
+                )
+                logger.error(error_msg)
+                await self.task_queue.send_result(
+                    task_id=task.task_id,
+                    success=False,
+                    error=error_msg,
+                    worker_pod=self.pod_name,
+                )
+                return
 
             await self.task_queue.send_result(
                 task_id=task.task_id,
@@ -413,6 +495,7 @@ class RedisWorkerAgent:
                 worker_pod=self.pod_name,
             )
         except Exception as e:
+            logger.error(f"Command execution failed: {e}")
             await self.task_queue.send_result(
                 task_id=task.task_id,
                 success=False,

--- a/tests/integration/test_redis_task_queue_integration.py
+++ b/tests/integration/test_redis_task_queue_integration.py
@@ -758,5 +758,403 @@ class TestStatePersistence:
         mock_redis_client.expire.assert_called_with("ares:results:test_task", 3600)
 
 
+# ============================================================================
+# Tools Container PID Discovery Tests
+# ============================================================================
+
+
+class TestFindToolsContainerPid:
+    """Tests for _find_tools_container_pid method."""
+
+    @pytest.mark.asyncio
+    async def test_find_tools_container_pid_success(self, task_queue, mock_agent):
+        """Test successful discovery of tools container PID."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        # Mock ps aux output with sleep infinity process
+        mock_ps_output = """USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0   4240   728 ?        Ss   10:00   0:00 /pause
+root        15  0.0  0.0   2392   752 ?        Ss   10:00   0:00 sleep infinity
+root       100  0.5  1.0 123456 12345 ?        Sl   10:00   0:05 python worker.py"""
+
+        mock_result = MagicMock()
+        mock_result.stdout = mock_ps_output
+        mock_result.returncode = 0
+
+        with patch("subprocess.run", return_value=mock_result):
+            pid = worker._find_tools_container_pid()
+
+        assert pid == 15
+
+    @pytest.mark.asyncio
+    async def test_find_tools_container_pid_not_found(self, task_queue, mock_agent):
+        """Test when tools container is not running."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        # Mock ps aux output without sleep infinity process
+        mock_ps_output = """USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0   4240   728 ?        Ss   10:00   0:00 /pause
+root       100  0.5  1.0 123456 12345 ?        Sl   10:00   0:05 python worker.py"""
+
+        mock_result = MagicMock()
+        mock_result.stdout = mock_ps_output
+        mock_result.returncode = 0
+
+        with patch("subprocess.run", return_value=mock_result):
+            pid = worker._find_tools_container_pid()
+
+        assert pid is None
+
+    @pytest.mark.asyncio
+    async def test_find_tools_container_pid_excludes_grep(self, task_queue, mock_agent):
+        """Test that grep processes are excluded from results."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        # Mock ps aux output with grep sleep infinity (should be excluded)
+        mock_ps_output = """USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.0  0.0   4240   728 ?        Ss   10:00   0:00 /pause
+root        50  0.0  0.0   2392   752 ?        S    10:00   0:00 grep sleep infinity
+root        15  0.0  0.0   2392   752 ?        Ss   10:00   0:00 sleep infinity"""
+
+        mock_result = MagicMock()
+        mock_result.stdout = mock_ps_output
+        mock_result.returncode = 0
+
+        with patch("subprocess.run", return_value=mock_result):
+            pid = worker._find_tools_container_pid()
+
+        # Should return 15 (actual sleep infinity), not 50 (grep)
+        assert pid == 15
+
+    @pytest.mark.asyncio
+    async def test_find_tools_container_pid_handles_exception(self, task_queue, mock_agent):
+        """Test graceful handling of subprocess failure."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        with patch("subprocess.run", side_effect=Exception("ps command failed")):
+            pid = worker._find_tools_container_pid()
+
+        assert pid is None
+
+    @pytest.mark.asyncio
+    async def test_find_tools_container_pid_invalid_pid_format(self, task_queue, mock_agent):
+        """Test handling of malformed PID in ps output."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        # Mock ps aux output with invalid PID format
+        mock_ps_output = """USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root       abc  0.0  0.0   2392   752 ?        Ss   10:00   0:00 sleep infinity"""
+
+        mock_result = MagicMock()
+        mock_result.stdout = mock_ps_output
+        mock_result.returncode = 0
+
+        with patch("subprocess.run", return_value=mock_result):
+            pid = worker._find_tools_container_pid()
+
+        assert pid is None
+
+
+# ============================================================================
+# Command Task Execution with nsenter Tests
+# ============================================================================
+
+
+class TestExecuteCommandTaskNsenter:
+    """Tests for _execute_command_task with nsenter namespace execution."""
+
+    @pytest.mark.asyncio
+    async def test_execute_command_success(self, task_queue, mock_agent, mock_redis_client):
+        """Test successful command execution via nsenter."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        # Set cached tools PID
+        worker._tools_pid = 15
+
+        task = TaskMessage(
+            task_id="cmd_001",
+            task_type="command",
+            source_agent="orchestrator",
+            target_agent="worker",
+            payload={
+                "command": "whoami",
+                "working_directory": "/tmp",
+                "timeout_seconds": 60,
+            },
+        )
+
+        mock_result = MagicMock()
+        mock_result.stdout = "root\n"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            await worker._execute_command_task(task)
+
+            call_args = mock_run.call_args
+            nsenter_cmd = call_args[0][0]
+            assert nsenter_cmd[0] == "nsenter"
+            assert "-t" in nsenter_cmd
+            assert "15" in nsenter_cmd
+            assert "-m" in nsenter_cmd
+            assert "/bin/bash" in nsenter_cmd
+
+        mock_redis_client.lpush.assert_called()
+        call_args = mock_redis_client.lpush.call_args
+        result_json = call_args[0][1]
+        result_data = json.loads(result_json)
+        assert result_data["success"] is True
+        assert result_data["result"]["stdout"] == "root\n"
+        assert result_data["result"]["return_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_command_tools_container_not_found(
+        self, task_queue, mock_agent, mock_redis_client
+    ):
+        """Test error when tools container cannot be found."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        task = TaskMessage(
+            task_id="cmd_002",
+            task_type="command",
+            source_agent="orchestrator",
+            target_agent="worker",
+            payload={"command": "whoami"},
+        )
+
+        with patch.object(worker, "_find_tools_container_pid", return_value=None):
+            await worker._execute_command_task(task)
+
+        call_args = mock_redis_client.lpush.call_args
+        result_json = call_args[0][1]
+        result_data = json.loads(result_json)
+        assert result_data["success"] is False
+        assert "Cannot find tools container" in result_data["error"]
+        assert "shareProcessNamespace" in result_data["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_command_nsenter_permission_denied(
+        self, task_queue, mock_agent, mock_redis_client
+    ):
+        """Test handling of nsenter permission error (missing CAP_SYS_ADMIN)."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        worker._tools_pid = 15
+
+        task = TaskMessage(
+            task_id="cmd_003",
+            task_type="command",
+            source_agent="orchestrator",
+            target_agent="worker",
+            payload={"command": "whoami"},
+        )
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = "nsenter: cannot open /proc/15/ns/mnt: Operation not permitted"
+        mock_result.returncode = 1
+
+        with patch("subprocess.run", return_value=mock_result):
+            await worker._execute_command_task(task)
+
+        call_args = mock_redis_client.lpush.call_args
+        result_json = call_args[0][1]
+        result_data = json.loads(result_json)
+        assert result_data["success"] is False
+        assert "Operation not permitted" in result_data["error"]
+        assert "CAP_SYS_ADMIN" in result_data["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_command_timeout(self, task_queue, mock_agent, mock_redis_client):
+        """Test handling of command timeout."""
+        import subprocess
+
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        worker._tools_pid = 15
+
+        task = TaskMessage(
+            task_id="cmd_004",
+            task_type="command",
+            source_agent="orchestrator",
+            target_agent="worker",
+            payload={
+                "command": "sleep 1000",
+                "timeout_seconds": 5,
+            },
+        )
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("nsenter", 5)):
+            await worker._execute_command_task(task)
+
+        call_args = mock_redis_client.lpush.call_args
+        result_json = call_args[0][1]
+        result_data = json.loads(result_json)
+        assert result_data["success"] is False
+        assert "timed out" in result_data["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_command_general_exception(
+        self, task_queue, mock_agent, mock_redis_client
+    ):
+        """Test handling of general execution exception."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        worker._tools_pid = 15
+
+        task = TaskMessage(
+            task_id="cmd_005",
+            task_type="command",
+            source_agent="orchestrator",
+            target_agent="worker",
+            payload={"command": "whoami"},
+        )
+
+        with patch("subprocess.run", side_effect=Exception("Unexpected error")):
+            await worker._execute_command_task(task)
+
+        call_args = mock_redis_client.lpush.call_args
+        result_json = call_args[0][1]
+        result_data = json.loads(result_json)
+        assert result_data["success"] is False
+        assert "Unexpected error" in result_data["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_command_caches_tools_pid(
+        self, task_queue, mock_agent, mock_redis_client
+    ):
+        """Test that tools PID is cached after first lookup."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        task = TaskMessage(
+            task_id="cmd_006",
+            task_type="command",
+            source_agent="orchestrator",
+            target_agent="worker",
+            payload={"command": "echo test"},
+        )
+
+        mock_result = MagicMock()
+        mock_result.stdout = "test\n"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with (
+            patch.object(worker, "_find_tools_container_pid", return_value=42) as mock_find,
+            patch("subprocess.run", return_value=mock_result),
+        ):
+            await worker._execute_command_task(task)
+            assert mock_find.call_count == 1
+
+            await worker._execute_command_task(task)
+            assert mock_find.call_count == 1
+
+        assert worker._tools_pid == 42
+
+    @pytest.mark.asyncio
+    async def test_execute_command_with_nonzero_exit(
+        self, task_queue, mock_agent, mock_redis_client
+    ):
+        """Test command that returns non-zero exit code (but not permission error)."""
+        worker = RedisWorkerAgent(
+            role=AgentRole.CRACKER,
+            task_queue=task_queue,
+            agent=mock_agent,
+            agent_name="cracker-agent",
+            pod_name="cracker-0",
+        )
+
+        worker._tools_pid = 15
+
+        task = TaskMessage(
+            task_id="cmd_007",
+            task_type="command",
+            source_agent="orchestrator",
+            target_agent="worker",
+            payload={"command": "ls /nonexistent"},
+        )
+
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = "ls: cannot access '/nonexistent': No such file or directory"
+        mock_result.returncode = 2
+
+        with patch("subprocess.run", return_value=mock_result):
+            await worker._execute_command_task(task)
+
+        call_args = mock_redis_client.lpush.call_args
+        result_json = call_args[0][1]
+        result_data = json.loads(result_json)
+        assert result_data["success"] is True
+        assert result_data["result"]["return_code"] == 2
+        assert "No such file or directory" in result_data["result"]["stderr"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -175,6 +175,7 @@ dependencies = [
     { name = "kubernetes" },
     { name = "loguru" },
     { name = "redis" },
+    { name = "rigging" },
 ]
 
 [package.optional-dependencies]
@@ -220,6 +221,7 @@ requires-dist = [
     { name = "pygments", marker = "extra == 'docs'", specifier = ">=2.18.0" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.8.1" },
     { name = "redis", specifier = ">=7.1.0,<8.0.0" },
+    { name = "rigging", git = "https://github.com/dreadnode/rigging.git?rev=5f9b33da3f5546ed2a65166b97b2f5efae824015" },
 ]
 provides-extras = ["docs"]
 
@@ -2944,7 +2946,7 @@ wheels = [
 [[package]]
 name = "rigging"
 version = "3.3.5"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/dreadnode/rigging.git?rev=5f9b33da3f5546ed2a65166b97b2f5efae824015#5f9b33da3f5546ed2a65166b97b2f5efae824015" }
 dependencies = [
     { name = "colorama" },
     { name = "dreadnode" },
@@ -2957,10 +2959,6 @@ dependencies = [
     { name = "pydantic-xml" },
     { name = "ruamel-yaml" },
     { name = "xmltodict" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b2/4deaacda6b4237d9c5f8324b3458929e98b51158ed3eb3e6574a3ee31fa6/rigging-3.3.5.tar.gz", hash = "sha256:3f24ef62155f1049f0d485cf24649b4ded70a2771e49410da71b6c3d0fd626b4", size = 112840, upload-time = "2025-11-14T04:29:15.463Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/82/35c80126ba849b0c06529e2184e6e7c7a6bf6b0887ff95f041a7d7758554/rigging-3.3.5-py3-none-any.whl", hash = "sha256:e3cba9dca540488b71ded5e491ecdea1037b76e6e0501145079885aafc7a2bbf", size = 130701, upload-time = "2025-11-14T04:29:13.91Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Key Changes:**

- Added logic to execute commands within the tools container using nsenter for
  improved isolation and compatibility
- Introduced automated detection of the tools container PID via process listing
- Implemented detailed integration tests for PID discovery and command execution
- Updated dependencies and build config to support direct git reference installs

**Added:**

- nsenter-based command execution: RedisWorkerAgent now runs commands in the
  tools sidecar's mount namespace using nsenter, requiring shareProcessNamespace
  and CAP_SYS_ADMIN for proper operation
- Tools container PID discovery: Added method to scan running processes for
  "sleep infinity" and select the correct PID for namespace entry
- Comprehensive integration tests: Test cases for PID discovery, error handling,
  command execution success/failure, permission errors, timeouts, and PID caching
  in `test_redis_task_queue_integration.py`
- Direct dependency reference: Added rigging as a git-based dependency in
  `pyproject.toml` and `uv.lock` for up-to-date source usage

**Changed:**

- RedisWorkerAgent command execution: Replaced previous subprocess logic with
  nsenter-based invocation, including error handling for missing tools container,
  missing capabilities, and general execution errors
- Dependency management: Updated pyproject.toml and uv.lock to allow direct
  references and to pin rigging to a specific commit via git URL
- Build config: Enabled `allow-direct-references` in Hatch metadata for direct
  dependency support

**Removed:**

- Static wheel/sdist source URLs for rigging: These are now replaced by a git
  source reference for more precise dependency management