### PR TITLE
feat: improve operation discovery robustness and add comprehensive tests

### DIFF
--- a/src/ares/core/worker.py
+++ b/src/ares/core/worker.py
@@ -35,24 +35,25 @@ if TYPE_CHECKING:
 
 
 async def discover_active_operation(  # noqa: PLR0912
-    redis_url: str, max_wait: int = 300, max_operation_age: int = 300
+    redis_url: str, max_wait: int | None = None, max_operation_age: int = 300
 ) -> str | None:
     """
     Discover an active operation from Redis by scanning for operation keys.
 
-    Waits up to max_wait seconds for an operation to appear.
+    Waits indefinitely (by default) for an operation to appear.
     Returns the most recently checkpointed operation ID, only if it was
     checkpointed within max_operation_age seconds.
 
     Args:
         redis_url: Redis connection URL
-        max_wait: Maximum seconds to wait for an operation (default: 300 = 5 minutes)
+        max_wait: Maximum seconds to wait for an operation (default: None = wait forever).
+            Set to a positive integer to timeout after that many seconds.
         max_operation_age: Maximum age in seconds for an operation to be considered
             active (default: 300 = 5 minutes). Operations with older checkpoints
             are ignored to prevent workers from joining stale operations.
 
     Returns:
-        Operation ID if found, None otherwise
+        Operation ID if found, None only if max_wait is set and exceeded
     """
     try:
         import redis.asyncio as redis_async
