### PR TITLE
refactor: centralize redis url and namespace resolution in config

### DIFF
--- a/.taskfiles/remote/Taskfile.yaml
+++ b/.taskfiles/remote/Taskfile.yaml
@@ -10,7 +10,7 @@ vars:
   # Defaults
   NAMESPACE: '{{.NAMESPACE | default "attack-simulation"}}'
   ORCH_CONTAINER: '{{.ORCH_CONTAINER | default "orchestrator"}}'
-  WORKER_CONTAINER: '{{.WORKER_CONTAINER | default "worker"}}'
+  WORKER_CONTAINER: '{{.WORKER_CONTAINER | default "ares-worker"}}'
   SITE_PACKAGES: '/usr/local/lib/python3.12/site-packages'
 
 tasks:

--- a/config/multi-agent-production.yaml
+++ b/config/multi-agent-production.yaml
@@ -6,7 +6,7 @@
 operation:
   name: "ares-multi-agent"
   namespace: "attack-simulation"
-  redis_url: "redis://redis.attack-simulation.svc.cluster.local:6379"
+  # redis_url is derived from namespace (redis://redis.{namespace}.svc.cluster.local:6379)
   checkpoint_interval: 60  # seconds
 
 # Agent configurations

--- a/src/ares/cli_ops.py
+++ b/src/ares/cli_ops.py
@@ -7,6 +7,7 @@ from typing import Annotated
 import cyclopts
 from loguru import logger
 
