### PR TITLE
feat: improve agent orchestration, reporting, and credential guardrails

### DIFF
--- a/.taskfiles/remote/Taskfile.yaml
+++ b/.taskfiles/remote/Taskfile.yaml
@@ -310,9 +310,16 @@ tasks:
         fi
 
         # Sync to worker pods
+        if [ "{{.VERIFY_PVC_DIFF}}" = "true" ]; then
+          MANIFEST=$(mktemp /tmp/ares-sha256.XXXX)
+          (cd src/ares && find . -type d -name __pycache__ -prune -o -type f ! -name "*.pyc" -print0 | sort -z | xargs -0 shasum -a 256) > "$MANIFEST"
+        else
+          MANIFEST=""
+        fi
         if [ -n "$PODS" ]; then
           printf '%s\n' $PODS | xargs -n1 -P {{.PARALLELISM}} -I{} bash -c '
             pod="$1"
+            manifest="$2"
             worker_container="{{.WORKER_CONTAINER}}"
             if [ -z "$worker_container" ]; then
               worker_container=$(kubectl get pod -n {{.NAMESPACE}} "$pod" \
@@ -323,35 +330,106 @@ tasks:
             else
               container_flag=()
             fi
+            sync_ok="false"
             if kubectl exec -n {{.NAMESPACE}} "${container_flag[@]}" "$pod" -- \
                 mkdir -p {{.PVC_PATH}}/src/ares 2>/dev/null && \
               kubectl cp src/ares/. "$pod":{{.PVC_PATH}}/src/ares \
                 -n {{.NAMESPACE}} "${container_flag[@]}" 2>/dev/null; then
-              echo -e "{{.SUCCESS}}   -> $pod"
+              sync_ok="true"
             elif kubectl cp src/ares/. "$pod":{{.PVC_PATH}}/src/ares \
                 -n {{.NAMESPACE}} 2>/dev/null; then
-              echo -e "{{.SUCCESS}}   -> $pod"
+              sync_ok="true"
+            fi
+            if [ "{{.VERIFY_PVC_DIFF}}" = "true" ]; then
+              if [ "$sync_ok" = "true" ] && kubectl exec -n {{.NAMESPACE}} "${container_flag[@]}" "$pod" -- \
+                  mkdir -p {{.PVC_PATH}}/tmp 2>/dev/null && \
+                kubectl cp "$manifest" "$pod:{{.PVC_PATH}}/tmp/ares.sha256" \
+                  -n {{.NAMESPACE}} "${container_flag[@]}" 2>/dev/null; then
+                set +e
+                verify_out=$(kubectl exec -n {{.NAMESPACE}} "${container_flag[@]}" "$pod" -- \
+                  sh -c "cd {{.PVC_PATH}}/src/ares && sha256sum -c {{.PVC_PATH}}/tmp/ares.sha256" 2>&1)
+                verify_rc=$?
+                set -e
+                if [ $verify_rc -eq 0 ]; then
+                  echo -e "{{.SUCCESS}}   -> $pod (synced, pvc verified)"
+                else
+                  echo -e "{{.WARN}}   x $pod (synced, pvc differs)"
+                  failed_lines=$(printf "%s\n" "$verify_out" | grep -E "FAILED|No such file" || true)
+                  failed_count=$(printf "%s\n" "$failed_lines" | sed "/^$/d" | wc -l | tr -d " ")
+                  if [ "$failed_count" -gt 0 ]; then
+                    if [ "$failed_count" -gt 20 ]; then
+                      echo -e "{{.INFO}}   showing first 20 of $failed_count failures"
+                    fi
+                    printf "%s\n" "$failed_lines" | head -n 20
+                  else
+                    printf "%s\n" "$verify_out" | head -n 5
+                  fi
+                fi
+              else
+                echo -e "{{.WARN}}   x $pod (sync failed)"
+              fi
             else
-              echo -e "{{.WARN}}   x $pod"
+              if [ "$sync_ok" = "true" ]; then
+                echo -e "{{.SUCCESS}}   -> $pod (synced)"
+              else
+                echo -e "{{.WARN}}   x $pod (sync failed)"
+              fi
             fi
             exit 0
-          ' _ {}
+          ' _ {} "$MANIFEST"
         fi
 
         # Sync to orchestrator
         if [ -n "$ORCH_POD" ]; then
+          sync_ok="false"
           if kubectl exec -n {{.NAMESPACE}} -c {{.ORCH_CONTAINER}} "$ORCH_POD" -- \
               mkdir -p {{.PVC_PATH}}/src/ares 2>/dev/null && \
             kubectl cp src/ares/. "$ORCH_POD":{{.PVC_PATH}}/src/ares \
               -n {{.NAMESPACE}} -c {{.ORCH_CONTAINER}} 2>/dev/null; then
-            echo -e "{{.SUCCESS}}   -> $ORCH_POD"
+            sync_ok="true"
+          fi
+          if [ "{{.VERIFY_PVC_DIFF}}" = "true" ]; then
+            if [ "$sync_ok" = "true" ] && kubectl exec -n {{.NAMESPACE}} -c {{.ORCH_CONTAINER}} "$ORCH_POD" -- \
+                mkdir -p {{.PVC_PATH}}/tmp 2>/dev/null && \
+              kubectl cp "$MANIFEST" "$ORCH_POD:{{.PVC_PATH}}/tmp/ares.sha256" \
+                -n {{.NAMESPACE}} -c {{.ORCH_CONTAINER}} 2>/dev/null; then
+              set +e
+              verify_out=$(kubectl exec -n {{.NAMESPACE}} -c {{.ORCH_CONTAINER}} "$ORCH_POD" -- \
+                sh -c "cd {{.PVC_PATH}}/src/ares && sha256sum -c {{.PVC_PATH}}/tmp/ares.sha256" 2>&1)
+              verify_rc=$?
+              set -e
+              if [ $verify_rc -eq 0 ]; then
+                echo -e "{{.SUCCESS}}   -> $ORCH_POD (synced, pvc verified)"
+              else
+                echo -e "{{.WARN}}   x $ORCH_POD (synced, pvc differs)"
+                failed_lines=$(printf "%s\n" "$verify_out" | grep -E "FAILED|No such file" || true)
+                failed_count=$(printf "%s\n" "$failed_lines" | sed "/^$/d" | wc -l | tr -d " ")
+                if [ "$failed_count" -gt 0 ]; then
+                  if [ "$failed_count" -gt 20 ]; then
+                    echo -e "{{.INFO}}   showing first 20 of $failed_count failures"
+                  fi
+                  printf "%s\n" "$failed_lines" | head -n 20
+                else
+                  printf "%s\n" "$verify_out" | head -n 5
+                fi
+              fi
+            else
+              echo -e "{{.WARN}}   x $ORCH_POD (sync failed)"
+            fi
           else
-            echo -e "{{.WARN}}   x $ORCH_POD"
+            if [ "$sync_ok" = "true" ]; then
+              echo -e "{{.SUCCESS}}   -> $ORCH_POD (synced)"
+            else
+              echo -e "{{.WARN}}   x $ORCH_POD (sync failed)"
+            fi
           fi
         fi
 
         echo ""
         echo -e "{{.SUCCESS}} Full sync complete"
+        if [ -n "$MANIFEST" ]; then
+          rm -f "$MANIFEST"
+        fi
 
   # ============================================================================
   # SYNC:BRANCH: Sync only files changed on current branch
@@ -670,54 +748,49 @@ tasks:
   # LOGS: Tail pod logs
   # ============================================================================
   logs:
-    desc: "Tail logs from pods (usage: task remote:logs [ROLE=enum] [FOLLOW=true])"
+    desc: "Tail logs from pods (usage: task remote:logs [ROLE=enum|orchestrator] [FOLLOW=true])"
     silent: true
     vars:
       ROLE: '{{.ROLE | default ""}}'
       FOLLOW: '{{.FOLLOW | default "true"}}'
       LINES: '{{.LINES | default "100"}}'
+      MAX_LOG_REQUESTS: '{{.MAX_LOG_REQUESTS | default "20"}}'
     cmds:
       - |
-        if [ -n "{{.ROLE}}" ]; then
+        CONTAINER_ARGS=""
+        if [ "{{.ROLE}}" = "orchestrator" ]; then
+          SELECTOR="-l app.kubernetes.io/name=ares-orchestrator"
+          CONTAINER_ARGS="-c {{.ORCH_CONTAINER}}"
+          echo -e "{{.INFO}} Orchestrator logs:"
+        elif [ -n "{{.ROLE}}" ]; then
           SELECTOR="-l ares.dreadnode.io/role={{.ROLE}}"
+          if [ -n "{{.WORKER_CONTAINER}}" ]; then
+            CONTAINER_ARGS="-c {{.WORKER_CONTAINER}}"
+          fi
           echo -e "{{.INFO}} Logs from {{.ROLE}} agent:"
         else
           SELECTOR="-l ares.dreadnode.io/component=red-team"
+          if [ -n "{{.WORKER_CONTAINER}}" ]; then
+            CONTAINER_ARGS="-c {{.WORKER_CONTAINER}}"
+          fi
           echo -e "{{.INFO}} Logs from all agents:"
         fi
         echo "========================================"
 
         if [ "{{.FOLLOW}}" = "true" ]; then
-          if [ -n "{{.WORKER_CONTAINER}}" ]; then
-            kubectl logs -n {{.NAMESPACE}} $SELECTOR -c {{.WORKER_CONTAINER}} --tail={{.LINES}} -f --prefix=true 2>/dev/null || \
-              kubectl logs -n {{.NAMESPACE}} $SELECTOR --tail={{.LINES}} -f --prefix=true
+          if [ -n "$CONTAINER_ARGS" ]; then
+            kubectl logs -n {{.NAMESPACE}} $SELECTOR $CONTAINER_ARGS --tail={{.LINES}} -f --prefix=true --max-log-requests={{.MAX_LOG_REQUESTS}} 2>/dev/null || \
+              kubectl logs -n {{.NAMESPACE}} $SELECTOR --tail={{.LINES}} -f --prefix=true --max-log-requests={{.MAX_LOG_REQUESTS}}
           else
-            kubectl logs -n {{.NAMESPACE}} $SELECTOR --tail={{.LINES}} -f --prefix=true
+            kubectl logs -n {{.NAMESPACE}} $SELECTOR --tail={{.LINES}} -f --prefix=true --max-log-requests={{.MAX_LOG_REQUESTS}}
           fi
         else
-          if [ -n "{{.WORKER_CONTAINER}}" ]; then
-            kubectl logs -n {{.NAMESPACE}} $SELECTOR -c {{.WORKER_CONTAINER}} --tail={{.LINES}} --prefix=true 2>/dev/null || \
-              kubectl logs -n {{.NAMESPACE}} $SELECTOR --tail={{.LINES}} --prefix=true
+          if [ -n "$CONTAINER_ARGS" ]; then
+            kubectl logs -n {{.NAMESPACE}} $SELECTOR $CONTAINER_ARGS --tail={{.LINES}} --prefix=true --max-log-requests={{.MAX_LOG_REQUESTS}} 2>/dev/null || \
+              kubectl logs -n {{.NAMESPACE}} $SELECTOR --tail={{.LINES}} --prefix=true --max-log-requests={{.MAX_LOG_REQUESTS}}
           else
-            kubectl logs -n {{.NAMESPACE}} $SELECTOR --tail={{.LINES}} --prefix=true
+            kubectl logs -n {{.NAMESPACE}} $SELECTOR --tail={{.LINES}} --prefix=true --max-log-requests={{.MAX_LOG_REQUESTS}}
           fi
-        fi
-
-  logs:orchestrator:
-    desc: "Tail orchestrator logs"
-    silent: true
-    vars:
-      FOLLOW: '{{.FOLLOW | default "true"}}'
-      LINES: '{{.LINES | default "100"}}'
-    cmds:
-      - |
-        echo -e "{{.INFO}} Orchestrator logs:"
-        echo "========================================"
-
-        if [ "{{.FOLLOW}}" = "true" ]; then
-          kubectl logs -n {{.NAMESPACE}} -l app.kubernetes.io/name=ares-orchestrator -c {{.ORCH_CONTAINER}} --tail={{.LINES}} -f
-        else
-          kubectl logs -n {{.NAMESPACE}} -l app.kubernetes.io/name=ares-orchestrator -c {{.ORCH_CONTAINER}} --tail={{.LINES}}
         fi
 
   # ============================================================================

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -475,126 +475,21 @@ tasks:
         fi
 
   # ===========================================================================
-  # Ares Local Log Management
+  # Ares Logs
   # ===========================================================================
 
-  ares:logs:list:
-    desc: List all local agent logs
-    cmds:
-      - |
-        echo "Agent Logs:"
-        echo "==========="
-        if [ -d {{.LOG_DIR}} ]; then
-          ls -lht {{.LOG_DIR}}/*.log 2>/dev/null || echo "No logs found"
-        else
-          echo "Log directory not found: {{.LOG_DIR}}"
-        fi
-
-  ares:logs:tail:
-    desc: "Tail the latest log file (usage: task ares:logs:tail [LINES=100] [FOLLOW=true])"
+  ares:logs:
+    desc: "Tail remote logs (usage: task ares:logs [ROLE=enum|orchestrator] [LINES=100] [FOLLOW=true])"
     vars:
+      ROLE: '{{.ROLE | default ""}}'
+      FOLLOW: '{{.FOLLOW | default "true"}}'
       LINES: '{{.LINES | default "100"}}'
-      FOLLOW: '{{.FOLLOW | default "false"}}'
     cmds:
-      - |
-        LATEST=$(ls -t {{.LOG_DIR}}/*.log 2>/dev/null | head -1)
-        if [ -z "$LATEST" ]; then
-          echo "No logs found in {{.LOG_DIR}}"
-          exit 1
-        fi
-
-        echo "📋 Log file: $LATEST"
-        echo "======================================================================"
-
-        if [ "{{.FOLLOW}}" = "true" ]; then
-          tail -f "$LATEST"
-        else
-          tail -n {{.LINES}} "$LATEST"
-        fi
-
-  ares:logs:operation:
-    desc: "Tail logs for a multi-agent operation (usage: task ares:logs:operation OPERATION_ID=op-xxx [LINES=100] [FOLLOW=true])"
-    vars:
-      OPERATION_ID: '{{.OPERATION_ID | default ""}}'
-      LINES: '{{.LINES | default "100"}}'
-      FOLLOW: '{{.FOLLOW | default "false"}}'
-    preconditions:
-      - sh: test -n "{{.OPERATION_ID}}"
-        msg: "OPERATION_ID variable is required. Usage: task ares:logs:operation OPERATION_ID=op-xxx"
-    cmds:
-      - |
-        LATEST=$(ls -t {{.LOG_DIR}}/red-multi-{{.OPERATION_ID}}-*.log 2>/dev/null | head -1)
-        if [ -z "$LATEST" ]; then
-          LATEST=$(ls -t {{.LOG_DIR}}/orchestrator-{{.OPERATION_ID}}-*.log 2>/dev/null | head -1)
-        fi
-        if [ -z "$LATEST" ]; then
-          echo "No logs found for operation {{.OPERATION_ID}} in {{.LOG_DIR}}"
-          exit 1
-        fi
-
-        echo "📋 Operation log: $LATEST"
-        echo "======================================================================"
-
-        if [ "{{.FOLLOW}}" = "true" ]; then
-          tail -f "$LATEST"
-        else
-          tail -n {{.LINES}} "$LATEST"
-        fi
-
-  ares:logs:blue:
-    desc: "Tail the latest blue team log (usage: task ares:logs:blue [LINES=100] [FOLLOW=true])"
-    vars:
-      LINES: '{{.LINES | default "100"}}'
-      FOLLOW: '{{.FOLLOW | default "false"}}'
-    cmds:
-      - |
-        LATEST=$(ls -t {{.LOG_DIR}}/blue-*.log 2>/dev/null | head -1)
-        if [ -z "$LATEST" ]; then
-          echo "No blue team logs found in {{.LOG_DIR}}"
-          exit 1
-        fi
-
-        echo "📋 Blue team log: $LATEST"
-        echo "======================================================================"
-
-        if [ "{{.FOLLOW}}" = "true" ]; then
-          tail -f "$LATEST"
-        else
-          tail -n {{.LINES}} "$LATEST"
-        fi
-
-  ares:logs:red:
-    desc: "Tail the latest red team log (usage: task ares:logs:red [LINES=100] [FOLLOW=true])"
-    vars:
-      LINES: '{{.LINES | default "100"}}'
-      FOLLOW: '{{.FOLLOW | default "false"}}'
-    cmds:
-      - |
-        LATEST=$(ls -t {{.LOG_DIR}}/red-*.log 2>/dev/null | head -1)
-        if [ -z "$LATEST" ]; then
-          echo "No red team logs found in {{.LOG_DIR}}"
-          exit 1
-        fi
-
-        echo "📋 Red team log: $LATEST"
-        echo "======================================================================"
-
-        if [ "{{.FOLLOW}}" = "true" ]; then
-          tail -f "$LATEST"
-        else
-          tail -n {{.LINES}} "$LATEST"
-        fi
-
-  ares:logs:clean:
-    desc: Remove all local agent logs
-    cmds:
-      - |
-        read -p "Delete all logs in {{.LOG_DIR}}? (y/N) " -n 1 -r
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-          rm -rf {{.LOG_DIR}}/*.log
-          echo "✅ Logs cleaned"
-        fi
+      - task: remote:logs
+        vars:
+          ROLE: '{{.ROLE}}'
+          FOLLOW: '{{.FOLLOW}}'
+          LINES: '{{.LINES}}'
 
   ares:version:
     desc: Show Ares version information
@@ -638,7 +533,7 @@ tasks:
     internal: true
     vars:
       PROFILE: '{{.PROFILE | default "lab"}}'
-      REGION: '{{.REGION | default "us-west-2"}}'
+      REGION: '{{.REGION | default "us-west-1"}}'
     cmds:
       - |
         # Check if AWS CLI is installed
@@ -673,7 +568,7 @@ tasks:
     vars:
       TARGET: '{{.TARGET | default ""}}'
       PROFILE: '{{.PROFILE | default "lab"}}'
-      REGION: '{{.REGION | default "us-west-2"}}'
+      REGION: '{{.REGION | default "us-west-1"}}'
       REDTEAM_PROJECT: '{{.REDTEAM_PROJECT | default "ares-redteam"}}'
     preconditions:
       - sh: test -n "{{.TARGET}}"
@@ -781,7 +676,7 @@ tasks:
       RESUME: '{{.RESUME | default "false"}}'
       # Target resolution (where the AD targets live)
       TARGET_PROFILE: '{{.TARGET_PROFILE | default "lab"}}'
-      TARGET_REGION: '{{.TARGET_REGION | default "us-west-2"}}'
+      TARGET_REGION: '{{.TARGET_REGION | default "us-west-1"}}'
       # K8s cluster (where the agents run)
       K8S_NAMESPACE: '{{.K8S_NAMESPACE | default "attack-simulation"}}'
       REDTEAM_PROJECT: '{{.REDTEAM_PROJECT | default "ares-redteam"}}'
@@ -882,6 +777,25 @@ tasks:
       # Create log directory
       - cmd: mkdir -p {{.LOG_DIR}}
         silent: true
+
+      # Pin workers to this operation ID to avoid auto-discovery drift
+      - cmd: |
+          echo "🔧 Setting OPERATION_ID on worker deployments..."
+          for role in enum cracker acl privesc lateral poisoning; do
+            DEPLOYS=$(kubectl get deploy -n {{.K8S_NAMESPACE}} -l ares.dreadnode.io/role=$role -o name 2>/dev/null)
+            if [ -z "$DEPLOYS" ]; then
+              echo "   ⚠️  No deployments found for role: $role"
+              continue
+            fi
+            kubectl set env -n {{.K8S_NAMESPACE}} $DEPLOYS OPERATION_ID="{{.OPERATION_ID_COMPUTED}}"
+          done
+          echo "⏳ Waiting for worker rollouts..."
+          for role in enum cracker acl privesc lateral poisoning; do
+            for deploy in $(kubectl get deploy -n {{.K8S_NAMESPACE}} -l ares.dreadnode.io/role=$role -o name 2>/dev/null); do
+              kubectl rollout status -n {{.K8S_NAMESPACE}} "$deploy"
+            done
+          done
+        silent: false
 
       # Submit operation
       - cmd: |
@@ -1021,6 +935,84 @@ tasks:
                 print(f\"  {op['operation_id']}: checkpoint at {op['checkpoint_time']}\")
 
             await recovery.stop()
+
+        asyncio.run(main())
+        "
+
+  ares:red:multi:current:
+    desc: "Print current multi-agent operation ID (prefer running, fallback to latest)"
+    vars:
+      K8S_NAMESPACE: '{{.K8S_NAMESPACE | default "attack-simulation"}}'
+    cmds:
+      - |
+        REDIS_PASS=$(kubectl get secret redis-secret -n {{.K8S_NAMESPACE}} -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || echo "")
+        if [ -n "$REDIS_PASS" ]; then
+          REDIS_URL="redis://:${REDIS_PASS}@redis:6379"
+        else
+          REDIS_URL="redis://redis:6379"
+        fi
+
+        kubectl exec -n {{.K8S_NAMESPACE}} deploy/ares-orchestrator -- python -c "
+        import asyncio
+        from datetime import datetime
+
+        import redis.asyncio as redis
+
+        from ares.core.task_queue import RedisTaskQueue
+
+        def _pick_latest(items):
+            with_time = [item for item in items if item[0] is not None]
+            if with_time:
+                with_time.sort(key=lambda item: item[0], reverse=True)
+                return with_time[0][1]
+            items.sort(key=lambda item: item[1])
+            return items[0][1]
+
+        async def main():
+            client = redis.from_url('$REDIS_URL', decode_responses=True)
+            await client.ping()
+
+            running = []
+            async for key in client.scan_iter(f\"{RedisTaskQueue.LOCK_PREFIX}:*\"):
+                parts = key.split(':', 2)
+                if len(parts) < 3:
+                    continue
+                op_id = parts[2]
+                checkpoint_key = f'ares:operation:{op_id}:checkpoint_time'
+                checkpoint = await client.get(checkpoint_key)
+                checkpoint_time = None
+                if checkpoint:
+                    try:
+                        checkpoint_time = datetime.fromisoformat(checkpoint)
+                    except Exception:
+                        checkpoint_time = None
+                running.append((checkpoint_time, op_id))
+
+            if running:
+                print(_pick_latest(running))
+                return
+
+            operations = []
+            async for key in client.scan_iter('ares:operation:*:state'):
+                parts = key.split(':')
+                if len(parts) < 3:
+                    continue
+                op_id = parts[2]
+                checkpoint_key = f'ares:operation:{op_id}:checkpoint_time'
+                checkpoint = await client.get(checkpoint_key)
+                checkpoint_time = None
+                if checkpoint:
+                    try:
+                        checkpoint_time = datetime.fromisoformat(checkpoint)
+                    except Exception:
+                        checkpoint_time = None
+                operations.append((checkpoint_time, op_id))
+
+            if operations:
+                print(_pick_latest(operations))
+                return
+
+            print('No operations found')
 
         asyncio.run(main())
         "
@@ -1342,7 +1334,7 @@ tasks:
       LINES: '{{.LINES | default "100"}}'
       FOLLOW: '{{.FOLLOW | default "false"}}'
       PROFILE: '{{.PROFILE | default "lab"}}'
-      REGION: '{{.REGION | default "us-west-2"}}'
+      REGION: '{{.REGION | default "us-west-1"}}'
     deps:
       - task: check-aws-auth
         vars:

--- a/config/multi-agent-production.yaml
+++ b/config/multi-agent-production.yaml
@@ -12,7 +12,8 @@ operation:
 # Agent configurations
 agents:
   orchestrator:
-    model: "claude-sonnet-4-20250514"
+    model: "gpt-5.2"
+    # model: "claude-sonnet-4-20250514"
     max_steps: 200
     pod_selector: "ares.dreadnode.io/role=enum"
     tools:
@@ -33,7 +34,8 @@ agents:
       - announce_domain_admin
 
   enum:
-    model: "claude-sonnet-4-20250514"
+    model: "gpt-5.2"
+    # model: "claude-sonnet-4-20250514"
     max_steps: 100
     pod_selector: "ares.dreadnode.io/role=enum"
     capabilities:
@@ -46,7 +48,8 @@ agents:
       - enum4linux
 
   cracker:
-    model: "claude-sonnet-4-20250514"
+    model: "gpt-5.2"
+    # model: "claude-sonnet-4-20250514"
     max_steps: 50
     pod_selector: "ares.dreadnode.io/role=cracker"
     capabilities:
@@ -55,7 +58,8 @@ agents:
       - ntlmrelayx
 
   acl:
-    model: "claude-sonnet-4-20250514"
+    model: "gpt-5.2"
+    # model: "claude-sonnet-4-20250514"
     max_steps: 50
     pod_selector: "ares.dreadnode.io/role=acl"
     capabilities:
@@ -66,7 +70,8 @@ agents:
       - writedacl_abuse
 
   privesc:
-    model: "claude-sonnet-4-20250514"
+    model: "gpt-5.2"
+    # model: "claude-sonnet-4-20250514"
     max_steps: 100
     pod_selector: "ares.dreadnode.io/role=privesc"
     capabilities:
@@ -79,8 +84,9 @@ agents:
       - shadow_credentials
 
   lateral:
-    model: "claude-sonnet-4-20250514"
-    max_steps: 100
+    model: "gpt-5.2"
+    # model: "claude-sonnet-4-20250514"
+    max_steps: 200
     pod_selector: "ares.dreadnode.io/role=lateral"
     capabilities:
       - psexec
@@ -92,7 +98,8 @@ agents:
       - pass_the_ticket
 
   poisoning:
-    model: "claude-sonnet-4-20250514"
+    model: "gpt-5.2"
+    # model: "claude-sonnet-4-20250514"
     max_steps: 30
     pod_selector: "ares.dreadnode.io/role=poison"
     capabilities:
@@ -101,7 +108,8 @@ agents:
       - ntlmrelayx
 
   atomic:
-    model: "claude-sonnet-4-20250514"
+    model: "gpt-5.2"
+    # model: "claude-sonnet-4-20250514"
     max_steps: 50
     pod_selector: "ares.dreadnode.io/role=atomic"
     capabilities:
@@ -113,7 +121,7 @@ timeouts:
   agent_heartbeat: 30  # seconds - agent considered offline after this
   task_timeout: 300  # seconds - default task timeout
   operation_timeout: 7200  # seconds - 2 hours max operation time
-  lateral_movement: 60  # seconds
+  lateral_movement: 180  # seconds
   hash_cracking: 600  # seconds - 10 minutes
   exploitation: 300  # seconds
 

--- a/src/ares/cli_ops.py
+++ b/src/ares/cli_ops.py
@@ -25,6 +25,39 @@ app = cyclopts.App(
 )
 
 
+def _persist_report(
+    status: dict[str, object],
+    *,
+    operation_id: str,
+    report_dir: Path | None = None,
+) -> Path | None:
+    result_payload = status.get("result") if isinstance(status.get("result"), dict) else None
+    report_markdown = None
+    report_path = None
+    if result_payload:
+        report_markdown = result_payload.get("report_markdown")
+        report_path = result_payload.get("report_path")
+    else:
+        report_markdown = status.get("report_markdown")
+        report_path = status.get("report_path")
+
+    if not report_markdown:
+        return None
+
+    resolved_dir = Path(report_dir or "./reports").resolve()
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(report_path, str) and report_path:
+        filename = Path(report_path).name
+    else:
+        filename = f"{operation_id}_report.md"
+
+    output_path = resolved_dir / filename
+    output_path.write_text(str(report_markdown))
+    logger.success(f"Report saved: {output_path}")
+    return output_path
+
+
 async def _stream_orchestrator_logs(
     namespace: str,
     log_path: Path | None,
@@ -209,6 +242,7 @@ async def submit(
 
         if wait and result["status"] == "completed":
             logger.success("Operation completed successfully!")
+            _persist_report(result, operation_id=operation_id)
         elif wait and result["status"] == "failed":
             logger.error(f"Operation failed: {result.get('error', 'Unknown error')}")
 
@@ -259,6 +293,7 @@ async def status(
 
             if result["status"] == "completed":
                 logger.success("Operation completed successfully")
+                _persist_report(result, operation_id=operation_id)
             elif result["status"] == "failed":
                 logger.error(f"Operation failed: {result.get('error', 'Unknown')}")
         else:
@@ -296,6 +331,7 @@ async def wait_for(
 
         if result["status"] == "completed":
             logger.success("Operation completed successfully!")
+            _persist_report(result, operation_id=operation_id)
         elif result["status"] == "failed":
             logger.error(f"Operation failed: {result.get('error', 'Unknown error')}")
 

--- a/src/ares/core/dispatcher.py
+++ b/src/ares/core/dispatcher.py
@@ -946,7 +946,7 @@ class RedTeamDispatcher:
 
     # Task Completion
 
-    async def complete_task(
+    async def complete_task(  # noqa: PLR0912
         self,
         task_id: str,
         success: bool,
@@ -989,6 +989,55 @@ class RedTeamDispatcher:
             error=error,
         )
         self.shared_state.completed_tasks[task_id] = task_result
+
+        if success and isinstance(result, dict):
+            cred_data = result.get("credential")
+            if isinstance(cred_data, dict):
+                credential = Credential(
+                    username=cred_data.get("username", ""),
+                    password=cred_data.get("password", ""),
+                    domain=cred_data.get("domain", ""),
+                    source=cred_data.get("source", f"task:{task_id}"),
+                    is_admin=cred_data.get("is_admin", False),
+                )
+                await self.publish_credential(credential, source_agent)
+            creds_data = result.get("credentials")
+            if isinstance(creds_data, list):
+                for cred in creds_data:
+                    if not isinstance(cred, dict):
+                        continue
+                    credential = Credential(
+                        username=cred.get("username", ""),
+                        password=cred.get("password", ""),
+                        domain=cred.get("domain", ""),
+                        source=cred.get("source", f"task:{task_id}"),
+                        is_admin=cred.get("is_admin", False),
+                    )
+                    await self.publish_credential(credential, source_agent)
+
+            hash_data = result.get("hash")
+            if isinstance(hash_data, dict):
+                hash_obj = Hash(
+                    username=hash_data.get("username", ""),
+                    hash_value=hash_data.get("hash_value", ""),
+                    hash_type=hash_data.get("hash_type", "NTLM"),
+                    domain=hash_data.get("domain", ""),
+                    cracked_password=hash_data.get("cracked_password", ""),
+                )
+                await self.publish_hash(hash_obj, source_agent)
+            hashes_data = result.get("hashes")
+            if isinstance(hashes_data, list):
+                for h in hashes_data:
+                    if not isinstance(h, dict):
+                        continue
+                    hash_obj = Hash(
+                        username=h.get("username", ""),
+                        hash_value=h.get("hash_value", ""),
+                        hash_type=h.get("hash_type", "NTLM"),
+                        domain=h.get("domain", ""),
+                        cracked_password=h.get("cracked_password", ""),
+                    )
+                    await self.publish_hash(hash_obj, source_agent)
 
         # Broadcast completion
         if success:

--- a/src/ares/core/evidence_validation.py
+++ b/src/ares/core/evidence_validation.py
@@ -241,17 +241,10 @@ def validate_evidence_value(value: str) -> tuple[bool, str | None]:
     normalized_value = value.lower().strip()
 
     for stored in reversed(_recent_results):
+        # Exact match only
         if normalized_value in stored.extracted_values:
             logger.info(f"Evidence '{value[:50]}...' validated against query {stored.query_id}")
             return True, stored.query_id
-
-        # Also do a substring search in extracted values for partial matches
-        for extracted in stored.extracted_values:
-            if normalized_value in extracted or extracted in normalized_value:
-                logger.info(
-                    f"Evidence '{value[:50]}...' partially validated against query {stored.query_id}"
-                )
-                return True, stored.query_id
 
     logger.warning(f"Evidence '{value[:50]}...' could not be validated against recent queries")
     return False, None

--- a/src/ares/core/factories/red_agents.py
+++ b/src/ares/core/factories/red_agents.py
@@ -350,6 +350,8 @@ def create_specialized_agent(
             # Set shared state if toolset supports it
             if hasattr(toolset, "set_shared_state"):
                 toolset.set_shared_state(shared_state)
+            elif hasattr(toolset, "set_state"):
+                toolset.set_state(shared_state)
             if hasattr(toolset, "set_dispatcher"):
                 toolset.set_dispatcher(dispatcher)
             if hasattr(toolset, "set_executor") and pod_executor:

--- a/src/ares/core/litellm_env.py
+++ b/src/ares/core/litellm_env.py
@@ -1,0 +1,10 @@
+"""LiteLLM environment defaults for long-running agents."""
+
+from __future__ import annotations
+
+import os
+
+
+def configure_litellm_env() -> None:
+    """Set safe LiteLLM logging-worker defaults to reduce timeout noise."""
+    os.environ.setdefault("LOGGING_WORKER_MAX_TIME_PER_COROUTINE", "60")

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -636,6 +636,7 @@ class SharedRedTeamState:
     all_hosts: list[Host] = field(default_factory=list)
     all_users: list[User] = field(default_factory=list)
     all_shares: list[Share] = field(default_factory=list)
+    all_weaknesses: list[str] = field(default_factory=list)
 
     # Vulnerability registry
     discovered_vulnerabilities: dict[str, VulnerabilityInfo] = field(default_factory=dict)
@@ -646,6 +647,7 @@ class SharedRedTeamState:
     completed_tasks: dict[str, TaskResult] = field(default_factory=dict)
 
     # Success flags
+    completed: bool = False
     has_domain_admin: bool = False
     has_golden_ticket: bool = False
     domain_admin_path: str | None = None
@@ -659,6 +661,9 @@ class SharedRedTeamState:
 
     def add_credential(self, credential: Credential, source_agent: str) -> bool:
         """Add credential if not duplicate. Returns True if added."""
+        username = credential.username.strip()
+        if not username or username.lower() in {"(none)", "none", "null", "(null)"}:
+            return False
         key = f"{credential.domain}:{credential.username}:{credential.password}".lower()
         for existing in self.all_credentials:
             existing_key = f"{existing.domain}:{existing.username}:{existing.password}".lower()
@@ -736,6 +741,11 @@ class SharedRedTeamState:
     def shares(self) -> list[Share]:
         """Alias for all_shares (RedTeamState compatibility)."""
         return self.all_shares
+
+    @property
+    def weaknesses(self) -> list[str]:
+        """Alias for all_weaknesses (RedTeamState compatibility)."""
+        return self.all_weaknesses
 
     @property
     def queried_hosts(self) -> set[str]:

--- a/src/ares/core/orchestrator.py
+++ b/src/ares/core/orchestrator.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import dreadnode as dn
@@ -27,12 +28,15 @@ from ares.core.models import (
     AgentInfo,
     AgentRole,
     Credential,
+    InvestigationStage,
+    RedTeamState,
     SharedRedTeamState,
     Target,
 )
 from ares.core.recovery import OperationRecoveryManager
 from ares.core.task_queue import RedisTaskQueue
 from ares.core.workflows import exploitation_workflow
+from ares.reports.redteam import RedTeamReportGenerator
 from ares.tools.red.network import (
     BloodHoundTools,
     CertipyTools,
@@ -169,7 +173,6 @@ async def _prime_operation(
         logger.info("Initial checkpoint saved - workers can now discover operation")
     else:
         logger.warning("Failed to save initial checkpoint - workers may not discover operation")
-    _run_mandatory_user_enum(target_ips, target_domain, dispatcher.shared_state)
 
 
 def _log_orchestrator_result(result: rg.RunResult, model: str) -> None:
@@ -186,33 +189,98 @@ def _log_orchestrator_result(result: rg.RunResult, model: str) -> None:
     log_fn(log_msg)
 
 
-@dn.tool
-def complete_operation(summary: str) -> str:
+def _create_completion_tools(
+    shared_state: SharedRedTeamState,
+    dispatcher: RedTeamDispatcher,
+) -> tuple[Any, Any]:
     """
-    Mark the multi-agent red team operation as complete.
+    Create the completion tools that can access shared state.
 
-    Use this tool when you have:
-    - Achieved domain admin access OR exhausted all attack paths
-    - Coordinated with all specialized agents
-    - Collected all available credentials and hashes
-    - Generated golden ticket (if krbtgt hash was found)
-
-    Args:
-        summary: Executive summary of the operation including:
-            - All domain administrators compromised
-            - Attack paths used
-            - Total credentials obtained
-            - Hosts compromised
-            - Key vulnerabilities exploited
+    These tools are used as stop conditions for the orchestrator agent.
+    They need to modify the shared state, so we create them as closures.
 
     Returns:
-        Confirmation message
-
-    Example:
-        >>> complete_operation("Domain admin achieved via ADCS ESC1...")
+        Tuple of (complete_operation, announce_domain_admin) tools
     """
-    logger.success(f"🎯 Multi-agent operation completed: {summary}")
-    return f"✓ Operation marked as complete. Summary: {summary}"
+
+    @dn.tool
+    def complete_operation(summary: str) -> str:
+        """
+        Mark the multi-agent red team operation as complete.
+
+        Use this tool when you have:
+        - Achieved domain admin access OR exhausted all attack paths
+        - Coordinated with all specialized agents
+        - Collected all available credentials and hashes
+        - Generated golden ticket (if krbtgt hash was found)
+
+        Args:
+            summary: Executive summary of the operation including:
+                - All domain administrators compromised
+                - Attack paths used
+                - Total credentials obtained
+                - Hosts compromised
+                - Key vulnerabilities exploited
+
+        Returns:
+            Confirmation message
+
+        Example:
+            >>> complete_operation("Domain admin achieved via ADCS ESC1...")
+        """
+        shared_state.completed = True
+        logger.success(f"🎯 Multi-agent operation completed: {summary}")
+        return f"✓ Operation marked as complete. Summary: {summary}"
+
+    @dn.tool
+    async def announce_domain_admin(
+        domain: str,
+        username: str,
+        credential_type: str,
+        attack_path: str,
+    ) -> str:
+        """
+        Announce successful achievement of Domain Admin privileges.
+
+        Use this tool when you have confirmed Domain Admin access through:
+        - Valid DA credentials (password or hash)
+        - Forged Golden Ticket with krbtgt hash
+        - Successful DA-level command execution (e.g., DCSync, remote code execution on DC)
+
+        Args:
+            domain: Target domain name
+            username: Domain Admin username achieved
+            credential_type: Type of credential (password, hash, golden_ticket)
+            attack_path: Brief description of the attack path used to achieve DA
+
+        Returns:
+            Confirmation message
+
+        Example:
+            >>> await announce_domain_admin(
+            ...     domain="example.local",
+            ...     username="Administrator",
+            ...     credential_type="password",
+            ...     attack_path="ADCS ESC1 exploit -> cert auth"
+            ... )
+        """
+        await dispatcher.announce_domain_admin(
+            username=username,
+            domain=domain,
+            attack_path=attack_path,
+            credential_type=credential_type,
+            source_agent="ares-orchestrator",
+        )
+        logger.success(
+            f"🎯 DOMAIN ADMIN ACHIEVED! Domain: {domain}, User: {username}, "
+            f"Type: {credential_type}, Path: {attack_path}"
+        )
+        return (
+            f"✓ Domain Admin access confirmed for {domain}\\{username} "
+            f"via {credential_type} (attack path: {attack_path})"
+        )
+
+    return complete_operation, announce_domain_admin
 
 
 async def run_multi_agent_operation(
@@ -227,6 +295,7 @@ async def run_multi_agent_operation(
     max_steps: int = 200,
     checkpoint_interval: int = 60,
     openai_api_key: str | None = None,
+    report_dir: str | Path | None = None,
 ) -> dict[str, Any]:
     """
     Main entry point for multi-agent red team operations.
@@ -243,6 +312,7 @@ async def run_multi_agent_operation(
         max_steps: Maximum agent steps
         checkpoint_interval: Seconds between checkpoints
         openai_api_key: Optional OpenAI API key to bind directly to the generator
+        report_dir: Directory to write the final report (default: ./reports)
 
     Returns:
         Operation results summary
@@ -316,10 +386,7 @@ async def run_multi_agent_operation(
     )
 
     try:
-        # Do initial checkpoint so workers can discover the operation BEFORE
-        # calling _run_mandatory_user_enum (which is synchronous and blocks the event loop).
-        # The background checkpoint task won't get a chance to run until after
-        # _run_mandatory_user_enum returns.
+        # Do initial checkpoint so workers can discover the operation.
         await _prime_operation(recovery, dispatcher, target_ips, target_domain)
 
         # Create the orchestrator agent with tools
@@ -332,6 +399,19 @@ async def run_multi_agent_operation(
 
         logger.info(f"Starting orchestrator for {target_domain}")
         logger.info(f"Initial prompt:\n{initial_prompt}")
+
+        # Start mandatory user enumeration once the operation commences.
+        tasks.append(
+            asyncio.create_task(
+                asyncio.to_thread(
+                    _run_mandatory_user_enum,
+                    target_ips,
+                    target_domain,
+                    dispatcher.shared_state,
+                ),
+                name="mandatory_user_enum",
+            )
+        )
 
         # Run the orchestrator agent - this drives the entire operation
         with dn.run(tags=["multi-agent-operation", target_domain]):
@@ -349,12 +429,55 @@ async def run_multi_agent_operation(
 
             _log_orchestrator_result(result, model)
 
-        # Wait for any remaining background tasks
-        await _wait_for_completion(dispatcher, tasks, max_runtime=300.0)
+        stop_reason = getattr(result, "stop_reason", None)
+        if (
+            stop_reason == "max_steps_reached"
+            and not dispatcher.shared_state.pending_tasks
+            and not dispatcher.shared_state.completed
+        ):
+            dispatcher.shared_state.completed = True
+            logger.warning(
+                "Orchestrator stopped ({}) with no pending tasks; marking operation complete",
+                stop_reason,
+            )
+
+        if not dispatcher.shared_state.completed:
+            unexploited = [
+                vuln_id
+                for vuln_id in dispatcher.shared_state.discovered_vulnerabilities
+                if vuln_id not in dispatcher.shared_state.exploited_vulnerabilities
+            ]
+            if not dispatcher.shared_state.pending_tasks and not unexploited:
+                dispatcher.shared_state.completed = True
+                if stop_reason == "error":
+                    logger.warning(
+                        "Orchestrator stopped with error; no pending tasks or unexploited "
+                        "vulnerabilities, marking operation complete"
+                    )
+                else:
+                    logger.info(
+                        "No pending tasks or unexploited vulnerabilities; marking operation complete"
+                    )
+
+        if dispatcher.shared_state.completed:
+            logger.info("Operation marked complete; skipping post-run wait")
+        else:
+            # Wait for any remaining background tasks
+            await _wait_for_completion(dispatcher, tasks, max_runtime=300.0)
 
         # Get final state
         final_state = dispatcher.shared_state
         end_time = datetime.now(timezone.utc)
+
+        report_path = None
+        report_markdown = None
+        try:
+            report_path, report_markdown = _generate_multi_agent_report(
+                final_state,
+                report_dir=report_dir,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to generate report for {operation_id}: {e}")
 
         return {
             "operation_id": operation_id,
@@ -371,6 +494,8 @@ async def run_multi_agent_operation(
             "start_time": start_time.isoformat(),
             "end_time": end_time.isoformat(),
             "duration_seconds": (end_time - start_time).total_seconds(),
+            "report_path": str(report_path) if report_path else None,
+            "report_markdown": report_markdown,
         }
 
     except Exception as e:
@@ -401,6 +526,7 @@ async def _create_orchestrator_agent(
     Create the orchestrator agent that coordinates the multi-agent operation.
 
     The orchestrator has:
+    - Completion tools (complete_operation, announce_domain_admin) for stop conditions
     - OrchestratorTools for dispatching tasks to specialized agents
     - NetworkEnumerationTools for initial reconnaissance
     - CredentialDiscoveryTools for finding quick wins
@@ -417,6 +543,9 @@ async def _create_orchestrator_agent(
         Configured orchestrator agent
     """
     shared_state = dispatcher.shared_state
+
+    # Create completion tools that can modify shared state (for stop conditions)
+    complete_operation, announce_domain_admin = _create_completion_tools(shared_state, dispatcher)
 
     # Create orchestrator tools with dispatcher wired in
     orchestrator_tools = OrchestratorTools()
@@ -444,6 +573,8 @@ async def _create_orchestrator_agent(
     reporting_tools.set_state(shared_state)  # type: ignore[arg-type]
 
     tools = [
+        complete_operation,  # Stop condition tool for marking operation complete
+        announce_domain_admin,  # Stop condition tool for announcing DA achievement
         orchestrator_tools,  # Coordination tools (dispatch_*, get_*, broadcast_*)
         network_tools,  # nmap, enum4linux, crackmapexec
         cred_discovery_tools,  # ldap_search_descriptions, password_spray, etc.
@@ -451,7 +582,6 @@ async def _create_orchestrator_agent(
         certipy_tools,  # certipy_find for ADCS enumeration
         bloodhound_tools,  # run_bloodhound for attack path discovery
         reporting_tools,  # record_finding, generate_report
-        complete_operation,  # Stop condition tool
     ]
 
     # Load orchestrator-specific instructions
@@ -476,6 +606,47 @@ async def _create_orchestrator_agent(
         ],
         thread=Thread(),  # type: ignore[call-arg]
     )
+
+
+def _generate_multi_agent_report(
+    state: SharedRedTeamState,
+    *,
+    report_dir: str | Path | None,
+) -> tuple[Path, str]:
+    report_state = _build_redteam_report_state(state)
+    resolved_report_dir = Path(report_dir or "./reports").resolve()
+    resolved_report_dir.mkdir(parents=True, exist_ok=True)
+
+    report_generator = RedTeamReportGenerator()
+    report_content = report_generator.generate(report_state)
+
+    report_filename = f"{state.operation_id}_report.md"
+    report_path = resolved_report_dir / report_filename
+    report_path.write_text(report_content)
+    logger.success(f"Red team report generated: {report_path}")
+    return report_path, report_content
+
+
+def _build_redteam_report_state(state: SharedRedTeamState) -> RedTeamState:
+    target = state.target or Target(ip="", domain="")
+    report_state = RedTeamState(operation_id=state.operation_id, target=target)
+    report_state.completed = state.completed
+    report_state.started_at = state.started_at
+    report_state.stage = InvestigationStage.SYNTHESIS
+    report_state.hosts = list(state.all_hosts)
+    report_state.users = list(state.all_users)
+    report_state.credentials = list(state.all_credentials)
+    report_state.hashes = list(state.all_hashes)
+    report_state.shares = list(state.all_shares)
+    report_state.has_domain_admin = state.has_domain_admin
+    report_state.has_golden_ticket = state.has_golden_ticket
+    report_state.timeline = list(state.operation_timeline)
+    report_state.identified_techniques = set(state.identified_techniques)
+    report_state.weaknesses = [
+        f"{v.vuln_type} on {v.target} ({v.vuln_id})"
+        for v in state.discovered_vulnerabilities.values()
+    ]
+    return report_state
 
 
 async def _create_agent_ensemble(
@@ -693,9 +864,12 @@ async def _wait_for_completion(
             logger.warning(f"Operation reached max runtime ({max_runtime}s)")
             break
 
-        # Check for domain admin
+        # Check for domain admin or explicit completion
         if dispatcher.shared_state.has_domain_admin:
             logger.success("Domain Admin achieved! Operation complete.")
+            break
+        if dispatcher.shared_state.completed:
+            logger.success("Operation marked complete.")
             break
 
         # Check for failed background tasks
@@ -743,14 +917,23 @@ Your objectives:
 4. If no creds, run Kerberos user enumeration with kerberos_user_enum_noauth
 5. Run certipy_find to discover ADCS vulnerabilities
 6. Run run_bloodhound for ACL analysis and attack path discovery
-7. Coordinate with specialized agents to exploit discovered vulnerabilities
-8. Use trigger_credential_expansion after getting new credentials
-9. Continue until Domain Admin access achieved
+7. **CRITICAL CREDENTIAL EXPANSION (run IMMEDIATELY after finding ANY credentials):**
+   - Use secretsdump on ALL domain controllers to dump hashes
+   - Use kerberoast to find service accounts with weak passwords
+   - Use asrep_roast to find accounts without Kerberos pre-auth
+   - Check secretsdump output for krbtgt or Administrator hashes
+   - If krbtgt hash found → Generate golden ticket → Announce Domain Admin
+   - If Administrator hash found → Test DA access → Announce Domain Admin
+8. Coordinate with specialized agents to exploit discovered vulnerabilities
+9. Use trigger_credential_expansion after getting new credentials
+10. Continue until Domain Admin access achieved
 
 Priority vulnerabilities to look for:
 - Passwords in LDAP description fields (QUICK WIN - check first!)
 - Username=password combinations (QUICK WIN)
 - Weak/common passwords via spraying (QUICK WIN)
+- **krbtgt hash via secretsdump (HIGHEST PRIORITY - instant DA)**
+- **Administrator hash via secretsdump (VERY HIGH PRIORITY)**
 - ADCS ESC1-ESC8
 - Kerberoastable accounts
 - AS-REP roastable accounts
@@ -758,10 +941,18 @@ Priority vulnerabilities to look for:
 - ACL abuse paths (GenericAll, WriteDACL, etc.)
 - MSSQL linked servers
 
+CRITICAL WORKFLOW AFTER FINDING CREDENTIALS:
+1. Run secretsdump against all DCs immediately
+2. Run kerberoast and asrep_roast with the credentials
+3. Look for krbtgt or Administrator in secretsdump output
+4. Crack any discovered hashes with dispatch_crack_hash
+5. Test new credentials and repeat steps 1-4
+
 Remember:
 - Use dispatch_* tools to route tasks to specialized agents
 - Use queue_vulnerability_for_exploitation to queue discovered vulnerabilities
 - Use trigger_credential_expansion after finding new credentials
+- **ALWAYS run secretsdump after finding ANY credentials**
 - Monitor progress with get_operation_summary
 - Announce domain admin when achieved with announce_domain_admin
 

--- a/src/ares/core/orchestrator_service.py
+++ b/src/ares/core/orchestrator_service.py
@@ -20,6 +20,7 @@ from loguru import logger
 from ares.core.config import get_namespace, get_redis_url
 from ares.core.litellm_env import configure_litellm_env
 from ares.core.models import Credential
+from ares.core.orchestrator import run_multi_agent_operation
 from ares.core.recovery import OperationRecoveryManager
 from ares.core.task_queue import RedisTaskQueue
 
@@ -227,7 +228,6 @@ class OrchestratorService:
             )
 
             configure_litellm_env()
-            from ares.core.orchestrator import run_multi_agent_operation
 
             result = await run_multi_agent_operation(
                 operation_id=operation_id,
@@ -474,7 +474,6 @@ class OrchestratorService:
                     "orchestrator environment or passed via env_vars."
                 )
             configure_litellm_env()
-            from ares.core.orchestrator import run_multi_agent_operation
 
             result = await run_multi_agent_operation(
                 operation_id=request.operation_id,

--- a/src/ares/core/orchestrator_service.py
+++ b/src/ares/core/orchestrator_service.py
@@ -15,14 +15,20 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-import dreadnode as dn
 from loguru import logger
 
 from ares.core.config import get_namespace, get_redis_url
+from ares.core.litellm_env import configure_litellm_env
 from ares.core.models import Credential
-from ares.core.orchestrator import run_multi_agent_operation
 from ares.core.recovery import OperationRecoveryManager
 from ares.core.task_queue import RedisTaskQueue
+
+
+def _configure_dreadnode():
+    configure_litellm_env()
+    import dreadnode as dn
+
+    return dn
 
 
 @dataclass
@@ -220,6 +226,9 @@ class OrchestratorService:
                 f"hosts={len(state.all_hosts)}"
             )
 
+            configure_litellm_env()
+            from ares.core.orchestrator import run_multi_agent_operation
+
             result = await run_multi_agent_operation(
                 operation_id=operation_id,
                 target_domain=target_domain,
@@ -355,6 +364,47 @@ class OrchestratorService:
                 logger.warning("OPENAI_API_KEY missing in request env vars; using process env")
         return openai_api_key
 
+    async def _persist_operation_model(self, operation_id: str, model: str) -> None:
+        """Persist per-operation model so workers can resolve it."""
+        if not self.task_queue or not self.task_queue._client:
+            logger.warning("Cannot persist operation model: Redis client unavailable")
+            return
+        key = f"ares:operation:{operation_id}:model"
+        try:
+            await self.task_queue._client.set(key, model)
+        except Exception as e:
+            logger.warning(f"Failed to persist operation model for {operation_id}: {e}")
+
+    async def _persist_operation_model_overrides(
+        self, operation_id: str, request_env_vars: dict[str, str] | None
+    ) -> None:
+        """Persist model env overrides so workers can resolve role-specific models."""
+        if not request_env_vars:
+            return
+        if not self.task_queue or not self.task_queue._client:
+            logger.warning("Cannot persist model overrides: Redis client unavailable")
+            return
+
+        allowed_keys = {
+            "ARES_MODEL",
+            "ARES_ORCHESTRATOR_MODEL",
+            "ARES_WORKER_MODEL",
+        }
+        overrides = {
+            key: value
+            for key, value in request_env_vars.items()
+            if value
+            and (key in allowed_keys or (key.startswith("ARES_AGENT_") and key.endswith("_MODEL")))
+        }
+        if not overrides:
+            return
+
+        key = f"ares:operation:{operation_id}:model_overrides"
+        try:
+            await self.task_queue._client.set(key, json.dumps(overrides))
+        except Exception as e:
+            logger.warning(f"Failed to persist model overrides for {operation_id}: {e}")
+
     async def _process_operation_request(self, request_data: dict[str, Any]) -> None:
         """Process an operation request.
 
@@ -376,9 +426,14 @@ class OrchestratorService:
                         os.environ[key] = value
                         logger.debug(f"Set environment variable: {key}")
 
+            if request.model:
+                await self._persist_operation_model(request.operation_id, request.model)
+            await self._persist_operation_model_overrides(request.operation_id, request.env_vars)
+
             openai_api_key = self._resolve_openai_api_key(request.env_vars)
 
             try:
+                dn = _configure_dreadnode()
                 dn.configure()
             except Exception as e:
                 logger.warning(f"Dreadnode configure failed, continuing without telemetry: {e}")
@@ -418,6 +473,9 @@ class OrchestratorService:
                     "OPENAI_API_KEY is required for OpenAI models. Ensure it is set in the "
                     "orchestrator environment or passed via env_vars."
                 )
+            configure_litellm_env()
+            from ares.core.orchestrator import run_multi_agent_operation
+
             result = await run_multi_agent_operation(
                 operation_id=request.operation_id,
                 target_domain=request.target_domain,

--- a/src/ares/core/remote.py
+++ b/src/ares/core/remote.py
@@ -111,12 +111,10 @@ class K8sExecutor:
         self._task_queue = None
 
     def _get_task_queue(self):
-        """Lazy-load the RedisTaskQueue."""
-        if self._task_queue is None:
-            from ares.core.task_queue import RedisTaskQueue
+        """Deprecated: Use per-call task queue instances to avoid loop conflicts."""
+        from ares.core.task_queue import RedisTaskQueue
 
-            self._task_queue = RedisTaskQueue(self._redis_url)
-        return self._task_queue
+        return RedisTaskQueue(self._redis_url)
 
     def run_command(
         self,
@@ -173,6 +171,8 @@ class K8sExecutor:
         working_directory: str,
     ) -> CommandResult:
         """Dispatch command via Redis and wait for result."""
+        # Create a fresh task queue bound to the current event loop to avoid
+        # "Future attached to a different loop" errors.
         task_queue = self._get_task_queue()
         await task_queue.connect()
 

--- a/src/ares/core/task_queue.py
+++ b/src/ares/core/task_queue.py
@@ -99,6 +99,11 @@ class RedisTaskQueue:
         self._client = None
         self._connected = False
 
+    @property
+    def redis(self):
+        """Expose the underlying Redis client for legacy call sites."""
+        return self._client
+
     async def connect(self) -> None:
         """Connect to Redis."""
         if self._connected:

--- a/src/ares/core/worker.py
+++ b/src/ares/core/worker.py
@@ -23,6 +23,7 @@ from loguru import logger
 from ares.core.config import get_redis_url
 from ares.core.dispatcher import RedTeamDispatcher
 from ares.core.exceptions import AuthenticationError, ConfigurationError, CriticalWorkerError
+from ares.core.factories.red_agents import create_agent_info, create_specialized_agent
 from ares.core.litellm_env import configure_litellm_env
 from ares.core.messages import (
     AgentMessage,
@@ -33,6 +34,7 @@ from ares.core.messages import (
 )
 from ares.core.models import AgentRole
 from ares.core.task_queue import RedisTaskQueue, TaskMessage
+from ares.tools.red import CrackerCallbackTools, LateralCallbackTools
 
 if TYPE_CHECKING:
     from dreadnode.agent import Agent
@@ -1013,8 +1015,6 @@ async def run_worker(  # noqa: PLR0912
         use_redis_queue: If True, poll Redis queue for tasks (Kubernetes mode).
     """
     configure_litellm_env()
-    from ares.core.factories.red_agents import create_agent_info, create_specialized_agent
-    from ares.tools.red import CrackerCallbackTools, LateralCallbackTools
 
     # Resolve config defaults
     redis_url = redis_url or get_redis_url()

--- a/src/ares/core/worker.py
+++ b/src/ares/core/worker.py
@@ -23,7 +23,7 @@ from loguru import logger
 from ares.core.config import get_redis_url
 from ares.core.dispatcher import RedTeamDispatcher
 from ares.core.exceptions import AuthenticationError, ConfigurationError, CriticalWorkerError
-from ares.core.factories.red_agents import create_agent_info, create_specialized_agent
+from ares.core.litellm_env import configure_litellm_env
 from ares.core.messages import (
     AgentMessage,
     DomainAdminAchieved,
@@ -31,7 +31,7 @@ from ares.core.messages import (
     MessageType,
     OperationComplete,
 )
-from ares.core.models import AgentRole  # noqa: TC001 - used at runtime
+from ares.core.models import AgentRole
 from ares.core.task_queue import RedisTaskQueue, TaskMessage
 
 if TYPE_CHECKING:
@@ -171,6 +171,55 @@ async def discover_active_operation(  # noqa: PLR0912
     finally:
         # Ensure cleanup on any exit path
         await _cleanup_client()
+
+
+async def get_operation_model(redis_url: str, operation_id: str) -> str | None:
+    """Fetch the model configured for a specific operation from Redis."""
+    try:
+        import redis.asyncio as redis_async
+    except ImportError:
+        logger.error("redis package not installed, cannot resolve operation model")
+        return None
+
+    client = redis_async.from_url(redis_url, decode_responses=True)
+    try:
+        return await client.get(f"ares:operation:{operation_id}:model")
+    except Exception as e:
+        logger.warning(f"Failed to read operation model for {operation_id}: {e}")
+        return None
+    finally:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+
+
+async def get_operation_model_overrides(redis_url: str, operation_id: str) -> dict[str, str] | None:
+    """Fetch model override env vars for a specific operation from Redis."""
+    try:
+        import redis.asyncio as redis_async
+    except ImportError:
+        logger.error("redis package not installed, cannot resolve operation model overrides")
+        return None
+
+    client = redis_async.from_url(redis_url, decode_responses=True)
+    try:
+        raw = await client.get(f"ares:operation:{operation_id}:model_overrides")
+        if not raw:
+            return None
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items() if v}
+        logger.warning("Unexpected model overrides payload type: {}", type(data))
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to read model overrides for {operation_id}: {e}")
+        return None
+    finally:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
 
 
 # Mapping of message types to task prompt generators (for dispatcher-based messaging)
@@ -349,6 +398,35 @@ def _extract_structured_payload(result_text: str) -> dict[str, Any] | None:
     return payload
 
 
+def _extract_asrep_hashes(result_text: str) -> list[dict[str, str]]:
+    """Extract Kerberos AS-REP hashes from raw tool output."""
+    hashes: list[dict[str, str]] = []
+    matches = re.findall(
+        r"(\$krb5asrep\$\d+\$[^\s:$]+@[^\s:$]+:[0-9a-fA-F]{32}\$[0-9a-fA-F]+)",
+        result_text,
+    )
+    for value in matches:
+        username = "Unknown"
+        domain = ""
+        parts = value.split("$", 3)
+        if len(parts) >= 4:
+            user_realm_part = parts[3]
+            user_realm = user_realm_part.split(":", 1)[0]
+            if "@" in user_realm:
+                username, domain = user_realm.split("@", 1)
+            elif user_realm:
+                username = user_realm
+        hashes.append(
+            {
+                "username": username,
+                "hash_value": value,
+                "hash_type": "AS-REP",
+                "domain": domain,
+            }
+        )
+    return hashes
+
+
 class RedisWorkerAgent:
     """
     Worker agent that polls Redis task queue for work.
@@ -466,7 +544,7 @@ class RedisWorkerAgent:
                     await asyncio.sleep(5)
                     retry_delay = 1.0  # Reset backoff for non-connection errors
 
-    async def _process_task(self, task: TaskMessage) -> None:
+    async def _process_task(self, task: TaskMessage) -> None:  # noqa: PLR0912
         """Process a task from the Redis queue."""
         self._current_task = task.task_id
         logger.info(f"[{self.agent_name}] Processing task {task.task_id}")
@@ -494,13 +572,36 @@ class RedisWorkerAgent:
             logger.info(f"[{self.agent_name}] Running agent for task {task.task_id}")
             result = await self.agent.run(prompt)
             result_text = self._extract_result(result)
+            agent_error = self._extract_agent_error(result)
 
-            result_payload = {"output": result_text, "task_type": task.task_type}
+            result_payload: dict[str, Any] = {"output": result_text, "task_type": task.task_type}
             structured = _extract_structured_payload(result_text)
             if structured:
                 for key in ("credential", "hash"):
                     if key in structured:
                         result_payload[key] = structured[key]
+            asrep_hashes = _extract_asrep_hashes(result_text)
+            if asrep_hashes:
+                existing = set()
+                if isinstance(result_payload.get("hash"), dict):
+                    existing.add(result_payload["hash"].get("hash_value"))
+                filtered = [h for h in asrep_hashes if h.get("hash_value") not in existing]
+                if filtered:
+                    if "hash" not in result_payload and len(filtered) == 1:
+                        result_payload["hash"] = filtered[0]
+                    else:
+                        result_payload["hashes"] = filtered
+
+            if agent_error:
+                await self.task_queue.send_result(
+                    task_id=task.task_id,
+                    success=False,
+                    result=result_payload,
+                    error=agent_error,
+                    worker_pod=self.pod_name,
+                )
+                logger.error(f"[{self.agent_name}] Task {task.task_id} failed: {agent_error}")
+                return
 
             # Send success result via Redis
             await self.task_queue.send_result(
@@ -607,6 +708,24 @@ class RedisWorkerAgent:
         if hasattr(result, "content"):
             return str(result.content)
         return str(result)
+
+    def _extract_agent_error(self, result: Any) -> str | None:
+        """Pull error details from an agent result without raising."""
+        error = getattr(result, "error", None)
+        if error:
+            return str(error)
+        last_error = getattr(result, "last_error", None)
+        if last_error:
+            return str(last_error)
+        stop_reason = getattr(result, "stop_reason", None)
+        failed = bool(getattr(result, "failed", False))
+        if failed and stop_reason:
+            return f"Agent failed (stop_reason={stop_reason})"
+        if failed:
+            return "Agent failed"
+        if stop_reason == "error":
+            return "Agent stopped with error"
+        return None
 
     async def _heartbeat_loop(self) -> None:
         """Send heartbeats to Redis with automatic reconnection on failure."""
@@ -771,12 +890,23 @@ class WorkerAgent:
             # Extract result from agent output
             result_text = self._extract_result(result)
 
-            result_payload = {"output": result_text, "task_type": msg.type.value}
+            result_payload: dict[str, Any] = {"output": result_text, "task_type": msg.type.value}
             structured = _extract_structured_payload(result_text)
             if structured:
                 for key in ("credential", "hash"):
                     if key in structured:
                         result_payload[key] = structured[key]
+            asrep_hashes = _extract_asrep_hashes(result_text)
+            if asrep_hashes:
+                existing = set()
+                if isinstance(result_payload.get("hash"), dict):
+                    existing.add(result_payload["hash"].get("hash_value"))
+                filtered = [h for h in asrep_hashes if h.get("hash_value") not in existing]
+                if filtered:
+                    if "hash" not in result_payload and len(filtered) == 1:
+                        result_payload["hash"] = filtered[0]
+                    else:
+                        result_payload["hashes"] = filtered
 
             # Report completion
             await self.dispatcher.complete_task(
@@ -882,20 +1012,18 @@ async def run_worker(  # noqa: PLR0912
         discovery_timeout: Max seconds to wait for operation discovery (default: None = wait forever).
         use_redis_queue: If True, poll Redis queue for tasks (Kubernetes mode).
     """
+    configure_litellm_env()
+    from ares.core.factories.red_agents import create_agent_info, create_specialized_agent
+    from ares.tools.red import CrackerCallbackTools, LateralCallbackTools
+
     # Resolve config defaults
     redis_url = redis_url or get_redis_url()
-    model = (
+    resolved_model = (
         model
         or os.getenv(f"ARES_AGENT_{role.value.upper()}_MODEL")
         or os.getenv("ARES_WORKER_MODEL")
         or os.getenv("ARES_MODEL")
     )
-    if not model:
-        logger.error(
-            "No model specified for worker. Provide a model argument or set "
-            "ARES_AGENT_<ROLE>_MODEL/ARES_WORKER_MODEL/ARES_MODEL."
-        )
-        return
 
     pod_name = os.environ.get("HOSTNAME", f"local-{role.value}")
     if not os.environ.get("ARES_ROLE"):
@@ -927,6 +1055,27 @@ async def run_worker(  # noqa: PLR0912
         logger.error("Operation ID required but not provided and discovery disabled")
         return
 
+    overrides = await get_operation_model_overrides(redis_url, operation_id)
+    if overrides:
+        role_key = f"ARES_AGENT_{role.value.upper()}_MODEL"
+        if overrides.get(role_key):
+            resolved_model = overrides[role_key]
+        elif overrides.get("ARES_WORKER_MODEL"):
+            resolved_model = overrides["ARES_WORKER_MODEL"]
+        elif overrides.get("ARES_MODEL"):
+            resolved_model = overrides["ARES_MODEL"]
+
+    if not resolved_model:
+        resolved_model = await get_operation_model(redis_url, operation_id)
+
+    if not resolved_model:
+        logger.error(
+            "No model specified for worker. Provide a model argument, set "
+            "ARES_AGENT_<ROLE>_MODEL/ARES_WORKER_MODEL/ARES_MODEL, "
+            "or submit an operation model."
+        )
+        return
+
     logger.info(f"Starting {role.value} worker for operation {operation_id}")
     logger.info(f"Pod: {pod_name}, Redis: {redis_url}, Redis Queue: {use_redis_queue}")
 
@@ -952,14 +1101,26 @@ async def run_worker(  # noqa: PLR0912
     agent_info = create_agent_info(role, pod_name=pod_name)
     await dispatcher.register(agent_info)
 
+    # Add role-specific callback tools
+    additional_tools: list[Any] = []
+    if role == AgentRole.CRACKER:
+        cracker_callbacks = CrackerCallbackTools()
+        cracker_callbacks.set_dispatcher(dispatcher)
+        additional_tools.append(cracker_callbacks)
+    elif role == AgentRole.LATERAL:
+        lateral_callbacks = LateralCallbackTools()
+        lateral_callbacks.set_dispatcher(dispatcher)
+        additional_tools.append(lateral_callbacks)
+
     # Create the specialized agent
     agent = create_specialized_agent(
         role=role,
-        model=model,
+        model=resolved_model,
         shared_state=shared_state,
         dispatcher=dispatcher,
         pod_name=pod_name,
         max_steps=max_steps,
+        additional_tools=additional_tools if additional_tools else None,
     )
 
     try:

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import cyclopts
+import dreadnode as dn
 from loguru import logger
 
 app = cyclopts.App(
@@ -22,8 +23,6 @@ def _configure_dreadnode():
     from ares.core.litellm_env import configure_litellm_env
 
     configure_litellm_env()
-    import dreadnode as dn
-
     return dn
 
 

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -10,13 +10,21 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import cyclopts
-import dreadnode as dn
 from loguru import logger
 
 app = cyclopts.App(
     name="ares",
     help="Autonomous SOC Investigation Agent - Question-driven threat investigation",
 )
+
+
+def _configure_dreadnode():
+    from ares.core.litellm_env import configure_litellm_env
+
+    configure_litellm_env()
+    import dreadnode as dn
+
+    return dn
 
 
 @dataclass
@@ -115,6 +123,7 @@ async def main(  # noqa: PLR0912
     dreadnode_token = dn_args.token or os.getenv("DREADNODE_API_KEY", "")
 
     # Configure Dreadnode
+    dn = _configure_dreadnode()
     dn.configure(
         server=dn_args.server,
         token=dreadnode_token,
@@ -310,6 +319,7 @@ async def investigate_alert(
     )
     dreadnode_token = dn_args.token or os.getenv("DREADNODE_API_KEY", "")
 
+    dn = _configure_dreadnode()
     dn.configure(
         server=dn_args.server,
         token=dreadnode_token,
@@ -388,6 +398,7 @@ async def redteam(
     # Configure Dreadnode
     dreadnode_token = dn_args.token or os.getenv("DREADNODE_API_KEY", "")
 
+    dn = _configure_dreadnode()
     dn.configure(
         server=dn_args.server,
         token=dreadnode_token,
@@ -546,6 +557,7 @@ async def multi_agent(
     dreadnode_token = dn_args.token or os.getenv("DREADNODE_API_KEY", "")
 
     try:
+        dn = _configure_dreadnode()
         dn.configure(
             server=dn_args.server,
             token=dreadnode_token,
@@ -568,6 +580,7 @@ async def multi_agent(
     logger.info(f"Max Steps: {args.max_steps}")
     logger.info(f"Redis: {redis_url}")
     logger.info(f"Namespace: {namespace}")
+    logger.info(f"Report Dir: {args.report_dir}")
     logger.info("=" * 60)
 
     from ares.core.models import Credential
@@ -590,6 +603,10 @@ async def multi_agent(
     logger.info(f"Starting multi-agent operation {operation_id}...")
     logger.info("")
 
+    report_dir = Path(args.report_dir).resolve()
+    report_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Reports: {report_dir}")
+
     try:
         result = await run_multi_agent_operation(
             operation_id=operation_id,
@@ -600,6 +617,7 @@ async def multi_agent(
             namespace=namespace,
             model=model,
             max_steps=args.max_steps,
+            report_dir=report_dir,
         )
 
         logger.success("")
@@ -621,6 +639,8 @@ async def multi_agent(
         if result.get("golden_ticket_forged"):
             logger.success("  🎫 GOLDEN TICKET: FORGED")
 
+        if result.get("report_path"):
+            logger.success(f"  Report: {result['report_path']}")
         logger.success("")
 
     except Exception as e:
@@ -706,25 +726,23 @@ async def worker(
 
     # Use config values if CLI args not specified
     redis_url = worker_args.redis_url or config.redis_url
-    model = (
-        worker_args.model
-        or agent_config.model
-        or os.getenv(f"ARES_AGENT_{role.upper()}_MODEL")
-        or os.getenv("ARES_WORKER_MODEL")
-        or os.getenv("ARES_MODEL")
-    )
+    model = worker_args.model or os.getenv(f"ARES_AGENT_{role.upper()}_MODEL")
     if not model:
-        logger.error(
-            "No model specified. Set ARES_AGENT_<ROLE>_MODEL/ARES_WORKER_MODEL/ARES_MODEL "
-            "or pass --worker-args.model."
-        )
-        return
+        model = os.getenv("ARES_WORKER_MODEL") or os.getenv("ARES_MODEL")
+    if not model and operation_id:
+        model = agent_config.model
+    # If no model specified and no operation_id, the worker will discover an operation
+    # from Redis and fetch the model from the operation's configuration. This allows
+    # workers to start without ARES_MODEL in the ConfigMap.
+    if not model and not operation_id:
+        logger.info("No model specified - will fetch from operation config after discovery")
     max_steps = worker_args.max_steps if worker_args.max_steps > 0 else agent_config.max_steps
 
     # Configure Dreadnode (optional - don't fail if platform unavailable)
     dreadnode_token = dn_args.token or os.getenv("DREADNODE_API_KEY", "")
 
     try:
+        dn = _configure_dreadnode()
         dn.configure(
             server=dn_args.server,
             token=dreadnode_token,
@@ -769,7 +787,7 @@ async def worker(
             role=agent_role,
             operation_id=operation_id if operation_id else None,
             redis_url=redis_url,
-            model=model,
+            model=model or None,  # Pass None to let run_worker fetch from Redis
             max_steps=max_steps if max_steps > 0 else None,
         )
     except KeyboardInterrupt:

--- a/src/ares/templates/redteam/agents/enum.md.jinja
+++ b/src/ares/templates/redteam/agents/enum.md.jinja
@@ -31,15 +31,32 @@ Your role is to delegate tasks to specialized agents and coordinate the overall 
 
 | Tool | Target Agent | Use Case |
 |------|--------------|----------|
+| queue_vulnerability_for_exploitation | Auto-dispatch | Queue vuln for priority-based exploitation (PREFERRED) |
 | dispatch_crack_hash | CrackerAgent | Hash cracking (NTLM, Kerberos, etc.) |
 | dispatch_acl_analysis | ACLAgent | BloodHound paths, ACL abuse |
 | dispatch_lateral_movement | LateralAgent | Move to new hosts |
-| dispatch_privesc_exploit | PrivEscAgent | ADCS, delegation, MSSQL |
 | start_poisoning | PoisonAgent | Network poisoning |
 
 ## Priority Workflow
 
 Execute in this order when discoveries are made:
+
+### PRIORITY 0: CREDENTIAL EXPANSION (RUN IMMEDIATELY)
+```
+ANY credential found → RUN IMMEDIATELY:
+  1. secretsdump on ALL DCs (find krbtgt/Administrator)
+  2. kerberoast (find service accounts with weak passwords)
+  3. asrep_roast (find accounts without pre-auth)
+  4. dispatch_crack_hash for any discovered hashes
+
+  If secretsdump output contains krbtgt:
+    → Generate golden ticket
+    → announce_domain_admin()
+
+  If secretsdump output contains Administrator:
+    → Test DA access on all hosts
+    → announce_domain_admin()
+```
 
 ### PRIORITY 1: Krbtgt Hash
 ```
@@ -55,7 +72,11 @@ admin hash found → dispatch_crack_hash(priority=2)
 
 ### PRIORITY 3: ADCS Vulnerability
 ```
-ESC1/ESC4/ESC8 found → dispatch_privesc_exploit(vuln_type="ADCS_*")
+ESC1/ESC4/ESC8 found → queue_vulnerability_for_exploitation(
+                          vuln_type="ADCS_ESC1",  # or ADCS_ESC4, ADCS_ESC8
+                          target="CA-NAME",
+                          details='{"template": "VulnerableTemplate", "ca": "domain\\CA"}'
+                        )
 ```
 
 ### PRIORITY 4: ACL Abuse Path
@@ -65,52 +86,91 @@ GenericAll/GenericWrite found → dispatch_acl_analysis(target_user=X)
 
 ### PRIORITY 5: Delegation
 ```
-Unconstrained → dispatch_privesc_exploit + start_poisoning
-Constrained → dispatch_privesc_exploit(vuln_type="DELEGATION_CONSTRAINED")
+Unconstrained → queue_vulnerability_for_exploitation(
+                  vuln_type="unconstrained_delegation",
+                  target="SERVER-NAME"
+                ) + start_poisoning()
+Constrained → queue_vulnerability_for_exploitation(
+                vuln_type="constrained_delegation",
+                target="SERVER-NAME",
+                details='{"allowed_to": "TARGET-SPN"}'
+              )
 ```
 
 ## Coordination Rules
 
-1. **Check Before Dispatching**
+1. **CRITICAL: Credential Expansion Loop**
+   - **EVERY TIME** you find ANY credential (password, hash, ticket):
+     a. Run secretsdump on ALL domain controllers
+     b. Run kerberoast with the credential
+     c. Run asrep_roast with the credential
+     d. Parse secretsdump output for krbtgt or Administrator
+     e. Crack any new hashes with dispatch_crack_hash
+     f. Repeat this loop with any newly cracked credentials
+   - This is the fastest path to Domain Admin - DO NOT SKIP THIS STEP
+   - If you see any credentials in get_all_credentials() but no hashes in get_all_hashes(), YOU FORGOT TO RUN SECRETSDUMP
+
+2. **CRITICAL: Use Queue for Vulnerabilities**
+   - ALWAYS use queue_vulnerability_for_exploitation() for ADCS, delegation, MSSQL vulns
+   - This ensures deduplication and priority handling
+   - Check get_vulnerability_queue_status() to see what's queued
+   - DO NOT call dispatch_privesc_exploit() directly - it bypasses tracking!
+
+3. **Check Before Dispatching**
    - Always call get_pending_tasks() before dispatching duplicates
    - Don't dispatch crack requests for already-queued hashes
+   - Don't queue vulnerabilities that are already in get_vulnerability_queue_status()
 
-2. **Automatic Broadcasting**
+4. **Automatic Broadcasting**
    - Credentials are automatically broadcast to all agents
    - You don't need to manually share credentials
+   - If get_all_credentials() lists any entries, assume you have valid creds and pivot to authenticated actions
 
-3. **Focus on Coordination**
+5. **Focus on Coordination**
    - You have enumeration tools for initial recon
    - Delegate exploitation to specialized agents
    - Don't try to do everything yourself
 
-4. **Monitor Unexploited**
+6. **Monitor Unexploited**
    - Regularly check get_exploitation_status()
-   - Dispatch work for unexploited vulnerabilities
+   - Regularly check get_vulnerability_queue_status()
    - Don't complete operation with pending vulnerabilities
 
 ## Stop Conditions
 
-Complete the operation ONLY when:
-- Domain admin has been achieved, OR
-- All viable attack paths have been exhausted
-- All vulnerabilities have been exploited or determined unexploitable
-- All hashes have been cracked or attempted
+### When to call announce_domain_admin():
+- You found krbtgt hash in secretsdump output
+- You found Administrator hash in secretsdump output
+- You successfully ran secretsdump with DA-level credentials
 
-Use `complete_operation(summary)` when finished.
+### When to call complete_operation():
+- Domain admin has been achieved (after calling announce_domain_admin), OR
+- All viable attack paths have been exhausted:
+  - All credentials tested with secretsdump/kerberoast/asrep_roast
+  - All vulnerabilities exploited or determined unexploitable
+  - All hashes cracked or attempted
+  - No new attack vectors available
+
+**IMPORTANT:** If you have ANY credentials but haven't run secretsdump/kerberoast/asrep_roast yet, DO NOT call complete_operation() - you haven't exhausted all paths!
 
 ## Example Workflow
 
 ```
 1. Run initial enumeration (nmap, users, shares, domain info)
 2. If no creds, run pre-creds enumeration (SMB null sessions, RPC, SYSVOL/NETLOGON, Kerberos user enum)
-2. Review discovered assets
-3. Dispatch ACL analysis for attack paths
-4. As vulnerabilities are found:
-   - ADCS → dispatch_privesc_exploit
+3. Review discovered assets
+4. **AS SOON AS ANY CREDENTIAL IS FOUND:**
+   a. Run secretsdump on ALL DCs immediately
+   b. Run kerberoast to find service accounts
+   c. Run asrep_roast to find accounts without pre-auth
+   d. Check secretsdump output for krbtgt or Administrator
+   e. If found → Announce Domain Admin
+5. Dispatch ACL analysis for attack paths
+6. As vulnerabilities are found:
+   - ADCS/Delegation/MSSQL → queue_vulnerability_for_exploitation()
    - Hashes → dispatch_crack_hash
-   - New credentials → dispatch_lateral_movement
-5. Monitor progress with get_* tools
-6. Announce domain admin when achieved
-7. Complete operation with summary
+   - New credentials → REPEAT STEP 4 (secretsdump/kerberoast/asrep_roast)
+7. Monitor progress with get_vulnerability_queue_status() and get_pending_tasks()
+8. Announce domain admin when achieved
+9. Complete operation with summary
 ```

--- a/src/ares/tools/red/network.py
+++ b/src/ares/tools/red/network.py
@@ -9,6 +9,7 @@ All tools execute commands remotely on the Kali attack box via AWS SSM.
 import json
 import logging
 import re
+import shlex
 import time
 import uuid
 from datetime import datetime, timezone
@@ -99,6 +100,18 @@ def _run_tool(cmd: list[str], timeout_seconds: int = 300) -> tuple[str, str, int
     return result.stdout, result.stderr, result.return_code
 
 
+def _write_users_file_remote(users: list[str], users_file: str) -> tuple[bool, str]:
+    if not users:
+        return False, "no users provided"
+    escaped_users = " ".join(shlex.quote(user) for user in users)
+    cmd = f"printf '%s\\n' {escaped_users} > {shlex.quote(users_file)}"
+    result = run_remote(["bash", "-lc", cmd], timeout_seconds=60)
+    if result.return_code != 0:
+        error = (result.stderr or result.stdout or "unknown error").strip()
+        return False, error
+    return True, ""
+
+
 class NetworkEnumerationTools(Toolset):
     """Tools for network scanning and enumeration."""
 
@@ -107,6 +120,92 @@ class NetworkEnumerationTools(Toolset):
     def set_state(self, state: RedTeamState) -> None:
         """Set the operation state for this toolset."""
         self.state = state
+
+    def _extract_users_from_outputs(self, outputs: list[tuple[str, str]]) -> set[str]:  # noqa: PLR0912
+        users: set[str] = set()
+        user_pattern = r"[A-Za-z0-9._$-]+"
+
+        def _add_user(candidate: str) -> None:
+            user = candidate.strip()
+            if not user or user.endswith("$"):
+                return
+            if user.lower() in ("anonymous",):
+                return
+            users.add(user)
+
+        for label, content in outputs:
+            if not content:
+                continue
+            label_lower = label.lower()
+            for line in content.splitlines():
+                if not line.strip():
+                    continue
+
+                rpc_match = re.search(r"user:\[([^\]]+)\]", line, re.IGNORECASE)
+                if rpc_match:
+                    _add_user(rpc_match.group(1))
+                    continue
+
+                if "netexec smb --users" in label_lower:
+                    backslash_match = re.search(
+                        r"\\([A-Za-z0-9._-]+)\\s*\\(SidTypeUser\\)",
+                        line,
+                    )
+                    if backslash_match:
+                        _add_user(backslash_match.group(1))
+                        continue
+                    domain_match = re.search(
+                        rf"[A-Za-z0-9._-]+\\({user_pattern})",
+                        line,
+                    )
+                    if domain_match:
+                        _add_user(domain_match.group(1))
+                        continue
+                    rid_match = re.search(r"\bAccount:\s*([A-Za-z0-9._-]+)", line)
+                    if rid_match:
+                        _add_user(rid_match.group(1))
+                        continue
+
+                if "netexec smb --rid-brute" in label_lower:
+                    if "SidTypeUser" not in line:
+                        continue
+                    backslash_match = re.search(
+                        r"\\([A-Za-z0-9._-]+)\\s*\\(SidTypeUser\\)",
+                        line,
+                    )
+                    if backslash_match:
+                        _add_user(backslash_match.group(1))
+                        continue
+                    domain_match = re.search(
+                        rf"[A-Za-z0-9._-]+\\({user_pattern})",
+                        line,
+                    )
+                    if domain_match:
+                        _add_user(domain_match.group(1))
+                        continue
+                    rid_match = re.search(r"\bAccount:\s*([A-Za-z0-9._-]+)", line)
+                    if rid_match:
+                        _add_user(rid_match.group(1))
+                        continue
+
+                if "smb-enum-users" in label_lower:
+                    name_match = re.search(
+                        r"\b(?:username|user)\s*[:=]\s*([A-Za-z0-9._-]+)",
+                        line,
+                        re.IGNORECASE,
+                    )
+                    if name_match:
+                        _add_user(name_match.group(1))
+                        continue
+                    domain_match = re.search(
+                        rf"[A-Za-z0-9._-]+\\({user_pattern})",
+                        line,
+                    )
+                    if domain_match:
+                        _add_user(domain_match.group(1))
+                        continue
+
+        return users
 
     def _run_user_enum_commands(
         self, target: str, username: str, password: str, domain: str
@@ -138,26 +237,19 @@ class NetworkEnumerationTools(Toolset):
         outputs.append(("netexec smb --users", output))
 
         if not (username and password):
-            rpc_cmd = [
-                "rpcclient",
-                "-U",
-                "",
-                "-N",
-                target,
-                "-c",
-                "lsaquery; enumdomusers; querydispinfo; enumdomgroups",
-            ]
-            rpc_stdout, rpc_stderr, _ = _run_tool(rpc_cmd, timeout_seconds=120)
-            rpc_output = rpc_stdout or rpc_stderr or ""
-            outputs.append(
-                (
-                    "rpcclient null session lsaquery/enumdomusers/querydispinfo/enumdomgroups",
-                    rpc_output,
-                )
-            )
+            for rpc_op in ("lsaquery", "enumdomusers", "querydispinfo", "enumdomgroups"):
+                rpc_cmd = ["rpcclient", "-U", "", "-N", target, "-c", rpc_op]
+                rpc_stdout, rpc_stderr, _ = _run_tool(rpc_cmd, timeout_seconds=120)
+                rpc_output = rpc_stdout or rpc_stderr or ""
+                outputs.append((f"rpcclient null session {rpc_op}", rpc_output))
 
             combined_output = "\n".join(content for _, content in outputs)
             if not _has_user_entries(combined_output):
+                port_cmd = ["nmap", "-Pn", "-p", "445", target]
+                port_stdout, port_stderr, _ = _run_tool(port_cmd, timeout_seconds=120)
+                port_output = port_stdout or port_stderr or ""
+                outputs.append(("nmap port 445", port_output))
+
                 nmap_cmd = ["nmap", "-Pn", "-p", "445", "--script", "smb-enum-users", target]
                 nmap_stdout, nmap_stderr, _ = _run_tool(nmap_cmd, timeout_seconds=180)
                 nmap_output = nmap_stdout or nmap_stderr or ""
@@ -170,8 +262,80 @@ class NetworkEnumerationTools(Toolset):
 
         return outputs
 
+    def _classify_enum_output(self, label: str, output: str) -> str:
+        if not output or not output.strip():
+            return "no output"
+        lower = output.lower()
+        if "nt_status_access_denied" in lower or "access denied" in lower:
+            return "access denied"
+        if "nt_status_logon_failure" in lower or "logon failure" in lower:
+            return "auth failed"
+        if "filtered" in lower and ("445/tcp" in lower or "port 445" in lower):
+            return "445 filtered"
+        if any(
+            token in lower
+            for token in (
+                "connection refused",
+                "timed out",
+                "no route to host",
+                "host is down",
+                "network is unreachable",
+                "nt_status_connection_refused",
+                "nt_status_io_timeout",
+                "nt_status_host_unreachable",
+                "nt_status_network_unreachable",
+            )
+        ):
+            return "connection failed"
+        return "ok"
+
+    def _summarize_enum_outputs(self, outputs: list[tuple[str, str]]) -> str:
+        lines: list[str] = []
+        for label, content in outputs:
+            status = self._classify_enum_output(label, content)
+            lines.append(f"- {label}: {status}")
+        return "\n".join(lines)
+
+    def _format_enum_failure_message(self, outputs: list[tuple[str, str]], raw_output: str) -> str:
+        issues = {
+            "access_denied": False,
+            "auth_failed": False,
+            "conn_failed": False,
+            "filtered_445": False,
+        }
+        for label, content in outputs:
+            status = self._classify_enum_output(label, content)
+            if status == "access denied":
+                issues["access_denied"] = True
+            elif status == "auth failed":
+                issues["auth_failed"] = True
+            elif status == "connection failed":
+                issues["conn_failed"] = True
+            elif status == "445 filtered":
+                issues["filtered_445"] = True
+
+        notes: list[str] = []
+        if issues["filtered_445"] or issues["conn_failed"]:
+            notes.append("Network path to SMB/RPC appears blocked or filtered.")
+        if issues["access_denied"]:
+            notes.append("RPC/SAMR access denied; anonymous enumeration may be restricted.")
+        if issues["auth_failed"]:
+            notes.append("Authentication failed; verify credentials.")
+        if not notes:
+            notes.append("Target may be non-Windows or enumeration is blocked.")
+
+        summary = self._summarize_enum_outputs(outputs)
+        message = "[!] SMB user enumeration did not return users."
+        if summary:
+            message += "\nPer-command status:\n" + summary
+        if notes:
+            message += "\nNotes: " + " ".join(notes)
+        if raw_output:
+            message += "\nRaw output:\n" + raw_output[:500]
+        return message
+
     @dn.tool_method
-    def nmap_scan(self, target: str) -> str:
+    def nmap_scan(self, target: str) -> str:  # noqa: PLR0912
         """
         Scans target IPs to discover services, ports, and host information.
 
@@ -190,6 +354,63 @@ class NetworkEnumerationTools(Toolset):
             >>> result = nmap_scan("192.168.1.2 192.168.1.3 192.168.1.4")
         """
         import re
+
+        def _parse_nmap_hosts(output: str) -> list[Host]:
+            hosts: list[Host] = []
+            current_ip = ""
+            current_hostname = ""
+            current_os = ""
+            current_services: list[str] = []
+
+            def _commit_current() -> None:
+                if not current_ip:
+                    return
+                host = Host(
+                    ip=current_ip,
+                    hostname=current_hostname,
+                    os=current_os or "Unknown",
+                    roles=[],
+                    services=current_services,
+                )
+                hosts.append(host)
+
+            for line in output.splitlines():
+                line = line.strip()  # noqa: PLW2901
+                if not line:
+                    continue
+                report_match = re.match(r"^Nmap scan report for (.+)$", line)
+                if report_match:
+                    _commit_current()
+                    current_ip = ""
+                    current_hostname = ""
+                    current_os = ""
+                    current_services = []
+
+                    host_line = report_match.group(1)
+                    ip_match = re.match(r"(.+) \((\d+\.\d+\.\d+\.\d+)\)$", host_line)
+                    if ip_match:
+                        current_hostname = ip_match.group(1).strip()
+                        current_ip = ip_match.group(2)
+                    else:
+                        ip_only = re.match(r"^(\d+\.\d+\.\d+\.\d+)$", host_line)
+                        if ip_only:
+                            current_ip = ip_only.group(1)
+                        else:
+                            current_hostname = host_line
+                    continue
+
+                if current_ip:
+                    svc_match = re.match(r"^(\d+)/(tcp|udp)\s+open\s+([^\s]+)", line)
+                    if svc_match:
+                        current_services.append(
+                            f"{svc_match.group(1)}/{svc_match.group(2)} {svc_match.group(3)}"
+                        )
+                    os_match = re.search(r"Service Info: OS: ([^;]+)", line)
+                    if os_match and not current_os:
+                        current_os = os_match.group(1).strip()
+
+            _commit_current()
+            return hosts
 
         targets = target.split()
 
@@ -214,6 +435,13 @@ class NetworkEnumerationTools(Toolset):
                 if self.state:
                     for ip in targets:
                         self.state.queried_hosts.add(ip)
+                if self.state:
+                    parsed_hosts = _parse_nmap_hosts(stdout)
+                    for host in parsed_hosts:
+                        if hasattr(self.state, "add_host"):
+                            self.state.add_host(host)
+                        elif not any(h.ip == host.ip for h in self.state.hosts):
+                            self.state.hosts.append(host)
                 return stdout
 
             ports_str = ",".join(sorted(open_ports, key=int))
@@ -226,6 +454,13 @@ class NetworkEnumerationTools(Toolset):
             if svc_returncode != 0:
                 logger.warning(f"[!] Service scan had issues: {svc_stderr}")
                 # Return port scan results if service scan fails
+                if self.state:
+                    parsed_hosts = _parse_nmap_hosts(stdout)
+                    for host in parsed_hosts:
+                        if hasattr(self.state, "add_host"):
+                            self.state.add_host(host)
+                        elif not any(h.ip == host.ip for h in self.state.hosts):
+                            self.state.hosts.append(host)
                 return stdout
 
             logger.info(f"[*] Nmap scan completed for {len(targets)} target(s)")
@@ -234,6 +469,13 @@ class NetworkEnumerationTools(Toolset):
             if self.state:
                 for ip in targets:
                     self.state.queried_hosts.add(ip)
+
+                parsed_hosts = _parse_nmap_hosts(svc_stdout)
+                for host in parsed_hosts:
+                    if hasattr(self.state, "add_host"):
+                        self.state.add_host(host)
+                    elif not any(h.ip == host.ip for h in self.state.hosts):
+                        self.state.hosts.append(host)
 
             return svc_stdout
 
@@ -299,10 +541,8 @@ class NetworkEnumerationTools(Toolset):
             if output and _has_user_entries(output):
                 return output
 
-            return (
-                output
-                or "[!] No SMB user enumeration output. Target may be non-Windows or SMB is blocked."
-            )
+            raw_output = output or ""
+            return self._format_enum_failure_message(outputs, raw_output)
 
         except Exception as e:
             logger.error(f"User enumeration failed: {e}")
@@ -330,6 +570,36 @@ class NetworkEnumerationTools(Toolset):
         Example:
             >>> enumerate_shares("192.168.1.100", "DOMAIN", "user", "pass")
         """
+
+        def _parse_netexec_hosts(output: str) -> list[Host]:
+            hosts: list[Host] = []
+            for line in output.splitlines():
+                if not line.startswith("SMB"):
+                    continue
+                match = re.match(r"^SMB\s+(\d+\.\d+\.\d+\.\d+)\s+\d+\s+(\S+)\s+(.*)$", line)
+                if not match:
+                    continue
+                ip = match.group(1)
+                name = match.group(2)
+                details = match.group(3)
+
+                os_match = re.search(r"\[\*\]\s+([^(]+)", details)
+                os_name = os_match.group(1).strip() if os_match else "Unknown"
+
+                name_match = re.search(r"\(name:([^)]+)\)", details)
+                hostname = name_match.group(1) if name_match else name
+
+                hosts.append(
+                    Host(
+                        ip=ip,
+                        hostname=hostname,
+                        os=os_name,
+                        roles=[],
+                        services=["445/tcp smb"],
+                    )
+                )
+            return hosts
+
         try:
             cmd = ["netexec", "smb", target]
 
@@ -345,7 +615,15 @@ class NetworkEnumerationTools(Toolset):
             stdout, stderr, _ = _run_tool(cmd, timeout_seconds=120)
             logger.info(f"[*] Share enumeration completed for {target}")
 
-            return stdout or stderr
+            output = stdout or stderr
+            if self.state and output:
+                for host in _parse_netexec_hosts(output):
+                    if hasattr(self.state, "add_host"):
+                        self.state.add_host(host)
+                    elif not any(h.ip == host.ip for h in self.state.hosts):
+                        self.state.hosts.append(host)
+
+            return output
 
         except Exception as e:
             logger.error(f"Share enumeration failed: {e}")
@@ -378,31 +656,17 @@ class NetworkEnumerationTools(Toolset):
         """
         try:
             outputs = self._run_user_enum_commands(target, username, password, domain)
-            output = "\n".join(content for _, content in outputs if content).strip()
-
-            # Parse usernames from output
-            users: set[str] = set()
-
-            # Pattern for netexec: DOMAIN\username or domain\username
-            for match in re.finditer(r"[A-Za-z0-9._-]+\\([A-Za-z0-9._-]+)", output):
-                user = match.group(1)
-                # Filter out machine accounts and common noise
-                if not user.endswith("$") and user.lower() not in ("", "anonymous"):
-                    users.add(user)
-
-            # Pattern for rpcclient: user:[username] rid:[0x...]
-            for match in re.finditer(r"user:\[([^\]]+)\]", output):
-                user = match.group(1)
-                if not user.endswith("$"):
-                    users.add(user)
+            users = self._extract_users_from_outputs(outputs)
 
             if not users:
-                return f"[!] No users found to save. Raw output:\n{output[:500]}"
+                output = "\n".join(content for _, content in outputs if content).strip()
+                return self._format_enum_failure_message(outputs, output)
 
-            # Save to file
+            # Save to file on remote executor
             users_file = "/tmp/users.txt"  # nosec B108  # noqa: S108
-            with open(users_file, "w") as f:
-                f.write("\n".join(sorted(users)))
+            ok, error = _write_users_file_remote(sorted(users), users_file)
+            if not ok:
+                return f"[!] Failed to write users file on remote: {error}"
 
             logger.info(f"[+] Saved {len(users)} users to {users_file}")
             return f"[+] Saved {len(users)} users to {users_file}\nUsers: {', '.join(sorted(users)[:20])}{'...' if len(users) > 20 else ''}"
@@ -426,6 +690,14 @@ class CredentialDiscoveryTools(Toolset):
     def set_state(self, state: RedTeamState) -> None:
         """Set the operation state for this toolset."""
         self.state = state
+
+    def _run_user_enum_commands(
+        self, target: str, username: str, password: str, domain: str
+    ) -> list[tuple[str, str]]:
+        return NetworkEnumerationTools()._run_user_enum_commands(target, username, password, domain)
+
+    def _extract_users_from_outputs(self, outputs: list[tuple[str, str]]) -> set[str]:
+        return NetworkEnumerationTools()._extract_users_from_outputs(outputs)
 
     def _add_weakness(self, block: str) -> None:
         if not self.state or not block:
@@ -727,27 +999,23 @@ class CredentialDiscoveryTools(Toolset):
                 logger.info(f"[*] Using credential {domain}\\{username} for user enumeration")
 
             outputs = self._run_user_enum_commands(target, username, password, domain)
-            output = "\n".join(content for _, content in outputs if content).strip()
-
-            # Parse usernames
-            users: set[str] = set()
-            for match in re.finditer(r"[A-Za-z0-9._-]+\\([A-Za-z0-9._-]+)", output):
-                user = match.group(1)
-                if not user.endswith("$") and user.lower() not in ("", "anonymous"):
-                    users.add(user)
-            for match in re.finditer(r"user:\[([^\]]+)\]", output):
-                user = match.group(1)
-                if not user.endswith("$"):
-                    users.add(user)
+            users = self._extract_users_from_outputs(outputs)
 
             if not users:
-                logger.warning(f"[!] No users enumerated from {target}")
+                helper = NetworkEnumerationTools()
+                summary = helper._summarize_enum_outputs(outputs)
+                if summary:
+                    logger.warning(f"[!] No users enumerated from {target}. Status:\n{summary}")
+                else:
+                    logger.warning(f"[!] No users enumerated from {target}")
                 return None
 
-            # Save to temp file
+            # Save to temp file on remote executor
             users_file = "/tmp/users_auto.txt"  # nosec B108  # noqa: S108
-            with open(users_file, "w") as f:
-                f.write("\n".join(sorted(users)))
+            ok, error = _write_users_file_remote(sorted(users), users_file)
+            if not ok:
+                logger.warning(f"[!] Failed to write users file on remote: {error}")
+                return None
             logger.info(f"[+] Auto-enumerated {len(users)} users to {users_file}")
             return users_file
 
@@ -815,38 +1083,43 @@ class CredentialDiscoveryTools(Toolset):
             result = stdout + "\n" + (stderr or "")
 
             # Check for successful authentications
-            if "[+]" in result:
-                logger.warning("[!] FOUND USER WITH USERNAME=PASSWORD!")
+            creds = self._parse_netexec_credentials(result)
+            if creds:
+                accounts = sorted(
+                    {f"{cred_domain}\\{username}" for cred_domain, username, _, _ in creds}
+                )
+                logger.warning(
+                    "[!] FOUND USER WITH USERNAME=PASSWORD! Accounts: %s",
+                    ", ".join(accounts),
+                )
                 result = (
                     "🚨 USERNAME=PASSWORD FOUND!\n"
+                    f"→ Accounts: {', '.join(accounts)}\n"
                     "→ Common examples: user1:user1, guest:guest\n"
                     "→ Use found credentials for kerberoast, asrep_roast, bloodhound\n\n" + result
                 )
+            # If output contains [+] but no parseable creds, avoid a noisy warning.
 
-            if self.state:
-                creds = self._parse_netexec_credentials(result)
-                if creds:
-                    accounts = []
-                    for cred_domain, username, found_password, is_admin in creds:
-                        password_value = found_password or username
-                        self._add_credential(
-                            username,
-                            password_value,
-                            cred_domain,
-                            "username_as_password",
-                            is_admin=is_admin,
-                        )
-                        accounts.append(f"{cred_domain}\\{username}")
-                    block = _format_weakness_block(
-                        "Credential Discovery - Username=Password Combinations",
-                        "Users with passwords matching their usernames",
-                        {
-                            "Discovered Accounts": ", ".join(sorted(set(accounts))),
-                        },
-                        "Immediate authenticated access",
-                        "Username-as-password test",
+            if self.state and creds:
+                for cred_domain, username, found_password, is_admin in creds:
+                    password_value = found_password or username
+                    self._add_credential(
+                        username,
+                        password_value,
+                        cred_domain,
+                        "username_as_password",
+                        is_admin=is_admin,
                     )
-                    self._add_weakness(block)
+                block = _format_weakness_block(
+                    "Credential Discovery - Username=Password Combinations",
+                    "Users with passwords matching their usernames",
+                    {
+                        "Discovered Accounts": ", ".join(accounts),
+                    },
+                    "Immediate authenticated access",
+                    "Username-as-password test",
+                )
+                self._add_weakness(block)
 
             return result
 
@@ -1185,7 +1458,7 @@ class CredentialHarvestingTools(Toolset):
             return f"Kerberoasting failed: {e!s}"
 
     @dn.tool_method
-    def kerberos_user_enum_noauth(
+    def kerberos_user_enum_noauth(  # noqa: PLR0912
         self,
         domain: str,
         dc_ip: str,
@@ -1207,6 +1480,17 @@ class CredentialHarvestingTools(Toolset):
         """
         try:
             remote_temp_file = ""
+            users_payload = ""
+            if users_file:
+                check_cmd = ["bash", "-lc", f"test -f {shlex.quote(users_file)}"]
+                check_result = run_remote(check_cmd, timeout_seconds=30)
+                if check_result.return_code != 0:
+                    logger.warning(
+                        "[!] Users file %s not found on remote. Falling back to default list.",
+                        users_file,
+                    )
+                    users_file = ""
+
             if not users_file:
                 default_users = [
                     "administrator",
@@ -1283,7 +1567,13 @@ class CredentialHarvestingTools(Toolset):
 
             if validated:
                 summary = ", ".join(sorted(validated))
-                return f"✓ Valid principals (Kerberos no-auth): {summary}\n\n{output}"
+                users_file = f"/tmp/users_kerberos_{uuid.uuid4().hex}.txt"  # nosec B108  # noqa: S108
+                ok, error = _write_users_file_remote(sorted(validated), users_file)
+                if ok:
+                    file_note = f"\nUsers file: {users_file}"
+                else:
+                    file_note = f"\n[!] Failed to write users file on remote: {error}"
+                return f"✓ Valid principals (Kerberos no-auth): {summary}{file_note}\n\n{output}"
 
             return output
 
@@ -3128,7 +3418,7 @@ class RedTeamReportingTools(Toolset):
     def record_finding(
         self,
         finding_type: str,
-        data: dict[str, Any],
+        data: dict[str, Any] | None = None,
     ) -> str:
         """
         Record a discovery during the red team operation.
@@ -3184,6 +3474,8 @@ class RedTeamReportingTools(Toolset):
         """
         if not self.state:
             return "[!] Error: No operation state available"
+        if data is None:
+            return "[!] Error: record_finding requires a data payload"
 
         try:
             handlers = {

--- a/src/ares/tools/red/orchestrator.py
+++ b/src/ares/tools/red/orchestrator.py
@@ -53,6 +53,32 @@ class OrchestratorTools(Toolset):
         return self._shared_state
 
     @dn.tool_method
+    def complete_operation(self, summary: str) -> str:
+        """
+        Mark the multi-agent red team operation as complete.
+
+        Use this tool when you have:
+        - Achieved domain admin access OR exhausted all attack paths
+        - Coordinated with all specialized agents
+        - Collected all available credentials and hashes
+        - Generated golden ticket (if krbtgt hash was found)
+
+        Args:
+            summary: Executive summary of the operation including:
+                - All domain administrators compromised
+                - Attack paths used
+                - Total credentials obtained
+                - Hosts compromised
+                - Key vulnerabilities exploited
+
+        Returns:
+            Confirmation message
+        """
+        self.shared_state.completed = True
+        logger.success(f"🎯 Multi-agent operation completed: {summary}")
+        return f"✓ Operation marked as complete. Summary: {summary}"
+
+    @dn.tool_method
     async def dispatch_crack_hash(
         self,
         hash_value: str,
@@ -493,12 +519,15 @@ class OrchestratorTools(Toolset):
 
         lines = ["🔑 Discovered Credentials:"]
         for cred in creds:
+            username = cred.username.strip()
+            if not username or username.lower() in {"(none)", "none", "null", "(null)"}:
+                continue
             auth = cred.password if cred.password else "[hash]"
             admin_tag = " ⚡ADMIN" if cred.is_admin else ""
             lines.append(f"  • {cred.domain}\\{cred.username}: {auth[:20]}...{admin_tag}")
             lines.append(f"    Source: {cred.source}")
 
-        return "\n".join(lines)
+        return "\n".join(lines) if len(lines) > 1 else "No credentials discovered yet"
 
     @dn.tool_method
     def get_all_hashes(self) -> str:
@@ -675,6 +704,11 @@ class OrchestratorTools(Toolset):
         Returns:
             Confirmation message
         """
+        username = username.strip()
+        if not username or username.lower() in {"(none)", "none", "null", "(null)"}:
+            return "[!] Invalid username; credential not broadcast"
+        if not (password or hash_value):
+            return "[!] Missing password/hash; credential not broadcast"
         from ares.core.models import Credential
 
         cred = Credential(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def sample_evidence() -> Evidence:
     return Evidence(
         id="ev-001",
         type="ip_address",
-        value="192.168.1.100",
+        value="192.168.56.100",
         source="Loki query: {job='firewall'}",
         timestamp=datetime.now(timezone.utc),
         pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -285,7 +285,7 @@ def escalated_investigation_state(
 def sample_target() -> Target:
     """Create a sample target."""
     return Target(
-        ip="192.168.1.100",
+        ip="192.168.56.100",
         hostname="dc01.child.example.local",
         domain="child.example.local",
         os="Windows Server 2019",
@@ -323,8 +323,8 @@ def populated_red_team_state(sample_target: Target) -> RedTeamState:
         started_at=datetime.now(timezone.utc),
         stage=InvestigationStage.CAUSATION,
         hosts=[
-            Host(ip="192.168.1.100", hostname="dc01", os="Windows Server 2019"),
-            Host(ip="192.168.1.101", hostname="dc01", os="Windows 10"),
+            Host(ip="192.168.56.100", hostname="dc01", os="Windows Server 2019"),
+            Host(ip="192.168.56.101", hostname="dc01", os="Windows 10"),
         ],
         users=[
             User(username="alice.smith", domain="north", is_admin=True),
@@ -586,7 +586,7 @@ def correlation_context() -> dict[str, Any]:
     return {
         "cluster_id": "cluster-123",
         "related_alerts": 3,
-        "shared_indicators": ["192.168.1.100", "alice.smith"],
+        "shared_indicators": ["192.168.56.100", "alice.smith"],
         "common_techniques": ["T1003.006"],
         "time_window_minutes": 30,
     }

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -35,7 +35,7 @@ class TestCompletionTools:
                 Evidence(
                     id="ev-1",
                     type="ip_address",
-                    value="192.168.1.100",
+                    value="192.168.56.100",
                     source="Query",
                     timestamp=datetime.now(timezone.utc),
                     pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -199,7 +199,7 @@ class TestGenerateFallbackSynopsis:
             Evidence(
                 id="ev-test",
                 type="ip",
-                value="10.0.0.1",
+                value="192.168.56.1",
                 source="test",
                 timestamp=datetime.now(timezone.utc),
                 pyramid_level=PyramidLevel.IP_ADDRESSES,

--- a/tests/test_alert_correlation.py
+++ b/tests/test_alert_correlation.py
@@ -76,13 +76,13 @@ class TestAlertCluster:
         cluster = AlertCluster(cluster_id="cluster-0001")
 
         alert = {
-            "labels": {"instance": "192.168.1.100:9090"},
+            "labels": {"instance": "192.168.56.100:9090"},
             "fingerprint": "abc123",
         }
         cluster.add_alert(alert)
 
         # Should not add IP as hostname
-        assert "192.168.1.100" not in cluster.common_hosts
+        assert "192.168.56.100" not in cluster.common_hosts
 
     def test_add_alert_extracts_users_from_labels(self) -> None:
         """Test that add_alert extracts users from various label keys."""
@@ -133,15 +133,15 @@ class TestAlertCluster:
 
         alert = {
             "labels": {
-                "ip": "192.168.1.100",
-                "source_ip": "10.0.0.50",
+                "ip": "192.168.56.100",
+                "source_ip": "192.168.56.50",
             },
             "fingerprint": "abc123",
         }
         cluster.add_alert(alert)
 
-        assert "192.168.1.100" in cluster.common_ips
-        assert "10.0.0.50" in cluster.common_ips
+        assert "192.168.56.100" in cluster.common_ips
+        assert "192.168.56.50" in cluster.common_ips
 
     def test_add_alert_extracts_techniques_string(self) -> None:
         """Test that add_alert extracts MITRE techniques as string."""
@@ -249,9 +249,9 @@ class TestAlertCluster:
     def test_similarity_score_ip_match(self) -> None:
         """Test similarity score with matching IP."""
         cluster = AlertCluster(cluster_id="cluster-0001")
-        cluster.common_ips.add("192.168.1.100")
+        cluster.common_ips.add("192.168.56.100")
 
-        alert = {"labels": {"ip": "192.168.1.100"}}
+        alert = {"labels": {"ip": "192.168.56.100"}}
         score = cluster.similarity_score(alert)
 
         assert score >= 0.2  # IP match gives 0.2
@@ -299,13 +299,13 @@ class TestAlertCluster:
         cluster = AlertCluster(cluster_id="cluster-0001")
         cluster.common_hosts.add("server01")
         cluster.common_users.add("admin")
-        cluster.common_ips.add("192.168.1.100")
+        cluster.common_ips.add("192.168.56.100")
 
         alert = {
             "labels": {
                 "hostname": "server01",
                 "user": "admin",
-                "ip": "192.168.1.100",
+                "ip": "192.168.56.100",
             }
         }
         score = cluster.similarity_score(alert)
@@ -319,7 +319,7 @@ class TestAlertCluster:
         cluster = AlertCluster(cluster_id="cluster-0001")
         cluster.common_hosts.add("server01")
         cluster.common_users.add("admin")
-        cluster.common_ips.add("192.168.1.100")
+        cluster.common_ips.add("192.168.56.100")
         cluster.techniques.add("T1059.001")
         cluster.time_range = (
             datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
@@ -330,7 +330,7 @@ class TestAlertCluster:
             "labels": {
                 "hostname": "server01",
                 "user": "admin",
-                "ip": "192.168.1.100",
+                "ip": "192.168.56.100",
                 "mitre_technique": "T1059.001",
             },
             "startsAt": "2024-01-15T10:30:00Z",
@@ -365,7 +365,7 @@ class TestAlertCluster:
         cluster.alerts = [{"id": 1}, {"id": 2}]
         cluster.common_hosts = {"server01", "server02"}
         cluster.common_users = {"admin"}
-        cluster.common_ips = {"192.168.1.100"}
+        cluster.common_ips = {"192.168.56.100"}
         cluster.techniques = {"T1059.001"}
         cluster.time_range = (
             datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
@@ -489,14 +489,14 @@ class TestAlertCorrelator:
 
         # Alert with exactly 0.3 similarity (IP match = 0.2, below threshold)
         alert2 = {
-            "labels": {"ip": "192.168.1.100"},
+            "labels": {"ip": "192.168.56.100"},
             "fingerprint": "def456",
         }
         # This has different host, only IP would match (0.2 < 0.3 threshold)
         # So it should create a new cluster
 
         # But first, add an IP to make it matchable
-        correlator.clusters[0].common_ips.add("192.168.1.100")
+        correlator.clusters[0].common_ips.add("192.168.56.100")
 
         correlator.add_alert(alert2)
 
@@ -680,7 +680,7 @@ class TestAlertCorrelatorIntegration:
                 "labels": {
                     "hostname": "DC01",
                     "user": "admin",
-                    "source_ip": "192.168.1.100",
+                    "source_ip": "192.168.56.100",
                 },
                 "startsAt": "2024-01-15T10:10:00Z",
                 "fingerprint": "auth3",
@@ -736,7 +736,7 @@ class TestAlertCorrelatorIntegration:
                 "labels": {
                     "hostname": "WORKSTATION01",
                     "user": "compromised_user",
-                    "source_ip": "192.168.1.10",
+                    "source_ip": "192.168.56.10",
                 },
                 "fingerprint": "lat1",
             },
@@ -744,7 +744,7 @@ class TestAlertCorrelatorIntegration:
                 "labels": {
                     "hostname": "SERVER01",
                     "user": "compromised_user",
-                    "source_ip": "192.168.1.10",
+                    "source_ip": "192.168.56.10",
                 },
                 "fingerprint": "lat2",
             },
@@ -752,7 +752,7 @@ class TestAlertCorrelatorIntegration:
                 "labels": {
                     "hostname": "DC01",
                     "user": "compromised_user",
-                    "source_ip": "192.168.1.10",
+                    "source_ip": "192.168.56.10",
                 },
                 "fingerprint": "lat3",
             },

--- a/tests/test_blue_factory.py
+++ b/tests/test_blue_factory.py
@@ -97,7 +97,7 @@ class TestCalculateBonusQueries:
             Evidence(
                 id="ev-1",
                 type="ip",
-                value="10.0.0.1",
+                value="192.168.56.1",
                 source="test",
                 timestamp=datetime.now(timezone.utc),
                 pyramid_level=PyramidLevel.IP_ADDRESSES,

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -31,7 +31,7 @@ def sample_red_activity() -> RedTeamActivity:
         technique_id="T1059.001",
         technique_name="PowerShell",
         action="Executed PowerShell command for reconnaissance",
-        target_ip="192.168.1.100",
+        target_ip="192.168.56.100",
         target_host="server01",
         credential_used="admin",
         success=True,
@@ -47,7 +47,7 @@ def sample_blue_detection() -> BlueTeamDetection:
         alert_name="Suspicious PowerShell Activity",
         technique_id="T1059.001",
         severity="high",
-        target_ip="192.168.1.100",
+        target_ip="192.168.56.100",
         target_host="server01",
         investigation_id="inv-001",
         status="completed",
@@ -66,7 +66,7 @@ class TestRedTeamActivity:
 
         assert "2024-01-15" in key
         assert "T1059.001" in key
-        assert "192.168.1.100" in key
+        assert "192.168.56.100" in key
 
     def test_key_uniqueness(self) -> None:
         """Test that different activities have different keys."""
@@ -75,7 +75,7 @@ class TestRedTeamActivity:
             technique_id="T1059.001",
             technique_name="PowerShell",
             action="Action 1",
-            target_ip="192.168.1.100",
+            target_ip="192.168.56.100",
             target_host=None,
             credential_used=None,
             success=True,
@@ -85,7 +85,7 @@ class TestRedTeamActivity:
             technique_id="T1059.001",
             technique_name="PowerShell",
             action="Action 2",
-            target_ip="192.168.1.100",
+            target_ip="192.168.56.100",
             target_host=None,
             credential_used=None,
             success=True,
@@ -284,7 +284,7 @@ class TestRedBlueCorrelator:
             alert_name="Late Detection",
             technique_id="T1059.001",
             severity="high",
-            target_ip="192.168.1.100",
+            target_ip="192.168.56.100",
             target_host=None,
             investigation_id="inv-late",
             status="completed",
@@ -312,7 +312,7 @@ class TestRedBlueCorrelator:
             alert_name="Different Technique",
             technique_id="T1003.001",  # Different technique
             severity="high",
-            target_ip="192.168.1.100",
+            target_ip="192.168.56.100",
             target_host=None,
             investigation_id="inv-001",
             status="completed",
@@ -405,7 +405,7 @@ class TestRedBlueCorrelator:
             alert_name="Unrelated Alert",
             technique_id="T9999",  # No matching red activity
             severity="low",
-            target_ip="10.0.0.1",  # Different target
+            target_ip="192.168.56.1",  # Different target
             target_host=None,
             investigation_id="inv-fp",
             status="completed",
@@ -421,7 +421,7 @@ class TestRedBlueCorrelator:
                     alert_name="Matching Alert",
                     technique_id="T1059.001",
                     severity="high",
-                    target_ip="192.168.1.100",
+                    target_ip="192.168.56.100",
                     target_host=None,
                     investigation_id="inv-001",
                     status="completed",
@@ -505,7 +505,7 @@ class TestRedBlueCorrelator:
                 technique_id="T1059.001",
                 technique_name="PowerShell",
                 action="Action 1",
-                target_ip="192.168.1.100",
+                target_ip="192.168.56.100",
                 target_host=None,
                 credential_used=None,
                 success=True,
@@ -515,7 +515,7 @@ class TestRedBlueCorrelator:
                 technique_id="T1059.002",
                 technique_name="Script",
                 action="Action 2",
-                target_ip="192.168.1.100",
+                target_ip="192.168.56.100",
                 target_host=None,
                 credential_used=None,
                 success=True,
@@ -528,7 +528,7 @@ class TestRedBlueCorrelator:
                 alert_name="Alert 1",
                 technique_id="T1059.001",
                 severity="high",
-                target_ip="192.168.1.100",
+                target_ip="192.168.56.100",
                 target_host=None,
                 investigation_id="inv-1",
                 status="completed",
@@ -540,7 +540,7 @@ class TestRedBlueCorrelator:
                 alert_name="Alert 2",
                 technique_id="T1059.002",
                 severity="high",
-                target_ip="192.168.1.100",
+                target_ip="192.168.56.100",
                 target_host=None,
                 investigation_id="inv-2",
                 status="completed",
@@ -588,7 +588,7 @@ class TestRedBlueCorrelator:
         report_content = """# Red Team Operation Report
 
 **Operation ID**: op-test-001
-**Target**: 192.168.1.100
+**Target**: 192.168.56.100
 **Started**: 2024-01-15 10:00:00 UTC
 
 ### Hosts (3)
@@ -640,7 +640,7 @@ Source: credential dumping
 Alert payload contains:
 "startsAt": "2024-01-15T10:30:00Z"
 
-Target IP: 192.168.1.100
+Target IP: 192.168.56.100
 
 Technique: T1059.001
 
@@ -679,7 +679,7 @@ Technique: T1059.001
         red_report = temp_reports_dir / "redteam-op001.md"
         red_report.write_text("""# Red Team Report
 **Operation ID**: op001
-**Target**: 192.168.1.1
+**Target**: 192.168.56.1
 **Started**: 2024-01-15 10:00:00 UTC
 ### Hosts (1)
 ### Credentials (0)
@@ -750,7 +750,7 @@ class TestRedTeamReportParsingEdgeCases:
         content = """# Red Team Operation Report
 
 **Operation ID**: op-test
-**Target:** 192.168.1.1
+**Target:** 192.168.56.1
 **Started:** invalid-date-format
 
 ### Hosts (2)
@@ -772,7 +772,7 @@ class TestRedTeamReportParsingEdgeCases:
         content = """# Red Team Operation Report
 ## op-test
 
-**Target:** 192.168.1.1
+**Target:** 192.168.56.1
 **Started:** 2024-01-15 10:30:00 UTC
 
 ### Credentials (2)
@@ -799,7 +799,7 @@ Source: Secretsdump from DC
         content = """# Red Team Operation Report
 ## op-test
 
-**Target:** 192.168.1.1
+**Target:** 192.168.56.1
 **Started:** 2024-01-15 10:30:00 UTC
 
 ### Timeline of Key Events
@@ -827,7 +827,7 @@ Source: Secretsdump from DC
         content = """# Red Team Operation Report
 ## op-test
 
-**Target:** 192.168.1.1
+**Target:** 192.168.56.1
 
 ### Hosts (1)
 - host1
@@ -846,7 +846,7 @@ Source: Secretsdump from DC
         content = """# Red Team Operation Report
 ## op-test
 
-**Target:** 192.168.1.1
+**Target:** 192.168.56.1
 **Started:** 2024-01-15 10:30:00 UTC
 
 ### Credentials (1)
@@ -966,7 +966,7 @@ class TestGenerateReportMarkdownAdvanced:
                 technique_id="T1046",
                 technique_name="Network Service Discovery",
                 action="Scanned network for open ports",
-                target_ip="192.168.1.0/24",
+                target_ip="192.168.56.0/24",
                 target_host=None,
                 credential_used=None,
                 success=True,
@@ -1007,7 +1007,7 @@ class TestGenerateReportMarkdownAdvanced:
                 technique_id="T1003",
                 technique_name="OS Credential Dumping",
                 action="Dumped credentials via LSASS",
-                target_ip="192.168.1.100",
+                target_ip="192.168.56.100",
                 target_host="server01",
                 credential_used=None,
                 success=True,
@@ -1021,7 +1021,7 @@ class TestGenerateReportMarkdownAdvanced:
             alert_name="False Positive Alert",
             technique_id="T1071",
             severity="medium",
-            target_ip="192.168.1.50",
+            target_ip="192.168.56.50",
             target_host=None,
             investigation_id="inv-fp",
             status="closed",

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -101,7 +101,7 @@ def state_with_techniques(sample_alert: dict) -> InvestigationState:
             Evidence(
                 id="ev-1",
                 type="ip_address",
-                value="192.168.1.100",
+                value="192.168.56.100",
                 source="Query",
                 timestamp=datetime.now(timezone.utc),
                 pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -257,7 +257,7 @@ class TestPyramidClimberGenerateQuestions:
                 Evidence(
                     id="ev-ip",
                     type="ip_address",
-                    value="192.168.1.100",
+                    value="192.168.56.100",
                     source="Query",
                     timestamp=datetime.now(timezone.utc),
                     pyramid_level=PyramidLevel.IP_ADDRESSES,

--- a/tests/test_evidence_validation.py
+++ b/tests/test_evidence_validation.py
@@ -87,13 +87,13 @@ class TestStoreQueryResult:
     def test_store_extracts_values(self):
         """Test store extracts searchable values."""
         reset_evidence_validation()
-        data = {"ip": "192.168.1.100", "user": "admin@domain.local"}
+        data = {"ip": "192.168.56.100", "user": "admin@domain.local"}
         store_query_result("test", "query", data, 2)
 
         # Check via suggested IOCs
         suggestions = get_suggested_iocs()
         values = [s["value"] for s in suggestions]
-        assert any("192.168.1.100" in v for v in values)
+        assert any("192.168.56.100" in v for v in values)
 
     def test_store_respects_max_limit(self):
         """Test store respects MAX_STORED_RESULTS."""
@@ -112,14 +112,14 @@ class TestExtractSearchableValues:
 
     def test_extract_from_string(self):
         """Test extracting from string."""
-        values = _extract_searchable_values("192.168.1.100")
-        assert "192.168.1.100" in values
+        values = _extract_searchable_values("192.168.56.100")
+        assert "192.168.56.100" in values
 
     def test_extract_from_dict(self):
         """Test extracting from dictionary."""
-        data = {"ip": "10.0.0.1", "host": "server01.domain.local"}
+        data = {"ip": "192.168.56.1", "host": "server01.domain.local"}
         values = _extract_searchable_values(data)
-        assert "10.0.0.1" in values
+        assert "192.168.56.1" in values
         assert "server01.domain.local" in values
 
     def test_extract_from_list(self):
@@ -131,9 +131,9 @@ class TestExtractSearchableValues:
 
     def test_extract_nested(self):
         """Test extracting from nested structures."""
-        data = {"outer": {"inner": {"ip": "192.168.1.1"}}}
+        data = {"outer": {"inner": {"ip": "192.168.56.1"}}}
         values = _extract_searchable_values(data)
-        assert "192.168.1.1" in values
+        assert "192.168.56.1" in values
 
     def test_extract_depth_limit(self):
         """Test extraction respects depth limit."""
@@ -158,10 +158,10 @@ class TestExtractPatternsFromString:
 
     def test_extract_ipv4(self):
         """Test extracting IPv4 addresses."""
-        text = "Connection from 192.168.1.100 to 10.0.0.1"
+        text = "Connection from 192.168.56.100 to 192.168.56.1"
         patterns = _extract_patterns_from_string(text)
-        assert "192.168.1.100" in patterns
-        assert "10.0.0.1" in patterns
+        assert "192.168.56.100" in patterns
+        assert "192.168.56.1" in patterns
 
     def test_extract_hostname(self):
         """Test extracting hostnames."""
@@ -241,9 +241,9 @@ class TestValidateEvidenceValue:
     def test_validate_exact_match(self):
         """Test validating exact match."""
         reset_evidence_validation()
-        store_query_result("test", "query", {"ip": "192.168.1.100"}, 1)
+        store_query_result("test", "query", {"ip": "192.168.56.100"}, 1)
 
-        validated, query_id = validate_evidence_value("192.168.1.100")
+        validated, query_id = validate_evidence_value("192.168.56.100")
         assert validated is True
         assert query_id is not None
 
@@ -268,9 +268,9 @@ class TestValidateEvidenceValue:
     def test_validate_not_found(self):
         """Test validating value not in results."""
         reset_evidence_validation()
-        store_query_result("test", "query", {"ip": "192.168.1.100"}, 1)
+        store_query_result("test", "query", {"ip": "192.168.56.100"}, 1)
 
-        validated, query_id = validate_evidence_value("10.0.0.1")
+        validated, query_id = validate_evidence_value("192.168.56.1")
         assert validated is False
         assert query_id is None
 
@@ -287,7 +287,7 @@ class TestGetSuggestedIOCs:
     def test_returns_classified_iocs(self):
         """Test returns classified IOCs."""
         reset_evidence_validation()
-        store_query_result("test", "query", {"ip": "192.168.1.100"}, 1)
+        store_query_result("test", "query", {"ip": "192.168.56.100"}, 1)
 
         suggestions = get_suggested_iocs()
         ip_suggestions = [s for s in suggestions if s["type"] == "ip"]
@@ -306,11 +306,11 @@ class TestGetSuggestedIOCs:
     def test_deduplicates_values(self):
         """Test deduplicates values."""
         reset_evidence_validation()
-        store_query_result("test", "q1", {"ip": "192.168.1.100"}, 1)
-        store_query_result("test", "q2", {"ip": "192.168.1.100"}, 1)
+        store_query_result("test", "q1", {"ip": "192.168.56.100"}, 1)
+        store_query_result("test", "q2", {"ip": "192.168.56.100"}, 1)
 
         suggestions = get_suggested_iocs()
-        ip_values = [s["value"] for s in suggestions if s["value"] == "192.168.1.100"]
+        ip_values = [s["value"] for s in suggestions if s["value"] == "192.168.56.100"]
         # Should only appear once
         assert len(ip_values) <= 1
 
@@ -320,8 +320,8 @@ class TestClassifyIOC:
 
     def test_classify_ip(self):
         """Test classifying IP address."""
-        assert _classify_ioc("192.168.1.100") == "ip"
-        assert _classify_ioc("10.0.0.1") == "ip"
+        assert _classify_ioc("192.168.56.100") == "ip"
+        assert _classify_ioc("192.168.56.1") == "ip"
 
     def test_classify_hostname(self):
         """Test classifying hostname."""
@@ -467,7 +467,7 @@ class TestAutoExtractEvidenceFromQuery:
 
     def test_extract_ip_address(self):
         """Test extracting IP address evidence."""
-        result = {"ip": "192.168.1.100"}
+        result = {"ip": "192.168.56.100"}
         evidence = auto_extract_evidence_from_query(result, "test query")
 
         ip_evidence = [e for e in evidence if e["type"] == "ip"]
@@ -485,7 +485,7 @@ class TestAutoExtractEvidenceFromQuery:
 
     def test_extract_with_mitre_technique(self):
         """Test extracting with MITRE technique."""
-        result = {"ip": "192.168.1.100"}
+        result = {"ip": "192.168.56.100"}
         evidence = auto_extract_evidence_from_query(result, "test query", mitre_technique="T1003")
 
         ip_evidence = [e for e in evidence if e["type"] == "ip"]
@@ -494,7 +494,7 @@ class TestAutoExtractEvidenceFromQuery:
 
     def test_extract_validated_flag(self):
         """Test extracted evidence is marked validated."""
-        result = {"ip": "192.168.1.100"}
+        result = {"ip": "192.168.56.100"}
         evidence = auto_extract_evidence_from_query(result, "test query")
 
         for ev in evidence:
@@ -510,23 +510,23 @@ class TestAutoExtractEvidenceFromQuery:
 
     def test_extract_skips_short_values(self):
         """Test extraction skips very short values."""
-        result = {"short": "ab", "valid": "192.168.1.100"}
+        result = {"short": "ab", "valid": "192.168.56.100"}
         evidence = auto_extract_evidence_from_query(result, "test query")
 
         # Should have IP but not the short value
-        assert any(e["value"] == "192.168.1.100" for e in evidence)
+        assert any(e["value"] == "192.168.56.100" for e in evidence)
 
     def test_extract_deduplicates(self):
         """Test extraction deduplicates values."""
-        result = [{"ip": "192.168.1.100"}, {"ip": "192.168.1.100"}]
+        result = [{"ip": "192.168.56.100"}, {"ip": "192.168.56.100"}]
         evidence = auto_extract_evidence_from_query(result, "test query")
 
-        ip_values = [e["value"] for e in evidence if e["value"] == "192.168.1.100"]
+        ip_values = [e["value"] for e in evidence if e["value"] == "192.168.56.100"]
         assert len(ip_values) <= 1
 
     def test_extract_source_description(self):
         """Test source includes description."""
-        result = {"ip": "192.168.1.100"}
+        result = {"ip": "192.168.56.100"}
         evidence = auto_extract_evidence_from_query(result, "Loki query for auth logs")
 
         assert any("Loki query" in e["source"] for e in evidence)

--- a/tests/test_investigation_tools.py
+++ b/tests/test_investigation_tools.py
@@ -64,7 +64,7 @@ def investigation_state_with_evidence(sample_alert: dict) -> InvestigationState:
             Evidence(
                 id="ev-0000",
                 type="ip_address",
-                value="192.168.1.100",
+                value="192.168.56.100",
                 source="Query",
                 timestamp=datetime.now(timezone.utc),
                 pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -128,7 +128,7 @@ class TestRecordEvidence:
         tools = InvestigationTools()
         result = tools.record_evidence(
             evidence_type="ip",
-            value="192.168.1.100",
+            value="192.168.56.100",
             source="test",
             timestamp=None,
             pyramid_level=2,
@@ -148,7 +148,7 @@ class TestRecordEvidence:
                 mock_adjust.return_value = 0.8
                 result = tools.record_evidence(
                     evidence_type="ip",
-                    value="192.168.1.100",
+                    value="192.168.56.100",
                     source="Loki query",
                     timestamp="2024-01-15T14:30:00Z",
                     pyramid_level=2,
@@ -451,7 +451,7 @@ class TestGetSuggestedEvidence:
 
         with patch("ares.tools.blue.investigation.get_suggested_iocs") as mock_get:
             mock_get.return_value = [
-                {"type": "ip", "value": "192.168.1.100", "source_query_id": "q-0001"},
+                {"type": "ip", "value": "192.168.56.100", "source_query_id": "q-0001"},
                 {"type": "hostname", "value": "dc01.domain.local", "source_query_id": "q-0001"},
             ]
             result = tools.get_suggested_evidence()
@@ -567,7 +567,7 @@ class TestGetCorrelatedAlerts:
             "related_alerts": 3,
             "common_hosts": ["dc01.domain.local"],
             "common_users": ["admin"],
-            "common_ips": ["192.168.1.100"],
+            "common_ips": ["192.168.56.100"],
             "techniques_in_cluster": ["T1558.003"],
             "time_range": "2024-01-15T14:00:00Z to 2024-01-15T16:00:00Z",
         }

--- a/tests/test_lateral_analyzer.py
+++ b/tests/test_lateral_analyzer.py
@@ -345,8 +345,8 @@ class TestLateralMovementAnalyzer:
         """Test _looks_like_hostname rejects IP addresses."""
         analyzer = LateralMovementAnalyzer()
 
-        assert analyzer._looks_like_hostname("192.168.1.100") is False
-        assert analyzer._looks_like_hostname("10.0.0.1") is False
+        assert analyzer._looks_like_hostname("192.168.56.100") is False
+        assert analyzer._looks_like_hostname("192.168.56.1") is False
 
     def test_looks_like_hostname_invalid_no_dot(self) -> None:
         """Test _looks_like_hostname rejects strings without dots."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -319,9 +319,9 @@ class TestRedteamCommand:
 
             args = Args(model="test-model", report_dir=str(tmp_path))
 
-            await redteam("192.168.1.100", args=args)
+            await redteam("192.168.56.100", args=args)
 
-            mock_orchestrator.execute_operation.assert_called_once_with("192.168.1.100")
+            mock_orchestrator.execute_operation.assert_called_once_with("192.168.56.100")
 
     @pytest.mark.asyncio
     async def test_redteam_domain_admin_achieved(self, tmp_path: Path):
@@ -353,7 +353,7 @@ class TestRedteamCommand:
 
             args = Args(model="test-model", report_dir=str(tmp_path))
 
-            await redteam("192.168.1.100", args=args)
+            await redteam("192.168.56.100", args=args)
 
             mock_orchestrator.execute_operation.assert_called_once()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,7 @@ class TestEvidenceModel:
         evidence = Evidence(
             id="test-001",
             type="ip",
-            value="192.168.1.100",
+            value="192.168.56.100",
             source="loki_query",
             timestamp=datetime.now(timezone.utc),
             pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -23,7 +23,7 @@ class TestEvidenceModel:
 
         assert evidence.id == "test-001"
         assert evidence.type == "ip"
-        assert evidence.value == "192.168.1.100"
+        assert evidence.value == "192.168.56.100"
         assert evidence.pyramid_level == PyramidLevel.IP_ADDRESSES
         assert evidence.confidence == 0.5  # default
         assert evidence.validated is False  # default
@@ -82,7 +82,7 @@ class TestEvidenceModel:
         evidence = Evidence(
             id="test-004",
             type="ip",
-            value="10.0.0.1",
+            value="192.168.56.1",
             source="firewall",
             timestamp=None,
             pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -260,9 +260,9 @@ class TestRedTeamModels:
         """Test Target model."""
         from ares.core.models import Target
 
-        target = Target(ip="10.0.0.50", hostname="dc01", domain="corp.local")
+        target = Target(ip="192.168.56.50", hostname="dc01", domain="corp.local")
 
-        assert target.ip == "10.0.0.50"
+        assert target.ip == "192.168.56.50"
         assert target.hostname == "dc01"
         assert target.domain == "corp.local"
 
@@ -271,14 +271,14 @@ class TestRedTeamModels:
         from ares.core.models import Host
 
         host = Host(
-            ip="10.0.0.100",
+            ip="192.168.56.100",
             hostname="web01",
             os="Windows Server 2019",
             roles=["web", "app"],
             services=["http", "https", "rdp"],
         )
 
-        assert host.ip == "10.0.0.100"
+        assert host.ip == "192.168.56.100"
         assert host.roles == ["web", "app"]
         assert host.services == ["http", "https", "rdp"]
 
@@ -341,7 +341,7 @@ class TestParsingUtilities:
         """Test that models can be serialized to XML."""
         from ares.core.models import Target
 
-        target = Target(ip="192.168.1.1", hostname="test-host")
+        target = Target(ip="192.168.56.1", hostname="test-host")
         xml = target.to_xml()
 
         # Verify XML structure exists (pydantic-xml may use attributes for simple models)
@@ -374,7 +374,7 @@ class TestModelValidation:
             Evidence(
                 id="test",
                 type="ip",
-                value="192.168.1.1",
+                value="192.168.56.1",
                 source="test",
                 timestamp=None,
                 pyramid_level="not-an-int",  # should be PyramidLevel
@@ -433,7 +433,7 @@ class TestInvestigationStateHelpers:
         evidence1 = Evidence(
             id="ev-001",
             type="ip",
-            value="192.168.1.1",
+            value="192.168.56.1",
             source="test",
             timestamp=None,
             pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -463,7 +463,7 @@ class TestInvestigationStateHelpers:
         evidence = Evidence(
             id="ev-001",
             type="ip",
-            value="192.168.1.1",
+            value="192.168.56.1",
             source="test",
             timestamp=None,
             pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -488,7 +488,7 @@ class TestInvestigationStateHelpers:
         evidence1 = Evidence(
             id="ev-001",
             type="ip",
-            value="192.168.1.1",
+            value="192.168.56.1",
             source="network logs",
             timestamp=None,
             pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -621,7 +621,7 @@ class TestRedTeamStateHelpers:
 
         state = RedTeamState(
             operation_id="test-op",
-            target=Target(ip="192.168.1.1"),
+            target=Target(ip="192.168.56.1"),
         )
 
         key = state.get_credential_key("Admin", "P@ssword123", "DOMAIN")
@@ -633,7 +633,7 @@ class TestRedTeamStateHelpers:
 
         state = RedTeamState(
             operation_id="test-op",
-            target=Target(ip="192.168.1.1"),
+            target=Target(ip="192.168.56.1"),
         )
 
         key = state.get_credential_key("user", "pass")
@@ -645,7 +645,7 @@ class TestRedTeamStateHelpers:
 
         state = RedTeamState(
             operation_id="test-op",
-            target=Target(ip="192.168.1.1"),
+            target=Target(ip="192.168.56.1"),
             credentials=[
                 Credential(
                     username="admin",

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -26,7 +26,7 @@ def red_team_state() -> RedTeamState:
     """Create a basic red team state for testing."""
     return RedTeamState(
         operation_id="op-test-001",
-        target=Target(ip="192.168.1.100", hostname="dc01", domain="test.local"),
+        target=Target(ip="192.168.56.100", hostname="dc01", domain="test.local"),
         started_at=datetime.now(timezone.utc),
         stage=InvestigationStage.TRIAGE,
         hosts=[],
@@ -88,6 +88,38 @@ class TestNetworkEnumerationTools:
         tools.set_state(red_team_state)
         assert tools.state == red_team_state
 
+    def test_extract_users_from_netexec_users_backslash_format(self):
+        """Test parsing netexec --users output with backslash usernames."""
+        from ares.tools.red.network import NetworkEnumerationTools
+
+        tools = NetworkEnumerationTools()
+        outputs = [
+            (
+                "netexec smb --users",
+                "SMB 192.168.56.1 445 DC [*] ACME\\jdoe (SidTypeUser)\n",
+            )
+        ]
+
+        users = tools._extract_users_from_outputs(outputs)
+
+        assert "jdoe" in users
+
+    def test_extract_users_from_netexec_rid_brute_backslash_format(self):
+        """Test parsing netexec --rid-brute output with backslash usernames."""
+        from ares.tools.red.network import NetworkEnumerationTools
+
+        tools = NetworkEnumerationTools()
+        outputs = [
+            (
+                "netexec smb --rid-brute",
+                "SMB 192.168.56.1 445 DC ACME\\svc_account (SidTypeUser)\n",
+            )
+        ]
+
+        users = tools._extract_users_from_outputs(outputs)
+
+        assert "svc_account" in users
+
     def test_nmap_scan_success(self, red_team_state: RedTeamState):
         """Test successful nmap scan."""
         from ares.tools.red.network import NetworkEnumerationTools
@@ -101,11 +133,11 @@ class TestNetworkEnumerationTools:
                 stderr="",
                 return_code=0,
             )
-            result = tools.nmap_scan("192.168.1.100")
+            result = tools.nmap_scan("192.168.56.100")
 
         assert "PORT" in result
         assert "22/tcp" in result
-        assert "192.168.1.100" in red_team_state.queried_hosts
+        assert "192.168.56.100" in red_team_state.queried_hosts
 
     def test_nmap_scan_failure(self, red_team_state: RedTeamState):
         """Test nmap scan failure."""
@@ -118,7 +150,7 @@ class TestNetworkEnumerationTools:
             mock_run.return_value = MockRunResult(
                 stdout="", stderr="Host unreachable", return_code=1
             )
-            result = tools.nmap_scan("192.168.1.100")
+            result = tools.nmap_scan("192.168.56.100")
 
         assert "unreachable" in result.lower() or "failed" in result.lower()
 
@@ -131,7 +163,7 @@ class TestNetworkEnumerationTools:
 
         with patch("ares.tools.red.network.run_remote") as mock_run:
             mock_run.side_effect = Exception("Connection error")
-            result = tools.nmap_scan("192.168.1.100")
+            result = tools.nmap_scan("192.168.56.100")
 
         assert "failed" in result.lower()
 
@@ -144,11 +176,11 @@ class TestNetworkEnumerationTools:
 
         with patch("ares.tools.red.network.run_remote") as mock_run:
             mock_run.return_value = MockRunResult(stdout="Scan complete", return_code=0)
-            tools.nmap_scan("192.168.1.100 192.168.1.101")
+            tools.nmap_scan("192.168.56.100 192.168.56.101")
 
         # Both hosts should be tracked
-        assert "192.168.1.100" in red_team_state.queried_hosts
-        assert "192.168.1.101" in red_team_state.queried_hosts
+        assert "192.168.56.100" in red_team_state.queried_hosts
+        assert "192.168.56.101" in red_team_state.queried_hosts
 
     def test_enumerate_users_success(self, red_team_state: RedTeamState):
         """Test successful user enumeration."""
@@ -162,7 +194,7 @@ class TestNetworkEnumerationTools:
                 stdout="Administrator\nuser1\nuser2", return_code=0
             )
             result = tools.enumerate_users(
-                target="192.168.1.100",
+                target="192.168.56.100",
                 username="admin",
                 password="pass",  # pragma: allowlist secret
                 domain="TEST",
@@ -171,25 +203,64 @@ class TestNetworkEnumerationTools:
         assert "Administrator" in result
 
     def test_enumerate_users_null_session(self, red_team_state: RedTeamState):
-        """Test user enumeration with null session."""
+        """Test user enumeration with null session using GOAD-like output."""
         from ares.tools.red.network import NetworkEnumerationTools
 
         tools = NetworkEnumerationTools()
         tools.set_state(red_team_state)
 
+        netexec_users = (
+            "SMB                      192.168.56.9        445    HQ-DC            "
+            "[*] Windows 10 / Server 2019 Build 17763 x64 (name:HQ-DC) "
+            "(domain:marketing.bigco.com) (signing:True) (SMBv1:None) (Null Auth:True)\n"
+        )
+        lsaquery_output = (
+            "Domain Name: MARKETING\nDomain Sid: S-1-5-21-1111111111-2222222222-3333333333\n"
+        )
+        access_denied = "result was NT_STATUS_ACCESS_DENIED\n"
+        nmap_445 = (
+            "Starting Nmap 7.98 ( https://nmap.org ) at 2026-01-20 17:43 +0000\n"
+            "Nmap scan report for ip-10-0-9-9.us-west-2.compute.internal (192.168.56.9)\n"
+            "Host is up.\n\n"
+            "PORT    STATE    SERVICE\n"
+            "445/tcp filtered microsoft-ds\n\n"
+            "Nmap done: 1 IP address (1 host up) scanned in 2.14 seconds\n"
+        )
+        rid_brute = (
+            "SMB                      192.168.56.9        445    HQ-DC            "
+            "[*] Windows 10 / Server 2019 Build 17763 x64 (name:HQ-DC) "
+            "(domain:marketing.bigco.com) (signing:True) (SMBv1:None) (Null Auth:True)\n"
+            "SMB                      192.168.56.9        445    HQ-DC            "
+            "[+] marketing.bigco.com\\:\n"
+            "SMB                      192.168.56.9        445    HQ-DC            "
+            "[-] Error connecting: LSAD SessionError: code: 0xc0000022 - "
+            "STATUS_ACCESS_DENIED - {Access Denied} A process has requested access "
+            "to an object but has not been granted those access rights.\n"
+        )
+        kerb_noauth = (
+            "Impacket v0.13.0.dev0+20251022.125034.d843881f - Copyright Fortra, LLC "
+            "and its affiliated companies\n\n"
+            "[-] User admin doesn't have UF_DONT_REQUIRE_PREAUTH set\n"
+        )
+
         with patch("ares.tools.red.network.run_remote") as mock_run:
             mock_run.side_effect = [
-                MockRunResult(
-                    stdout="SMB 192.168.1.100 445 HOST [+] test.local\\:\n", return_code=0
-                ),
-                MockRunResult(stdout="user:[Administrator] rid:[0x1f4]\n", return_code=0),
-                MockRunResult(stdout="", return_code=0),
+                MockRunResult(stdout=netexec_users, return_code=0),
+                MockRunResult(stdout=lsaquery_output, return_code=0),
+                MockRunResult(stdout=access_denied, return_code=1),
+                MockRunResult(stdout=access_denied, return_code=1),
+                MockRunResult(stdout=access_denied, return_code=1),
+                MockRunResult(stdout=nmap_445, return_code=0),
+                MockRunResult(stdout=nmap_445, return_code=0),
+                MockRunResult(stdout=rid_brute, return_code=0),
+                MockRunResult(stdout=kerb_noauth, return_code=0),
             ]
-            result = tools.enumerate_users(target="192.168.1.100", username="", password="")
+            result = tools.enumerate_users(target="192.168.56.100", username="", password="")
 
-        # Should work without credentials
-        assert "Administrator" in result
-        assert mock_run.call_count == 3
+        assert "SMB user enumeration did not return users" in result
+        assert "445 filtered" in result
+        assert "access denied" in result.lower()
+        assert mock_run.call_count == 10
 
     def test_enumerate_users_exception(self, red_team_state: RedTeamState):
         """Test user enumeration handles exceptions."""
@@ -201,7 +272,7 @@ class TestNetworkEnumerationTools:
         with patch("ares.tools.red.network.run_remote") as mock_run:
             mock_run.side_effect = Exception("Auth failed")
             result = tools.enumerate_users(
-                target="192.168.1.100",
+                target="192.168.56.100",
                 username="user",
                 password="wrong",  # pragma: allowlist secret
             )
@@ -220,7 +291,7 @@ class TestNetworkEnumerationTools:
                 stdout="ADMIN$ READ,WRITE\nC$ READ\nSHARE1 READ", return_code=0
             )
             result = tools.enumerate_shares(
-                target="192.168.1.100",
+                target="192.168.56.100",
                 domain="TEST",
                 username="admin",
                 password="pass",  # pragma: allowlist secret
@@ -238,7 +309,7 @@ class TestNetworkEnumerationTools:
         with patch("ares.tools.red.network.run_remote") as mock_run:
             mock_run.side_effect = Exception("Connection refused")
             result = tools.enumerate_shares(
-                target="192.168.1.100",
+                target="192.168.56.100",
                 username="user",
                 password="pass",  # pragma: allowlist secret
             )
@@ -264,6 +335,35 @@ class TestCredentialHarvestingTools:
         tools.set_state(red_team_state)
         assert tools.state == red_team_state
 
+    def test_kerberos_user_enum_noauth_goad(self, red_team_state: RedTeamState):
+        """Test Kerberos no-auth user enumeration using GOAD-like output."""
+        from ares.tools.red.network import CredentialHarvestingTools
+
+        tools = CredentialHarvestingTools()
+        tools.set_state(red_team_state)
+
+        getnpusers_output = (
+            "Impacket v0.13.0.dev0+20251022.125034.d843881f - Copyright Fortra, LLC "
+            "and its affiliated companies\n\n"
+            "[-] User admin doesn't have UF_DONT_REQUIRE_PREAUTH set\n"
+            "[-] User jane.doe doesn't have UF_DONT_REQUIRE_PREAUTH set\n"
+            "[-] User bob.smith doesn't have UF_DONT_REQUIRE_PREAUTH set\n"
+        )
+
+        with patch("ares.tools.red.network.run_remote") as mock_run:
+            mock_run.return_value = MockRunResult(stdout=getnpusers_output, return_code=0)
+            result = tools.kerberos_user_enum_noauth(
+                domain="marketing.bigco.com",
+                dc_ip="192.168.56.9",
+                users_file="",
+            )
+
+        assert "✓ Valid principals" in result
+        assert "admin" in result
+        assert "jane.doe" in result
+        assert "bob.smith" in result
+        assert any(user.username == "admin" for user in red_team_state.users)
+
     def test_check_smb_connectivity_success(self, red_team_state: RedTeamState):
         """Test SMB connectivity check success."""
         from ares.tools.red.network import CredentialHarvestingTools
@@ -273,7 +373,7 @@ class TestCredentialHarvestingTools:
 
         with patch("ares.tools.red.network.run_remote") as mock_run:
             mock_run.return_value = MockRunResult(stdout="open", return_code=0)
-            success, _msg = tools._check_smb_connectivity("192.168.1.100")
+            success, _msg = tools._check_smb_connectivity("192.168.56.100")
 
         assert success is True
 
@@ -286,7 +386,7 @@ class TestCredentialHarvestingTools:
 
         with patch("ares.tools.red.network.run_remote") as mock_run:
             mock_run.return_value = MockRunResult(stdout="closed", return_code=1)
-            success, _msg = tools._check_smb_connectivity("192.168.1.100")
+            success, _msg = tools._check_smb_connectivity("192.168.56.100")
 
         assert success is False
 
@@ -422,6 +522,17 @@ class TestRedTeamReportingTools:
         tools = RedTeamReportingTools()
         tools.set_state(red_team_state)
         assert tools.state == red_team_state
+
+    def test_record_finding_requires_data_payload(self, red_team_state: RedTeamState):
+        """Test record_finding returns error when data payload is missing."""
+        from ares.tools.red.network import RedTeamReportingTools
+
+        tools = RedTeamReportingTools()
+        tools.set_state(red_team_state)
+
+        result = tools.record_finding("credential_reuse", None)
+
+        assert "requires a data payload" in result.lower()
 
 
 class TestCoercionTools:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,5 +1,11 @@
 """Tests for orchestrator module."""
 
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from ares.core.orchestrator import run_multi_agent_operation
@@ -14,5 +20,84 @@ async def test_run_multi_agent_operation_requires_model(monkeypatch):
         await run_multi_agent_operation(
             operation_id="op-1",
             target_domain="example.com",
-            target_ips=["10.0.0.1"],
+            target_ips=["192.168.56.1"],
         )
+
+
+@pytest.mark.asyncio
+async def test_run_multi_agent_operation_skips_wait_when_completed(monkeypatch):
+    from ares.core import orchestrator as orch
+
+    shared_state = SimpleNamespace(
+        completed=False,
+        has_domain_admin=False,
+        domain_admin_path=None,
+        has_golden_ticket=False,
+        all_credentials=[],
+        all_hashes=[],
+        all_hosts=[],
+        discovered_vulnerabilities=[],
+        exploited_vulnerabilities=[],
+        completed_tasks=[],
+    )
+
+    dispatcher = SimpleNamespace(shared_state=shared_state)
+    dispatcher.start = AsyncMock()
+    dispatcher.recover_state = AsyncMock(return_value=None)
+    dispatcher.register = AsyncMock()
+    dispatcher.stop = AsyncMock()
+
+    task_queue = SimpleNamespace()
+    task_queue.connect = AsyncMock()
+    task_queue.acquire_operation_lock = AsyncMock(return_value=True)
+    task_queue.release_operation_lock = AsyncMock()
+    task_queue.disconnect = AsyncMock()
+
+    recovery = SimpleNamespace()
+    recovery.start = AsyncMock()
+    recovery.start_periodic_checkpoint = AsyncMock()
+
+    class DummyAgent:
+        async def run(self, _prompt):
+            dispatcher.shared_state.completed = True
+            return SimpleNamespace(stop_reason="completed")
+
+    monkeypatch.setattr(orch, "RedTeamDispatcher", lambda **_kwargs: dispatcher)
+    monkeypatch.setattr(orch, "RedisTaskQueue", lambda *_args, **_kwargs: task_queue)
+    monkeypatch.setattr(orch, "OperationRecoveryManager", lambda **_kwargs: recovery)
+    monkeypatch.setattr(orch, "get_redis_url", lambda: "redis://")
+    monkeypatch.setattr(orch, "get_namespace", lambda: "default")
+    monkeypatch.setattr(orch, "_load_or_initialize_state", AsyncMock())
+    monkeypatch.setattr(orch, "_create_agent_ensemble", AsyncMock(return_value=[]))
+    monkeypatch.setattr(orch, "_register_agents", AsyncMock())
+    monkeypatch.setattr(orch, "_ensure_required_workers", AsyncMock())
+    monkeypatch.setattr(orch, "_prime_operation", AsyncMock())
+    monkeypatch.setattr(orch, "_create_orchestrator_agent", AsyncMock(return_value=DummyAgent()))
+    monkeypatch.setattr(orch, "_build_orchestrator_prompt", lambda **_kwargs: "prompt")
+    monkeypatch.setattr(orch, "_log_orchestrator_result", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        orch, "_generate_multi_agent_report", lambda *_args, **_kwargs: (None, None)
+    )
+    monkeypatch.setattr(orch, "_run_mandatory_user_enum", lambda *_args, **_kwargs: None)
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(orch, "exploitation_workflow", _noop)
+    monkeypatch.setattr(orch, "_monitor_agent_health", _noop)
+    monkeypatch.setattr(orch, "_extend_operation_lock", _noop)
+
+    wait_mock = AsyncMock()
+    monkeypatch.setattr(orch, "_wait_for_completion", wait_mock)
+
+    monkeypatch.setattr(orch.dn, "run", lambda **_kwargs: nullcontext())
+    monkeypatch.setattr(orch.dn, "log_params", MagicMock())
+
+    await run_multi_agent_operation(
+        operation_id="op-2",
+        target_domain="example.com",
+        target_ips=["192.168.56.2"],
+        model="test-model",
+    )
+
+    wait_mock.assert_not_awaited()

--- a/tests/test_orchestrator_client.py
+++ b/tests/test_orchestrator_client.py
@@ -31,7 +31,7 @@ async def test_submit_operation_uses_env_model_and_env_vars(monkeypatch):
         result = await submit_operation(
             operation_id="op-1",
             target_domain="example.com",
-            target_ips=["10.0.0.1"],
+            target_ips=["192.168.56.1"],
             model=None,
             env_vars={"OPENAI_API_KEY": "test-key"},  # pragma: allowlist secret
         )
@@ -53,6 +53,6 @@ async def test_submit_operation_raises_when_model_missing(monkeypatch):
         await submit_operation(
             operation_id="op-2",
             target_domain="example.com",
-            target_ips=["10.0.0.2"],
+            target_ips=["192.168.56.2"],
             model=None,
         )

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -79,9 +79,9 @@ async def test_recover_orphaned_operation_runs_and_publishes_status():
 
     state = SharedRedTeamState(
         operation_id="op-123",
-        target=Target(ip="10.0.0.1", domain="example.com"),
+        target=Target(ip="192.168.56.1", domain="example.com"),
     )
-    state.all_hosts.append(Host(ip="10.0.0.1", hostname="dc01"))
+    state.all_hosts.append(Host(ip="192.168.56.1", hostname="dc01"))
     state.all_credentials.append(
         Credential(
             username="admin",
@@ -110,7 +110,7 @@ async def test_recover_orphaned_operation_runs_and_publishes_status():
     mock_run.assert_awaited_once()
     _, kwargs = mock_run.call_args
     assert kwargs["target_domain"] == "example.com"
-    assert kwargs["target_ips"] == ["10.0.0.1"]
+    assert kwargs["target_ips"] == ["192.168.56.1"]
     assert kwargs["resume_from_checkpoint"] is True
     assert kwargs["initial_credential"].username == "admin"
 
@@ -159,7 +159,7 @@ async def test_process_operation_request_sets_env_vars():
     request_data = {
         "operation_id": "op-env",
         "target_domain": "example.com",
-        "target_ips": ["10.0.0.1"],
+        "target_ips": ["192.168.56.1"],
         "model": "test-model",
         "env_vars": {"OPENAI_API_KEY": "test-key", "EMPTY": ""},  # pragma: allowlist secret
     }
@@ -187,7 +187,7 @@ async def test_process_operation_request_missing_model_publishes_failed():
     request_data = {
         "operation_id": "op-missing-model",
         "target_domain": "example.com",
-        "target_ips": ["10.0.0.2"],
+        "target_ips": ["192.168.56.2"],
     }
 
     with (

--- a/tests/test_orchestrator_tools.py
+++ b/tests/test_orchestrator_tools.py
@@ -1,11 +1,11 @@
 """Tests for orchestrator tools module."""
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ares.core.models import SharedRedTeamState, Target, TaskInfo, TaskStatus
+from ares.core.models import Credential, SharedRedTeamState, Target, TaskInfo, TaskStatus
 from ares.tools.red.orchestrator import OrchestratorTools
 
 
@@ -14,6 +14,7 @@ def mock_dispatcher():
     """Create a mock dispatcher."""
     dispatcher = MagicMock()
     dispatcher.get_agent_status = MagicMock(return_value={})
+    dispatcher.publish_credential = AsyncMock(return_value=True)
     return dispatcher
 
 
@@ -22,7 +23,7 @@ def shared_state():
     """Create a shared state for testing."""
     return SharedRedTeamState(
         operation_id="test-op",
-        target=Target(ip="192.168.1.100", hostname="dc01"),
+        target=Target(ip="192.168.56.100", hostname="dc01"),
     )
 
 
@@ -122,6 +123,7 @@ class TestCleanupOrphanedTasks:
             created_at=now - timedelta(minutes=10),
             params={},
         )
+
         shared_state.pending_tasks["task_old_2"] = TaskInfo(
             task_id="task_old_2",
             task_type="lateral",
@@ -277,3 +279,91 @@ class TestCleanupOrphanedTasks:
         # Should include task type in output
         assert "crack" in result
         assert "task_001" in result
+
+
+class TestCredentialHandling:
+    """Tests for credential guardrails and reporting."""
+
+    def test_get_all_credentials_filters_placeholder_users(self, orchestrator_tools, shared_state):
+        """Ensure placeholder usernames are skipped in output."""
+        shared_state.all_credentials.extend(
+            [
+                Credential(
+                    username="(none)",
+                    password="hash123",  # pragma: allowlist secret
+                    domain="example.local",
+                    source="orchestrator:note",
+                ),
+                Credential(
+                    username="user1",
+                    password="password1",  # pragma: allowlist secret
+                    domain="example.local",
+                    source="username_as_password",
+                ),
+            ]
+        )
+
+        output = orchestrator_tools.get_all_credentials()
+        assert "example.local\\user1" in output
+        assert "example.local\\(none)" not in output
+
+    def test_get_all_credentials_only_invalid_returns_empty(self, orchestrator_tools, shared_state):
+        """If only invalid creds exist, return the empty message."""
+        shared_state.all_credentials.append(
+            Credential(
+                username="none",
+                password="hash123",  # pragma: allowlist secret
+                domain="example.local",
+                source="orchestrator:note",
+            )
+        )
+
+        output = orchestrator_tools.get_all_credentials()
+        assert output == "No credentials discovered yet"
+
+    @pytest.mark.asyncio
+    async def test_broadcast_credential_rejects_placeholder_username(self, orchestrator_tools):
+        """Reject placeholder usernames and avoid publishing."""
+        result = await orchestrator_tools.broadcast_credential(
+            username="(none)",
+            password="hash123",  # pragma: allowlist secret
+            domain="example.local",
+        )
+
+        assert "Invalid username" in result
+        orchestrator_tools.dispatcher.publish_credential.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_credential_rejects_missing_secret(self, orchestrator_tools):
+        """Reject broadcast with no password/hash."""
+        result = await orchestrator_tools.broadcast_credential(
+            username="user1",
+            domain="example.local",
+        )
+
+        assert "Missing password/hash" in result
+        orchestrator_tools.dispatcher.publish_credential.assert_not_awaited()
+
+    def test_get_all_credentials_hides_no_creds_source_when_valid_exists(
+        self, orchestrator_tools, shared_state
+    ):
+        """Ensure 'no valid creds yet' source never surfaces once real creds exist."""
+        shared_state.all_credentials.extend(
+            [
+                Credential(
+                    username="(none)",
+                    password="hash123",  # pragma: allowlist secret
+                    domain="example.local",
+                    source="orchestrator:No valid creds yet; only unauthenticated enumeration performed.",
+                ),
+                Credential(
+                    username="user1",
+                    password="password1",  # pragma: allowlist secret
+                    domain="example.local",
+                    source="username_as_password",
+                ),
+            ]
+        )
+
+        output = orchestrator_tools.get_all_credentials()
+        assert "No valid creds yet" not in output

--- a/tests/test_query_templates.py
+++ b/tests/test_query_templates.py
@@ -180,11 +180,11 @@ class TestPortScanningDetection:
             mock_instance = mock_client.return_value.__aenter__.return_value
             mock_instance.get = AsyncMock(return_value=mock_response)
 
-            await tools.detect_port_scanning(target_ip="192.168.1.100")
+            await tools.detect_port_scanning(target_ip="192.168.56.100")
 
             call_args = mock_instance.get.call_args
             params = call_args.kwargs.get("params", call_args[1].get("params", {}))
-            assert "192.168.1.100" in params["query"]
+            assert "192.168.56.100" in params["query"]
 
 
 class TestUserEnumerationDetection:

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -50,7 +50,7 @@ def sample_state():
     """Create a sample SharedRedTeamState for testing."""
     return SharedRedTeamState(
         operation_id="test-op-001",
-        target=Target(ip="192.168.1.100", hostname="dc01"),
+        target=Target(ip="192.168.56.100", hostname="dc01"),
     )
 
 
@@ -59,7 +59,7 @@ def state_with_in_progress_tasks():
     """Create a state with in-progress tasks for recovery testing."""
     state = SharedRedTeamState(
         operation_id="test-op-002",
-        target=Target(ip="192.168.1.100", hostname="dc01"),
+        target=Target(ip="192.168.56.100", hostname="dc01"),
     )
 
     # Add some in-progress tasks
@@ -79,7 +79,7 @@ def state_with_in_progress_tasks():
         assigned_agent="lateral",
         status=TaskStatus.IN_PROGRESS,
         created_at=datetime.now(timezone.utc),
-        params={"target_host": "192.168.1.50"},
+        params={"target_host": "192.168.56.50"},
         retry_count=2,  # Already retried twice
         max_retries=3,
     )
@@ -120,7 +120,7 @@ def state_with_max_retries_exceeded():
     """Create a state with tasks that have exceeded max retries."""
     state = SharedRedTeamState(
         operation_id="test-op-003",
-        target=Target(ip="192.168.1.100", hostname="dc01"),
+        target=Target(ip="192.168.56.100", hostname="dc01"),
     )
 
     # Add a task that has already hit max retries
@@ -143,7 +143,7 @@ def state_with_retrying_tasks():
     """Create a state with tasks in RETRYING status."""
     state = SharedRedTeamState(
         operation_id="test-op-004",
-        target=Target(ip="192.168.1.100", hostname="dc01"),
+        target=Target(ip="192.168.56.100", hostname="dc01"),
     )
 
     state.pending_tasks["task_retry_1"] = TaskInfo(
@@ -177,7 +177,7 @@ def state_with_failed_tasks():
     """Create a state with permanently failed tasks."""
     state = SharedRedTeamState(
         operation_id="test-op-005",
-        target=Target(ip="192.168.1.100", hostname="dc01"),
+        target=Target(ip="192.168.56.100", hostname="dc01"),
     )
 
     state.pending_tasks["task_failed_1"] = TaskInfo(
@@ -211,7 +211,7 @@ def state_for_resume_prompt():
     """Create a comprehensive state for resume prompt testing."""
     state = SharedRedTeamState(
         operation_id="test-op-resume",
-        target=Target(ip="192.168.1.100", hostname="dc01"),
+        target=Target(ip="192.168.56.100", hostname="dc01"),
     )
 
     # Add some credentials and hosts
@@ -221,8 +221,8 @@ def state_for_resume_prompt():
         Credential(username="admin", password="pass", domain="CORP"),  # pragma: allowlist secret
     ]
     state.all_hosts = [
-        Host(ip="192.168.1.100", hostname="dc01"),
-        Host(ip="192.168.1.101", hostname="web01"),
+        Host(ip="192.168.56.100", hostname="dc01"),
+        Host(ip="192.168.56.101", hostname="web01"),
     ]
 
     # Add retrying task

--- a/tests/test_red_agents.py
+++ b/tests/test_red_agents.py
@@ -20,7 +20,7 @@ async def test_create_multi_agent_ensemble_requires_model(monkeypatch):
     with pytest.raises(ValueError, match="No model specified"):
         await create_multi_agent_ensemble(
             operation_id="op-1",
-            target_ip="10.0.0.1",
+            target_ip="192.168.56.1",
             dispatcher=dispatcher,
             roles=[AgentRole.ENUM],
         )
@@ -39,7 +39,7 @@ async def test_create_multi_agent_ensemble_uses_env_models(monkeypatch):
 
         await create_multi_agent_ensemble(
             operation_id="op-2",
-            target_ip="10.0.0.2",
+            target_ip="192.168.56.2",
             dispatcher=dispatcher,
             roles=[AgentRole.ENUM, AgentRole.CRACKER],
         )
@@ -47,3 +47,40 @@ async def test_create_multi_agent_ensemble_uses_env_models(monkeypatch):
     assert mock_create.call_count == 2
     assert mock_create.call_args_list[0].kwargs["model"] == "orch-model"
     assert mock_create.call_args_list[1].kwargs["model"] == "worker-model"
+
+
+def test_create_specialized_agent_uses_set_state_when_shared_state_missing(monkeypatch):
+    created: dict[str, MagicMock] = {}
+
+    class DummyToolset:
+        def __init__(self) -> None:
+            self.set_state = MagicMock()
+            created["instance"] = self
+
+    monkeypatch.setattr(
+        "ares.core.factories.red_agents.ROLE_TOOLSETS",
+        {AgentRole.ENUM: [DummyToolset]},
+    )
+    monkeypatch.setattr(
+        "ares.core.factories.red_agents.load_agent_instructions",
+        lambda _role: "instructions",
+    )
+    monkeypatch.setattr(
+        "ares.core.factories.red_agents.create_role_hooks",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr("ares.core.factories.red_agents.dn.Agent", MagicMock())
+
+    from ares.core.factories.red_agents import create_specialized_agent
+
+    shared_state = MagicMock()
+    dispatcher = MagicMock()
+
+    create_specialized_agent(
+        role=AgentRole.ENUM,
+        model="test-model",
+        shared_state=shared_state,
+        dispatcher=dispatcher,
+    )
+
+    created["instance"].set_state.assert_called_once_with(shared_state)

--- a/tests/test_reports_investigation.py
+++ b/tests/test_reports_investigation.py
@@ -360,7 +360,7 @@ class TestPyramidAssessment:
             Evidence(
                 id="ip-1",
                 type="ip",
-                value="192.168.1.1",
+                value="192.168.56.1",
                 source="logs",
                 timestamp=datetime.now(timezone.utc),
                 pyramid_level=PyramidLevel.IP_ADDRESSES,
@@ -368,7 +368,7 @@ class TestPyramidAssessment:
             Evidence(
                 id="ip-2",
                 type="ip",
-                value="192.168.1.2",
+                value="192.168.56.2",
                 source="logs",
                 timestamp=datetime.now(timezone.utc),
                 pyramid_level=PyramidLevel.IP_ADDRESSES,

--- a/tests/test_reports_redteam.py
+++ b/tests/test_reports_redteam.py
@@ -327,7 +327,7 @@ class TestEdgeCases:
     ):
         """Test report with special characters in target."""
         red_team_state.target = Target(
-            ip="192.168.1.100",
+            ip="192.168.56.100",
             hostname="server-01.domain.local",
             domain="domain.local",
             os="Windows Server 2019 <Special>",

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -74,7 +74,7 @@ class TestTaskMessage:
             task_type="lateral",
             source_agent="orchestrator",
             target_agent="lateral",
-            payload={"target_host": "192.168.1.10"},
+            payload={"target_host": "192.168.56.10"},
         )
 
         json_str = msg.model_dump_json()
@@ -82,7 +82,7 @@ class TestTaskMessage:
 
         assert parsed["task_id"] == "test_123"
         assert parsed["task_type"] == "lateral"
-        assert parsed["payload"]["target_host"] == "192.168.1.10"
+        assert parsed["payload"]["target_host"] == "192.168.56.10"
 
     def test_task_message_deserialization(self):
         """Test TaskMessage JSON deserialization."""
@@ -668,7 +668,7 @@ class TestRedisTaskQueueRequeue:
         returned_id = await task_queue.requeue_task(
             task_type="lateral",
             target_role="lateral",
-            payload={"target_host": "192.168.1.10"},
+            payload={"target_host": "192.168.56.10"},
             task_id=original_id,
             retry_count=2,
         )
@@ -706,7 +706,7 @@ class TestRedisTaskQueueRequeue:
         await task_queue.requeue_task(
             task_type="enum",
             target_role="enum",
-            payload={"target": "192.168.1.0/24"},
+            payload={"target": "192.168.56.0/24"},
             task_id="enum_retry_001",
             retry_count=1,
         )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -137,6 +137,14 @@ class TestAgentTemplates:
 
         assert "TestAlert" in result
 
+    def test_redteam_enum_template_includes_vulnerability_queue(self) -> None:
+        """Test redteam enum template renders with vulnerability queue guidance."""
+        loader = get_template_loader()
+        result = loader.render("redteam/agents/enum.md.jinja")
+
+        assert "queue_vulnerability_for_exploitation" in result
+        assert "get_vulnerability_queue_status" in result
+
 
 class TestEngineTemplates:
     """Test engine template rendering."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -227,6 +227,64 @@ class TestRunWorkerModelResolution:
         assert result is None
 
 
+class TestRunWorkerCallbacks:
+    """Tests for role-specific callback tools in run_worker."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("role", "callback_attr"),
+        [
+            (AgentRole.CRACKER, "CrackerCallbackTools"),
+            (AgentRole.LATERAL, "LateralCallbackTools"),
+        ],
+    )
+    async def test_run_worker_adds_role_callback_tools(self, monkeypatch, role, callback_attr):
+        from ares.core import worker as worker_module
+
+        created: dict[str, MagicMock] = {}
+
+        class DummyCallback:
+            def __init__(self) -> None:
+                self.set_dispatcher = MagicMock()
+                created["instance"] = self
+
+        monkeypatch.setenv("ARES_MODEL", "test-model")
+
+        shared_state = MagicMock()
+        dispatcher = MagicMock(shared_state=shared_state)
+        dispatcher.start = AsyncMock()
+        dispatcher.recover_state = AsyncMock(return_value=None)
+        dispatcher.register = AsyncMock()
+        dispatcher.stop = AsyncMock()
+
+        agent_info = MagicMock()
+        agent_info.name = "agent-name"
+
+        monkeypatch.setattr(worker_module, "RedTeamDispatcher", lambda **_kwargs: dispatcher)
+        monkeypatch.setattr(
+            worker_module, "create_agent_info", lambda *_args, **_kwargs: agent_info
+        )
+        monkeypatch.setattr(worker_module, callback_attr, DummyCallback)
+
+        create_agent_mock = MagicMock()
+        monkeypatch.setattr(worker_module, "create_specialized_agent", create_agent_mock)
+
+        worker_instance = MagicMock()
+        worker_instance.start = AsyncMock()
+        monkeypatch.setattr(worker_module, "WorkerAgent", MagicMock(return_value=worker_instance))
+
+        await worker_module.run_worker(
+            role=role,
+            operation_id="op-1",
+            discover_operation=False,
+            use_redis_queue=False,
+        )
+
+        created["instance"].set_dispatcher.assert_called_once_with(dispatcher)
+        _, kwargs = create_agent_mock.call_args
+        assert created["instance"] in kwargs["additional_tools"]
+
+
 class TestDiscoverActiveOperationIndefiniteWait:
     """Tests for indefinite wait behavior when max_wait is None."""
 


### PR DESCRIPTION
**Key Changes:**

- Enhanced multi-agent orchestrator for robust completion, reporting, and guardrails
- Overhauled credential and hash extraction, deduplication, and propagation logic
- Upgraded user enumeration and reporting with improved parsing and feedback
- Standardized IP addresses in tests for consistent CI and local runs

**Added:**

- `_persist_report` utility in `cli_ops.py` to auto-save operation reports locally
- `configure_litellm_env` in `litellm_env.py` to reduce LiteLLM worker noise/timeouts
- New `ares:red:multi:current` task to print current multi-agent operation ID
- Model and override persistence for operations in orchestrator service for worker discovery
- Completion tools (`complete_operation`, `announce_domain_admin`) as orchestrator stop conditions
- Role-specific callback tool injection for worker agent roles (cracker/lateral)
- Extraction of AS-REP hashes and robust error extraction for worker tasks

**Changed:**

- All production red agents now default to `"gpt-5.2"` model in configuration (with `claude-sonnet-4` commented)
- Lateral agent `max_steps` increased to 200; lateral movement timeout raised to 180s
- Major improvements to agent workflow instructions and enum agent template:
  - Explicit credential expansion logic, attack path prioritization, and vulnerability queue usage
  - Emphasis on always running secretsdump/kerberoast/asrep_roast after finding any credential
- Orchestrator completion logic:
  - Explicit state guardrails for operation finalization (avoid premature completion)
  - Automatic report generation and propagation at operation end
- Improved user enumeration and share parsing:
  - Better extraction from netexec, nmap, rpcclient outputs
  - More helpful error/status messages when enumeration fails
- Credential and hash propagation:
  - Deduplication and validation before adding credentials/hashes to state
  - Guardrails to ignore placeholder/invalid usernames in reporting and broadcast
- Taskfile/Taskfile.yaml:
  - Unified and simplified log tailing for remote and local logs
  - Region defaults standardized to `us-west-1`
  - Worker pods pinned to operation ID on multi-agent run
- Test suite:
  - All test IPs converted to `192.168.56.x` for local/CI consistency
  - New/updated tests for credential guardrails, role callback tools, orchestrator completion

**Removed:**

- All legacy local log management tasks from Taskfile (`ares:logs:list`, `ares:logs:tail`, etc.)
- Old per-role log tailing Taskfile targets in favor of unified remote:logs