@@ -107,14 +108,17 @@ async def discover_active_operation(  # noqa: PLR0912
                 logger.info(f"Discovered active operation: {operation_id}")
                 return operation_id
 
-            # Check if we've exceeded max wait time
-            elapsed = asyncio.get_event_loop().time() - start_time
-            if elapsed >= max_wait:
-                logger.warning(f"No active operations found after {max_wait}s")
-                return None
+            # Check if we've exceeded max wait time (only if max_wait is set)
+            if max_wait is not None:
+                elapsed = asyncio.get_event_loop().time() - start_time
+                if elapsed >= max_wait:
+                    logger.warning(f"No active operations found after {max_wait}s")
+                    return None
 
-            # Wait before retrying
-            logger.debug("No operations found, waiting 10s before retry...")
+            # Wait before retrying (log less frequently to reduce noise)
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if int(elapsed) % 60 < 10:  # Log once per minute
+                logger.debug(f"No operations found, waiting... ({int(elapsed)}s elapsed)")
             await asyncio.sleep(10)
 
         except Exception as e:
@@ -908,7 +912,7 @@ async def run_worker(
     model: str = "claude-sonnet-4-20250514",
     max_steps: int | None = None,
     discover_operation: bool = True,
-    discovery_timeout: int = 300,
+    discovery_timeout: int | None = None,
     use_redis_queue: bool = True,
 ) -> None:
     """
@@ -925,7 +929,7 @@ async def run_worker(
         model: LLM model to use.
         max_steps: Override default max steps for role.
         discover_operation: If True and operation_id is None/empty, discover from Redis.
-        discovery_timeout: Max seconds to wait for operation discovery.
+        discovery_timeout: Max seconds to wait for operation discovery (default: None = wait forever).
         use_redis_queue: If True, poll Redis queue for tasks (Kubernetes mode).
     """
     # Resolve config defaults
@@ -939,11 +943,16 @@ async def run_worker(
 
     # Discover operation if not provided
     if operation_id is None and discover_operation:
-        logger.info("No operation ID provided, scanning Redis for active operations...")
+        if discovery_timeout is None:
+            logger.info("No operation ID provided, waiting indefinitely for an active operation...")
+        else:
+            logger.info(
+                f"No operation ID provided, waiting up to {discovery_timeout}s for an active operation..."
+            )
         operation_id = await discover_active_operation(redis_url, max_wait=discovery_timeout)
 
         if operation_id is None:
-            logger.error("No active operation found and none specified")
+            logger.error("No active operation found within timeout and none specified")
             return
 
     if operation_id is None:

--- a/src/ares/core/worker.py
+++ b/src/ares/core/worker.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import asyncio
 import os
+import random
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -44,6 +46,9 @@ async def discover_active_operation(  # noqa: PLR0912
     Returns the most recently checkpointed operation ID, only if it was
     checkpointed within max_operation_age seconds.
 
+    This function is cancellation-safe and will clean up resources properly
+    when cancelled (e.g., during graceful shutdown).
+
     Args:
         redis_url: Redis connection URL
         max_wait: Maximum seconds to wait for an operation (default: None = wait forever).
@@ -54,6 +59,9 @@ async def discover_active_operation(  # noqa: PLR0912
 
     Returns:
         Operation ID if found, None only if max_wait is set and exceeded
+
+    Raises:
+        asyncio.CancelledError: Re-raised after cleanup when the task is cancelled
     """
     try:
         import redis.asyncio as redis_async
@@ -61,74 +69,106 @@ async def discover_active_operation(  # noqa: PLR0912
         logger.error("redis package not installed, cannot discover operations")
         return None
 
-    start_time = asyncio.get_event_loop().time()
+    start_time = time.monotonic()
+    last_log_time = start_time
+    consecutive_errors = 0
+    client = None
 
-    while True:
-        client = None
-        try:
-            client = redis_async.from_url(redis_url)
-            await client.ping()
+    async def _cleanup_client() -> None:
+        """Close Redis client if open."""
+        nonlocal client
+        if client:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+            client = None
 
-            now = datetime.now(timezone.utc)
+    try:
+        while True:
+            try:
+                # Reuse existing connection or create new one
+                if client is None:
+                    client = redis_async.from_url(redis_url)
+                await client.ping()
 
-            # Scan for operation state keys
-            operations: list[tuple[str, datetime]] = []
-            async for key in client.scan_iter("ares:operation:*:state"):
-                # Extract operation ID from key: ares:operation:<op_id>:state
-                parts = key.decode().split(":")
-                if len(parts) >= 3:
-                    op_id = parts[2]
+                now = datetime.now(timezone.utc)
 
-                    # Get checkpoint time to find most recent operation
-                    time_key = f"ares:operation:{op_id}:checkpoint_time"
-                    checkpoint_data = await client.get(time_key)
+                # Scan for operation state keys
+                operations: list[tuple[str, datetime]] = []
+                async for key in client.scan_iter("ares:operation:*:state"):
+                    # Extract operation ID from key: ares:operation:<op_id>:state
+                    parts = key.decode().split(":")
+                    if len(parts) >= 3:
+                        op_id = parts[2]
 
-                    if checkpoint_data:
-                        checkpoint_time = datetime.fromisoformat(checkpoint_data.decode())
-                        # Ensure checkpoint_time is timezone-aware for comparison
-                        if checkpoint_time.tzinfo is None:
-                            checkpoint_time = checkpoint_time.replace(tzinfo=timezone.utc)
+                        # Get checkpoint time to find most recent operation
+                        time_key = f"ares:operation:{op_id}:checkpoint_time"
+                        checkpoint_data = await client.get(time_key)
 
-                        # Only consider operations checkpointed within max_operation_age
-                        age_seconds = (now - checkpoint_time).total_seconds()
-                        if age_seconds <= max_operation_age:
-                            operations.append((op_id, checkpoint_time))
-                        else:
-                            logger.debug(
-                                f"Ignoring stale operation {op_id} "
-                                f"(checkpoint age: {age_seconds:.0f}s > {max_operation_age}s)"
-                            )
+                        if checkpoint_data:
+                            checkpoint_time = datetime.fromisoformat(checkpoint_data.decode())
+                            # Ensure checkpoint_time is timezone-aware for comparison
+                            if checkpoint_time.tzinfo is None:
+                                checkpoint_time = checkpoint_time.replace(tzinfo=timezone.utc)
 
-            await client.aclose()
+                            # Only consider operations checkpointed within max_operation_age
+                            age_seconds = (now - checkpoint_time).total_seconds()
+                            if age_seconds <= max_operation_age:
+                                operations.append((op_id, checkpoint_time))
+                            else:
+                                logger.debug(
+                                    f"Ignoring stale operation {op_id} "
+                                    f"(checkpoint age: {age_seconds:.0f}s > "
+                                    f"{max_operation_age}s)"
+                                )
 
-            if operations:
-                # Return the most recently checkpointed operation
-                operations.sort(key=lambda x: x[1], reverse=True)
-                operation_id = operations[0][0]
-                logger.info(f"Discovered active operation: {operation_id}")
-                return operation_id
+                if operations:
+                    # Return the most recently checkpointed operation
+                    operations.sort(key=lambda x: x[1], reverse=True)
+                    operation_id = operations[0][0]
+                    logger.info(f"Discovered active operation: {operation_id}")
+                    await _cleanup_client()
+                    return operation_id
 
-            # Check if we've exceeded max wait time (only if max_wait is set)
-            if max_wait is not None:
-                elapsed = asyncio.get_event_loop().time() - start_time
-                if elapsed >= max_wait:
+                # Calculate elapsed time once for both timeout check and logging
+                elapsed = time.monotonic() - start_time
+
+                # Check if we've exceeded max wait time (only if max_wait is set)
+                if max_wait is not None and elapsed >= max_wait:
                     logger.warning(f"No active operations found after {max_wait}s")
+                    await _cleanup_client()
                     return None
 
-            # Wait before retrying (log less frequently to reduce noise)
-            elapsed = asyncio.get_event_loop().time() - start_time
-            if int(elapsed) % 60 < 10:  # Log once per minute
-                logger.debug(f"No operations found, waiting... ({int(elapsed)}s elapsed)")
-            await asyncio.sleep(10)
+                # Successful iteration (no errors) - reset backoff counter
+                consecutive_errors = 0
 
-        except Exception as e:
-            logger.warning(f"Failed to scan for operations: {e}")
-            if client:
-                try:
-                    await client.aclose()
-                except Exception:
-                    pass
-            await asyncio.sleep(5)
+                # Wait before retrying (log once per minute to reduce noise)
+                if elapsed - last_log_time >= 60:
+                    logger.debug(f"No operations found, waiting... ({int(elapsed)}s elapsed)")
+                    last_log_time = time.monotonic()
+                await asyncio.sleep(10)
+
+            except asyncio.CancelledError:  # noqa: PERF203
+                # Graceful shutdown - clean up and re-raise
+                logger.info("Operation discovery cancelled, cleaning up")
+                raise
+
+            except Exception as e:
+                consecutive_errors += 1
+                logger.warning(f"Failed to scan for operations: {e}")
+
+                # Close broken connection so we reconnect next iteration
+                await _cleanup_client()
+
+                # Exponential backoff with jitter, capped at 60s
+                backoff = min(5 * (2 ** (consecutive_errors - 1)), 60)
+                jitter = random.uniform(0, 1)  # nosec B311 # noqa: S311 - jitter for backoff
+                await asyncio.sleep(backoff + jitter)
+
+    finally:
+        # Ensure cleanup on any exit path
+        await _cleanup_client()
 
 
 # Mapping of message types to task prompt generators (for dispatcher-based messaging)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,657 @@
+"""Tests for worker module.
+
+Tests the discover_active_operation function and related worker utilities.
+"""
+
+# ruff: noqa: SIM117
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_redis_setup():
+    """Create a complete mock redis setup for testing discover_active_operation.
+
+    Returns a tuple of (mock_client, patch_context_manager) where:
+    - mock_client: The mock Redis client to configure
+    - patch_context_manager: A context manager that patches sys.modules
+    """
+    mock_client = AsyncMock()
+    mock_client.ping = AsyncMock(return_value=True)
+    mock_client.get = AsyncMock(return_value=None)
+    mock_client.aclose = AsyncMock()
+
+    mock_redis_async = MagicMock()
+    mock_redis_async.from_url = MagicMock(return_value=mock_client)
+
+    mock_redis = MagicMock()
+    mock_redis.asyncio = mock_redis_async
+
+    return mock_client, patch.dict(
+        sys.modules, {"redis": mock_redis, "redis.asyncio": mock_redis_async}
+    )
+
+
+@pytest.fixture
+def recent_checkpoint_time() -> bytes:
+    """Return a recent checkpoint time (within max_operation_age)."""
+    recent = datetime.now(timezone.utc) - timedelta(seconds=60)
+    return recent.isoformat().encode()
+
+
+@pytest.fixture
+def stale_checkpoint_time() -> bytes:
+    """Return a stale checkpoint time (older than max_operation_age)."""
+    stale = datetime.now(timezone.utc) - timedelta(seconds=600)
+    return stale.isoformat().encode()
+
+
+# ============================================================================
+# discover_active_operation Tests
+# ============================================================================
+
+
+class TestDiscoverActiveOperationFindsOperation:
+    """Tests for successfully discovering operations."""
+
+    @pytest.mark.asyncio
+    async def test_finds_operation_immediately(self, mock_redis_setup, recent_checkpoint_time):
+        """Test discovering an operation on first scan."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+        mock_client.get = AsyncMock(return_value=recent_checkpoint_time)
+
+        async def mock_scan_iter(pattern):
+            yield b"ares:operation:test-op-001:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch:
+            result = await discover_active_operation("redis://localhost:6379", max_wait=5)
+
+        assert result == "test-op-001"
+
+    @pytest.mark.asyncio
+    async def test_finds_most_recent_operation(self, mock_redis_setup):
+        """Test returning the most recently checkpointed operation."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        older_time = (now - timedelta(seconds=120)).isoformat().encode()
+        newer_time = (now - timedelta(seconds=30)).isoformat().encode()
+
+        async def mock_scan_iter(pattern):
+            yield b"ares:operation:old-op:state"
+            yield b"ares:operation:new-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        async def mock_get(key):
+            if "old-op" in key:
+                return older_time
+            if "new-op" in key:
+                return newer_time
+            return None
+
+        mock_client.get = mock_get
+
+        with redis_patch:
+            result = await discover_active_operation("redis://localhost:6379", max_wait=5)
+
+        assert result == "new-op"
+
+    @pytest.mark.asyncio
+    async def test_ignores_stale_operations(self, mock_redis_setup, stale_checkpoint_time):
+        """Test that stale operations are ignored."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+        mock_client.get = AsyncMock(return_value=stale_checkpoint_time)
+
+        async def mock_scan_iter(pattern):
+            yield b"ares:operation:stale-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch:
+            result = await discover_active_operation(
+                "redis://localhost:6379",
+                max_wait=1,
+                max_operation_age=300,
+            )
+
+        assert result is None
+
+
+class TestDiscoverActiveOperationTimeout:
+    """Tests for timeout behavior."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_after_timeout(self, mock_redis_setup):
+        """Test that function returns None after max_wait is exceeded."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        async def mock_scan_iter(pattern):
+            return
+            yield  # Make it a generator that yields nothing
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch, patch("asyncio.sleep", new_callable=AsyncMock):
+            start_time = 1000.0
+            call_count = 0
+
+            def mock_monotonic():
+                nonlocal call_count
+                result = start_time + (call_count * 5)
+                call_count += 1
+                return result
+
+            with patch("time.monotonic", side_effect=mock_monotonic):
+                result = await discover_active_operation("redis://localhost:6379", max_wait=2)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_respects_max_wait_value(self, mock_redis_setup):
+        """Test that different max_wait values are respected."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        async def mock_scan_iter(pattern):
+            return
+            yield
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch, patch("asyncio.sleep", new_callable=AsyncMock):
+            call_count = 0
+            start_time = 1000.0
+
+            def mock_monotonic():
+                nonlocal call_count
+                result = start_time + (call_count * 15)
+                call_count += 1
+                return result
+
+            with patch("time.monotonic", side_effect=mock_monotonic):
+                result = await discover_active_operation("redis://localhost:6379", max_wait=10)
+
+        assert result is None
+
+
+class TestDiscoverActiveOperationIndefiniteWait:
+    """Tests for indefinite wait behavior when max_wait is None."""
+
+    @pytest.mark.asyncio
+    async def test_waits_indefinitely_until_operation_found(self, mock_redis_setup):
+        """Test that function waits indefinitely until an operation is found."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=recent_time)
+
+        iteration_count = 0
+
+        async def mock_scan_iter(pattern):
+            nonlocal iteration_count
+            iteration_count += 1
+            if iteration_count >= 3:
+                yield b"ares:operation:found-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch, patch("asyncio.sleep", new_callable=AsyncMock):
+            with patch("time.monotonic", return_value=1000.0):
+                result = await discover_active_operation("redis://localhost:6379", max_wait=None)
+
+        assert result == "found-op"
+        assert iteration_count >= 3
+
+    @pytest.mark.asyncio
+    async def test_max_wait_none_does_not_timeout(self, mock_redis_setup):
+        """Test that max_wait=None never triggers timeout logic."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=recent_time)
+
+        iteration_count = 0
+        max_iterations = 5
+
+        async def mock_scan_iter(pattern):
+            nonlocal iteration_count
+            iteration_count += 1
+            if iteration_count >= max_iterations:
+                yield b"ares:operation:test-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch, patch("asyncio.sleep", new_callable=AsyncMock):
+            call_count = 0
+
+            def mock_monotonic():
+                nonlocal call_count
+                call_count += 1
+                # Simulate hours passing - should not matter with max_wait=None
+                return 1000.0 + (call_count * 3600)
+
+            with patch("time.monotonic", side_effect=mock_monotonic):
+                result = await discover_active_operation("redis://localhost:6379", max_wait=None)
+
+        assert result == "test-op"
+
+
+class TestDiscoverActiveOperationErrorHandling:
+    """Tests for error handling in discover_active_operation."""
+
+    @pytest.mark.asyncio
+    async def test_handles_redis_connection_error(self, mock_redis_setup):
+        """Test graceful handling of Redis connection errors."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=recent_time)
+
+        error_count = 0
+
+        async def mock_scan_iter(pattern):
+            nonlocal error_count
+            error_count += 1
+            if error_count < 3:
+                raise ConnectionError("Redis connection failed")
+            yield b"ares:operation:recovered-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch, patch("asyncio.sleep", new_callable=AsyncMock):
+            with patch("time.monotonic", return_value=1000.0):
+                result = await discover_active_operation("redis://localhost:6379", max_wait=None)
+
+        assert result == "recovered-op"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_redis_import_fails(self):
+        """Test returns None when redis package import fails."""
+        from ares.core.worker import discover_active_operation
+
+        with patch.dict(sys.modules, {"redis": None, "redis.asyncio": None}):
+            result = await discover_active_operation("redis://localhost:6379", max_wait=1)
+
+        assert result is None
+
+
+class TestDiscoverActiveOperationTimezoneHandling:
+    """Tests for timezone handling in checkpoint times."""
+
+    @pytest.mark.asyncio
+    async def test_handles_naive_datetime_checkpoint(self, mock_redis_setup):
+        """Test handling of naive (no timezone) checkpoint times."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        # Create a naive datetime that will be treated as UTC by the code
+        # The code does: checkpoint_time.replace(tzinfo=timezone.utc)
+        # So we need to create a naive time that's recent in UTC terms
+        now_utc = datetime.now(timezone.utc)
+        naive_time = now_utc.replace(tzinfo=None).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=naive_time)
+
+        async def mock_scan_iter(pattern):
+            yield b"ares:operation:naive-tz-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch:
+            result = await discover_active_operation("redis://localhost:6379", max_wait=5)
+
+        assert result == "naive-tz-op"
+
+    @pytest.mark.asyncio
+    async def test_handles_aware_datetime_checkpoint(self, mock_redis_setup):
+        """Test handling of timezone-aware checkpoint times."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        # Create an aware datetime with explicit UTC timezone
+        aware_time = datetime.now(timezone.utc).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=aware_time)
+
+        async def mock_scan_iter(pattern):
+            yield b"ares:operation:aware-tz-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        with redis_patch:
+            result = await discover_active_operation("redis://localhost:6379", max_wait=5)
+
+        assert result == "aware-tz-op"
+
+
+class TestDiscoverActiveOperationCancellation:
+    """Tests for graceful cancellation handling."""
+
+    @pytest.mark.asyncio
+    async def test_cancellation_cleans_up_resources(self, mock_redis_setup):
+        """Test that CancelledError triggers proper cleanup."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        async def mock_scan_iter(pattern):
+            return
+            yield
+
+        mock_client.scan_iter = mock_scan_iter
+
+        sleep_called = asyncio.Event()
+        real_sleep = asyncio.sleep
+
+        async def mock_sleep(delay):
+            sleep_called.set()
+            await real_sleep(delay)
+
+        with redis_patch, patch("time.monotonic", return_value=1000.0):
+            with patch("asyncio.sleep", side_effect=mock_sleep):
+                task = asyncio.create_task(
+                    discover_active_operation("redis://localhost:6379", max_wait=None)
+                )
+
+                # Wait until we're in the sleep call
+                await asyncio.wait_for(sleep_called.wait(), timeout=1.0)
+
+                # Cancel it
+                task.cancel()
+
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+                # Verify cleanup was called (in finally block)
+                mock_client.aclose.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_sleep_propagates(self, mock_redis_setup):
+        """Test that cancellation during sleep is handled properly."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        async def mock_scan_iter(pattern):
+            return
+            yield
+
+        mock_client.scan_iter = mock_scan_iter
+
+        sleep_called = asyncio.Event()
+        real_sleep = asyncio.sleep
+
+        async def mock_sleep(delay):
+            sleep_called.set()
+            # Actually wait so we can be cancelled
+            await real_sleep(delay)
+
+        with redis_patch, patch("time.monotonic", return_value=1000.0):
+            with patch("asyncio.sleep", side_effect=mock_sleep):
+                task = asyncio.create_task(
+                    discover_active_operation("redis://localhost:6379", max_wait=None)
+                )
+
+                # Wait until we're actually in the sleep
+                await asyncio.wait_for(sleep_called.wait(), timeout=1.0)
+
+                # Cancel
+                task.cancel()
+
+                # Should raise CancelledError
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+
+class TestDiscoverActiveOperationExponentialBackoff:
+    """Tests for exponential backoff on errors."""
+
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_consecutive_errors(self, mock_redis_setup):
+        """Test that backoff delay increases with consecutive errors."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=recent_time)
+
+        error_count = 0
+        sleep_delays = []
+
+        async def mock_scan_iter(pattern):
+            nonlocal error_count
+            error_count += 1
+            if error_count < 4:
+                raise ConnectionError("Redis connection failed")
+            yield b"ares:operation:recovered-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        async def capture_sleep(delay):
+            sleep_delays.append(delay)
+            # Don't actually sleep in tests
+
+        with redis_patch, patch("asyncio.sleep", side_effect=capture_sleep):
+            with patch("time.monotonic", return_value=1000.0):
+                with patch("ares.core.worker.random.uniform", return_value=0.5):
+                    result = await discover_active_operation(
+                        "redis://localhost:6379", max_wait=None
+                    )
+
+        assert result == "recovered-op"
+        # Should have 3 error sleeps with exponential backoff
+        # First error: 5 * 2^0 + 0.5 = 5.5
+        # Second error: 5 * 2^1 + 0.5 = 10.5
+        # Third error: 5 * 2^2 + 0.5 = 20.5
+        assert len(sleep_delays) >= 3
+        assert sleep_delays[0] == pytest.approx(5.5, rel=0.1)
+        assert sleep_delays[1] == pytest.approx(10.5, rel=0.1)
+        assert sleep_delays[2] == pytest.approx(20.5, rel=0.1)
+
+    @pytest.mark.asyncio
+    async def test_backoff_caps_at_60_seconds(self, mock_redis_setup):
+        """Test that backoff is capped at 60 seconds."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=recent_time)
+
+        error_count = 0
+        sleep_delays = []
+
+        async def mock_scan_iter(pattern):
+            nonlocal error_count
+            error_count += 1
+            if error_count < 10:
+                raise ConnectionError("Redis connection failed")
+            yield b"ares:operation:recovered-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        async def capture_sleep(delay):
+            sleep_delays.append(delay)
+
+        with redis_patch, patch("asyncio.sleep", side_effect=capture_sleep):
+            with patch("time.monotonic", return_value=1000.0):
+                with patch("ares.core.worker.random.uniform", return_value=0.5):
+                    result = await discover_active_operation(
+                        "redis://localhost:6379", max_wait=None
+                    )
+
+        assert result == "recovered-op"
+        # Later delays should be capped at 60 + jitter (0.5)
+        for delay in sleep_delays[4:]:  # After 4th error, should be capped
+            assert delay <= 60.5
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_after_success(self, mock_redis_setup):
+        """Test that error count resets after successful connection."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=recent_time)
+
+        call_count = 0
+        sleep_delays = []
+
+        async def mock_scan_iter(pattern):
+            nonlocal call_count
+            call_count += 1
+            # First call errors, second succeeds but no ops, third errors, fourth finds op
+            if call_count == 1:
+                raise ConnectionError("Error 1")
+            elif call_count == 2:
+                return  # Success but no operations
+                yield
+            elif call_count == 3:
+                raise ConnectionError("Error 2")
+            else:
+                yield b"ares:operation:test-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        async def capture_sleep(delay):
+            sleep_delays.append(delay)
+
+        with redis_patch, patch("asyncio.sleep", side_effect=capture_sleep):
+            with patch("time.monotonic", return_value=1000.0):
+                with patch("ares.core.worker.random.uniform", return_value=0.5):
+                    result = await discover_active_operation(
+                        "redis://localhost:6379", max_wait=None
+                    )
+
+        assert result == "test-op"
+        # First error: 5 + 0.5 = 5.5 (consecutive_errors=1)
+        # Second iteration succeeds (no ops found), resets count, normal sleep of 10
+        # Third error: 5 + 0.5 = 5.5 (consecutive_errors reset to 1)
+        # Error backoff sleeps have jitter (5.5), normal polling is 10
+        error_sleeps = [d for d in sleep_delays if d == pytest.approx(5.5, rel=0.1)]
+        assert len(error_sleeps) == 2  # Two separate errors, each reset to backoff=1
+
+
+class TestDiscoverActiveOperationConnectionReuse:
+    """Tests for Redis connection reuse."""
+
+    @pytest.mark.asyncio
+    async def test_reuses_connection_on_success(self, mock_redis_setup):
+        """Test that connection is reused across iterations when healthy."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, _redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=recent_time)
+
+        iteration_count = 0
+
+        async def mock_scan_iter(pattern):
+            nonlocal iteration_count
+            iteration_count += 1
+            if iteration_count >= 3:
+                yield b"ares:operation:test-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        mock_redis_async = MagicMock()
+        mock_redis_async.from_url = MagicMock(return_value=mock_client)
+        mock_redis = MagicMock()
+        mock_redis.asyncio = mock_redis_async
+
+        with (
+            patch.dict(sys.modules, {"redis": mock_redis, "redis.asyncio": mock_redis_async}),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with patch("time.monotonic", return_value=1000.0):
+                result = await discover_active_operation("redis://localhost:6379", max_wait=None)
+
+        assert result == "test-op"
+        # Connection should only be created once (reused across iterations)
+        assert mock_redis_async.from_url.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reconnects_after_error(self, mock_redis_setup):
+        """Test that connection is recreated after an error."""
+        from ares.core.worker import discover_active_operation
+
+        mock_client, _redis_patch = mock_redis_setup
+
+        now = datetime.now(timezone.utc)
+        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        mock_client.get = AsyncMock(return_value=recent_time)
+
+        error_count = 0
+
+        async def mock_scan_iter(pattern):
+            nonlocal error_count
+            error_count += 1
+            if error_count == 1:
+                raise ConnectionError("Connection lost")
+            yield b"ares:operation:test-op:state"
+
+        mock_client.scan_iter = mock_scan_iter
+
+        mock_redis_async = MagicMock()
+        mock_redis_async.from_url = MagicMock(return_value=mock_client)
+        mock_redis = MagicMock()
+        mock_redis.asyncio = mock_redis_async
+
+        with (
+            patch.dict(sys.modules, {"redis": mock_redis, "redis.asyncio": mock_redis_async}),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with patch("time.monotonic", return_value=1000.0):
+                with patch("ares.core.worker.random.uniform", return_value=0.0):
+                    result = await discover_active_operation(
+                        "redis://localhost:6379", max_wait=None
+                    )
+
+        assert result == "test-op"
+        # Connection created initially, then recreated after error
+        assert mock_redis_async.from_url.call_count == 2
+        # Client should have been closed after error
+        assert mock_client.aclose.call_count >= 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Key Changes:**

- Refactored `discover_active_operation` for robust cancellation and error handling
- Added exponential backoff with jitter on Redis errors
- Ensured resource cleanup and connection reuse in all exit paths
- Introduced a comprehensive test suite for operation discovery logic

**Added:**

- Comprehensive test suite for `discover_active_operation`, covering:
  - Success and failure scenarios, including operation discovery, timeouts,
    indefinite waits, cancellation, error handling, connection reuse, and
    exponential backoff logic
  - Timezone-aware and naive checkpoint time handling
  - Use of pytest fixtures and extensive mocking for Redis and async behaviors
  - Edge cases such as Redis import failures and graceful shutdowns
  - Located in `tests/test_worker.py`

**Changed:**

- Refactored `discover_active_operation` to:
  - Use `time.monotonic()` for more reliable elapsed time measurement
  - Add cancellation-safe logic and guarantee Redis connection cleanup on exit
  - Reuse healthy Redis connections across polling iterations and reconnect
    after errors only
  - Implement exponential backoff with jitter (capped at 60s) on consecutive
    Redis connection errors, resetting the backoff after successful scans
  - Improve logging for better traceability of polling, backoff, and shutdown
  - Log and skip over stale operations more clearly
  - Ensure both timezone-aware and naive checkpoint datetimes are handled
    correctly and consistently

**Removed:**

- Removed repeated Redis connection creation and teardown in each poll cycle,
  now using a persistent connection unless an error occurs