+from ares.core.config import get_redis_url
 from ares.core.orchestrator_client import (
     get_operation_status,
     submit_operation,
@@ -38,15 +39,16 @@ async def submit(
     wait: Annotated[bool, cyclopts.Parameter(help="Wait for operation to complete")] = False,
     model: Annotated[str, cyclopts.Parameter(help="LLM model to use")] = "claude-sonnet-4-20250514",
     max_steps: Annotated[int, cyclopts.Parameter(help="Maximum agent steps")] = 200,
-    redis_url: Annotated[
-        str, cyclopts.Parameter(help="Redis URL")
-    ] = "redis://redis.attack-simulation.svc.cluster.local:6379",
+    redis_url: Annotated[str, cyclopts.Parameter(help="Redis URL (default: from config)")] = "",
 ) -> None:
     """Submit a multi-agent red team operation to the orchestrator service.
 
     Example:
         ares-ops submit dreadgoad sevenkingdoms.local --ips 10.0.4.90 10.0.4.129 --wait
     """
+    # Resolve config defaults
+    resolved_redis_url = redis_url or get_redis_url()
+
     # Generate operation ID if not provided
     if not operation_id:
         operation_id = f"multiagent-{uuid.uuid4().hex[:8]}"
@@ -80,7 +82,7 @@ async def submit(
             resume_from_checkpoint=resume,
             model=model,
             max_steps=max_steps,
-            redis_url=redis_url,
+            redis_url=resolved_redis_url,
             wait_for_completion=wait,
         )
 
@@ -101,19 +103,19 @@ async def submit(
 async def status(
     operation_id: Annotated[str, cyclopts.Parameter(help="Operation ID")],
     *,
-    redis_url: Annotated[
-        str, cyclopts.Parameter(help="Redis URL")
-    ] = "redis://redis.attack-simulation.svc.cluster.local:6379",
+    redis_url: Annotated[str, cyclopts.Parameter(help="Redis URL (default: from config)")] = "",
 ) -> None:
     """Get the status of an operation.
 
     Example:
         ares-ops status multiagent-abc123
     """
+    resolved_redis_url = redis_url or get_redis_url()
+
     try:
         result = await get_operation_status(
             operation_id=operation_id,
-            redis_url=redis_url,
+            redis_url=resolved_redis_url,
         )
 
         if result:
@@ -138,21 +140,21 @@ async def wait_for(
     operation_id: Annotated[str, cyclopts.Parameter(help="Operation ID")],
     *,
     timeout: Annotated[float, cyclopts.Parameter(help="Timeout in seconds")] = 3600.0,
-    redis_url: Annotated[
-        str, cyclopts.Parameter(help="Redis URL")
-    ] = "redis://redis.attack-simulation.svc.cluster.local:6379",
+    redis_url: Annotated[str, cyclopts.Parameter(help="Redis URL (default: from config)")] = "",
 ) -> None:
     """Wait for an operation to complete.
 
     Example:
         ares-ops wait-for multiagent-abc123 --timeout 7200
     """
+    resolved_redis_url = redis_url or get_redis_url()
+
     logger.info(f"Waiting for operation: {operation_id}")
 
     try:
         result = await wait_for_operation_completion(
             operation_id=operation_id,
-            redis_url=redis_url,
+            redis_url=resolved_redis_url,
             timeout=timeout,
         )
 

--- a/src/ares/core/config.py
+++ b/src/ares/core/config.py
@@ -14,6 +14,23 @@ from typing import Any
 import yaml
 from loguru import logger
 
+# Default namespace - single source of truth
+DEFAULT_NAMESPACE = "attack-simulation"
+
+
+def derive_redis_url(namespace: str, host: str = "redis", port: int = 6379) -> str:
+    """Derive Redis URL from namespace using K8s service DNS.
+
+    Args:
+        namespace: Kubernetes namespace where Redis is deployed.
+        host: Redis service name (default: "redis").
+        port: Redis port (default: 6379).
+
+    Returns:
+        Redis URL in format redis://{host}.{namespace}.svc.cluster.local:{port}
+    """
+    return f"redis://{host}.{namespace}.svc.cluster.local:{port}"
+
 
 @dataclass
 class AgentConfig:
@@ -32,9 +49,14 @@ class OperationConfig:
 
     # Operation settings
     name: str = "ares-multi-agent"
-    namespace: str = "attack-simulation"
-    redis_url: str = "redis://redis.attack-simulation.svc.cluster.local:6379"
+    namespace: str = DEFAULT_NAMESPACE
+    redis_url: str = ""  # Derived from namespace if not explicitly set
     checkpoint_interval: int = 60
+
+    def __post_init__(self) -> None:
+        """Derive redis_url from namespace if not explicitly set."""
+        if not self.redis_url:
+            self.redis_url = derive_redis_url(self.namespace)
 
     # Agent configurations
     agents: dict[str, AgentConfig] = field(default_factory=dict)
@@ -141,12 +163,14 @@ def _build_config(data: dict[str, Any]) -> OperationConfig:
                 tools=agent_data.get("tools", []),
             )
 
+    namespace = operation.get("namespace", DEFAULT_NAMESPACE)
+    # Only use explicit redis_url from config, otherwise derive from namespace
+    redis_url = operation.get("redis_url") or derive_redis_url(namespace)
+
     return OperationConfig(
         name=operation.get("name", "ares-multi-agent"),
-        namespace=operation.get("namespace", "attack-simulation"),
-        redis_url=operation.get(
-            "redis_url", "redis://redis.attack-simulation.svc.cluster.local:6379"
-        ),
+        namespace=namespace,
+        redis_url=redis_url,
         checkpoint_interval=operation.get("checkpoint_interval", 60),
         agents=agents,
         agent_heartbeat_timeout=timeouts.get("agent_heartbeat", 30),
@@ -173,13 +197,16 @@ def _resolve_env(value: str) -> str:
 
 def _apply_env_overrides(config: OperationConfig) -> OperationConfig:
     """Apply environment variable overrides to config."""
-    # Redis URL override
-    if redis_url := os.environ.get("ARES_REDIS_URL") or os.environ.get("REDIS_URL"):
-        config.redis_url = redis_url
+    # Check for explicit Redis URL override
+    explicit_redis_url = os.environ.get("ARES_REDIS_URL") or os.environ.get("REDIS_URL")
+    if explicit_redis_url:
+        config.redis_url = explicit_redis_url
 
-    # Namespace override
+    # Namespace override - re-derive redis_url if namespace changes and no explicit URL
     if namespace := os.environ.get("ARES_NAMESPACE"):
         config.namespace = namespace
+        if not explicit_redis_url:
+            config.redis_url = derive_redis_url(namespace)
 
     # Grafana overrides
     if grafana_url := os.environ.get("GRAFANA_URL"):
@@ -223,9 +250,11 @@ def clear_config_cache() -> None:
 
 
 __all__ = [
+    "DEFAULT_NAMESPACE",
     "AgentConfig",
     "OperationConfig",
     "clear_config_cache",
+    "derive_redis_url",
     "get_agent_config",
     "get_namespace",
     "get_redis_url",

--- a/src/ares/core/orchestrator.py
+++ b/src/ares/core/orchestrator.py
@@ -15,6 +15,7 @@ from dreadnode.agent import Agent, Thread
 from dreadnode.agent.stop import tool_use
 from loguru import logger
 
+from ares.core.config import get_namespace, get_redis_url
 from ares.core.dispatcher import RedTeamDispatcher
 from ares.core.factories.red_agents import (
     create_role_hooks,
@@ -118,8 +119,8 @@ async def run_multi_agent_operation(
     target_ips: list[str],
     initial_credential: Credential | None = None,
     resume_from_checkpoint: bool = False,
-    redis_url: str = "redis://redis.attack-simulation.svc.cluster.local:6379",
-    namespace: str = "attack-simulation",
+    redis_url: str | None = None,
+    namespace: str | None = None,
     model: str = "claude-sonnet-4-20250514",
     max_steps: int = 200,
     checkpoint_interval: int = 60,
@@ -133,8 +134,8 @@ async def run_multi_agent_operation(
         target_ips: List of target IPs to scan
         initial_credential: Optional initial credential
         resume_from_checkpoint: Resume from previous checkpoint
-        redis_url: Redis URL for state persistence
-        namespace: Kubernetes namespace
+        redis_url: Redis URL for state persistence (default: derived from config)
+        namespace: Kubernetes namespace (default: from config)
         model: LLM model to use
         max_steps: Maximum agent steps
         checkpoint_interval: Seconds between checkpoints
@@ -142,6 +143,10 @@ async def run_multi_agent_operation(
     Returns:
         Operation results summary
     """
+    # Resolve config defaults
+    redis_url = redis_url or get_redis_url()
+    namespace = namespace or get_namespace()
+
     start_time = datetime.now(timezone.utc)
 
     # Initialize infrastructure

--- a/src/ares/core/orchestrator_client.py
+++ b/src/ares/core/orchestrator_client.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from loguru import logger
 
+from ares.core.config import get_redis_url
 from ares.core.task_queue import RedisTaskQueue
 
 
@@ -21,7 +22,7 @@ async def submit_operation(
     model: str = "claude-sonnet-4-20250514",
     max_steps: int = 200,
     checkpoint_interval: int = 60,
-    redis_url: str = "redis://redis.attack-simulation.svc.cluster.local:6379",
+    redis_url: str | None = None,
     operations_queue: str = "ares:operations",
     wait_for_completion: bool = False,
     poll_interval: float = 10.0,
@@ -41,7 +42,7 @@ async def submit_operation(
         model: LLM model to use
         max_steps: Maximum agent steps
         checkpoint_interval: Seconds between checkpoints
-        redis_url: Redis connection URL
+        redis_url: Redis connection URL (default: from config)
         operations_queue: Redis queue name for operations
         wait_for_completion: If True, wait for operation to complete
         poll_interval: Seconds between status polls when waiting
@@ -52,6 +53,9 @@ async def submit_operation(
         - status: "submitted", "running", "completed", or "failed"
         - Additional status data if wait_for_completion=True
     """
+    # Resolve config defaults
+    redis_url = redis_url or get_redis_url()
+
     # Build operation request
     request = {
         "operation_id": operation_id,
@@ -162,17 +166,18 @@ async def wait_for_operation_completion(
 
 async def get_operation_status(
     operation_id: str,
-    redis_url: str = "redis://redis.attack-simulation.svc.cluster.local:6379",
+    redis_url: str | None = None,
 ) -> dict[str, Any] | None:
     """Get the current status of an operation.
 
     Args:
         operation_id: Operation ID
-        redis_url: Redis connection URL
+        redis_url: Redis connection URL (default: from config)
 
     Returns:
         Operation status dict or None if not found
     """
+    redis_url = redis_url or get_redis_url()
     task_queue = RedisTaskQueue(redis_url)
     await task_queue.connect()
 

--- a/src/ares/core/orchestrator_service.py
+++ b/src/ares/core/orchestrator_service.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from loguru import logger
 
+from ares.core.config import get_namespace, get_redis_url
 from ares.core.models import Credential
 from ares.core.orchestrator import run_multi_agent_operation
 from ares.core.task_queue import RedisTaskQueue
@@ -61,19 +62,19 @@ class OrchestratorService:
 
     def __init__(
         self,
-        redis_url: str = "redis://redis.attack-simulation.svc.cluster.local:6379",
-        namespace: str = "attack-simulation",
+        redis_url: str | None = None,
+        namespace: str | None = None,
         operations_queue: str = "ares:operations",
     ):
         """Initialize orchestrator service.
 
         Args:
-            redis_url: Redis connection URL
-            namespace: Kubernetes namespace
+            redis_url: Redis connection URL (default: from config)
+            namespace: Kubernetes namespace (default: from config)
             operations_queue: Redis queue for operation requests
         """
-        self.redis_url = redis_url
-        self.namespace = namespace
+        self.redis_url = redis_url or get_redis_url()
+        self.namespace = namespace or get_namespace()
         self.operations_queue = operations_queue
         self.task_queue: RedisTaskQueue | None = None
         self.running = False
@@ -263,9 +264,7 @@ class OrchestratorService:
 
 async def main() -> None:
     """Main entry point for orchestrator service."""
-    # Get configuration from environment
-    redis_url = os.getenv("REDIS_URL", "redis://redis.attack-simulation.svc.cluster.local:6379")
-    namespace = os.getenv("NAMESPACE", "attack-simulation")
+    # Get configuration from environment (operations_queue not in config system)
     operations_queue = os.getenv("OPERATIONS_QUEUE", "ares:operations")
 
     # Setup logging
@@ -276,10 +275,8 @@ async def main() -> None:
         level=os.getenv("LOG_LEVEL", "INFO"),
     )
 
-    # Create and start service
+    # Create and start service (redis_url and namespace from config system)
     service = OrchestratorService(
-        redis_url=redis_url,
-        namespace=namespace,
         operations_queue=operations_queue,
     )
 

--- a/src/ares/core/recovery.py
+++ b/src/ares/core/recovery.py
@@ -32,8 +32,8 @@ class OperationRecoveryManager:
 
     Usage:
         manager = OperationRecoveryManager(
-            redis_url="redis://redis.attack-simulation.svc.cluster.local:6379",
             k8s_executor=executor,
+            # redis_url defaults to config value from ares.core.config
         )
 
         # Regular checkpoints during operation

--- a/src/ares/core/task_queue.py
+++ b/src/ares/core/task_queue.py
@@ -13,6 +13,8 @@ from typing import Any
 from loguru import logger
 from pydantic import BaseModel
 
+from ares.core.config import get_redis_url
+
 
 class TaskMessage(BaseModel):
     """Task message structure for Redis queues."""
@@ -92,8 +94,8 @@ class RedisTaskQueue:
     RESULT_TTL = 86400  # 24 hours
     HEARTBEAT_TTL = 60  # 60 seconds
 
-    def __init__(self, redis_url: str = "redis://redis.attack-simulation.svc.cluster.local:6379"):
-        self.redis_url = redis_url
+    def __init__(self, redis_url: str | None = None):
+        self.redis_url = redis_url or get_redis_url()
         self._client = None
         self._connected = False
 

--- a/src/ares/core/worker.py
+++ b/src/ares/core/worker.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
+from ares.core.config import get_redis_url
 from ares.core.dispatcher import RedTeamDispatcher
 from ares.core.factories.red_agents import create_agent_info, create_specialized_agent
 from ares.core.messages import (
@@ -903,7 +904,7 @@ class WorkerAgent:
 async def run_worker(
     role: AgentRole,
     operation_id: str | None = None,
-    redis_url: str = "redis://redis.attack-simulation.svc.cluster.local:6379",
+    redis_url: str | None = None,
     model: str = "claude-sonnet-4-20250514",
     max_steps: int | None = None,
     discover_operation: bool = True,
@@ -920,13 +921,16 @@ async def run_worker(
     Args:
         role: The agent role (cracker, acl, privesc, lateral, poisoning, atomic).
         operation_id: The operation ID to join (optional - will discover if not provided).
-        redis_url: Redis URL for task queue and state.
+        redis_url: Redis URL for task queue and state (default: from config).
         model: LLM model to use.
         max_steps: Override default max steps for role.
         discover_operation: If True and operation_id is None/empty, discover from Redis.
         discovery_timeout: Max seconds to wait for operation discovery.
         use_redis_queue: If True, poll Redis queue for tasks (Kubernetes mode).
     """
+    # Resolve config defaults
+    redis_url = redis_url or get_redis_url()
+
     pod_name = os.environ.get("HOSTNAME", f"local-{role.value}")
 
     # Handle empty string operation IDs from k8s configmaps


### PR DESCRIPTION
**Key Changes:**

- Replaced hardcoded Redis URLs and namespaces with dynamic resolution via config
- Introduced `derive_redis_url` utility and centralized default handling
- Updated orchestrator, worker, and client interfaces to accept optional Redis URLs
- Enhanced environment variable and config overrides for Redis and namespace

**Added:**

- Utility function `derive_redis_url` to construct Redis URLs based on namespace
- Single source of truth for default namespace (`DEFAULT_NAMESPACE`) in config
- Automatic Redis URL and namespace resolution in orchestrator, worker, and client
- Docstrings and comments clarifying new config resolution logic

**Changed:**

- All functions/classes that previously used a hardcoded Redis URL or namespace
  now use config-driven defaults, falling back to `get_redis_url()` and
  `get_namespace()` when not explicitly provided
- Environment variable overrides improved: if `ARES_NAMESPACE` is set and no
  explicit Redis URL is given, the Redis URL is re-derived from the new namespace
- Task queue and orchestrator service classes now accept optional Redis URL and
  namespace arguments, defaulting to config values if omitted
- CLI operations (`submit`, `status`, `wait-for`) now use config-based Redis URL
  by default, with an empty string signaling auto-resolution
- Configuration YAML and comments updated to reflect that Redis URL is derived
  from namespace if not explicitly set

**Removed:**

- All hardcoded Redis URLs and namespaces from orchestrator, worker, task queue,
  CLI, and orchestrator service logic
- Redundant default Redis URL assignments throughout the codebase