### PR TITLE
fix: ensure consistent stale task timeout and handle completed_at in state loading

### DIFF
--- a/src/ares/cli_ops.py
+++ b/src/ares/cli_ops.py
@@ -1098,6 +1098,14 @@ async def _load_state_from_redis(client: Any, operation_id: str) -> Any:
         except Exception:
             pass
 
+    completed_at_str = meta.get("completed_at")
+    completed_at = None
+    if completed_at_str:
+        try:
+            completed_at = datetime.fromisoformat(completed_at_str)
+        except Exception:
+            pass
+
     # Load target from meta if present
     target = None
     target_ip = meta.get("target_ip")
@@ -1130,6 +1138,8 @@ async def _load_state_from_redis(client: Any, operation_id: str) -> Any:
     }
     if started_at is not None:
         kwargs["started_at"] = started_at
+    if completed_at is not None:
+        kwargs["completed_at"] = completed_at
     return SharedRedTeamState(**kwargs)
 
 

--- a/src/ares/core/config.py
+++ b/src/ares/core/config.py
@@ -366,7 +366,7 @@ def _build_config(data: dict[str, Any]) -> OperationConfig:
         rate_limit_backoff=operation.get("rate_limit_backoff", 30.0),
         rate_limit_threshold=operation.get("rate_limit_threshold", 3),
         # Task monitoring / resilience from operation section
-        stale_task_timeout=operation.get("stale_task_timeout", 600),
+        stale_task_timeout=operation.get("stale_task_timeout", 180),  # Match field default
         max_redis_consecutive_failures=operation.get("max_redis_consecutive_failures", 30),
         redis_retry_base_delay=operation.get("redis_retry_base_delay", 1.0),
         redis_retry_max_delay=operation.get("redis_retry_max_delay", 10.0),

--- a/src/ares/core/dispatcher/monitoring.py
+++ b/src/ares/core/dispatcher/monitoring.py
@@ -352,8 +352,8 @@ class MonitoringMixin:
         """Remove stale tasks from pending_tasks dict.
 
         This runs in the threaded consumer to ensure cleanup happens even when
-        the main event loop is blocked by LLM API timeouts. Uses the same 180s
-        timeout as the main loop since LLM API calls regularly take 60+ seconds.
+        the main event loop is blocked by LLM API timeouts. Uses the configured
+        stale_task_timeout (default 180s) since LLM API calls can take 60+ seconds.
 
         NOTE: This only updates in-memory state, not Redis. The main loop's
         _cleanup_stale_tasks handles Redis task ID cleanup when it's available.
@@ -362,7 +362,7 @@ class MonitoringMixin:
             return
 
         now = datetime.now(timezone.utc)
-        stale_timeout = 180  # Match main loop timeout - LLM calls can take 60+ seconds
+        stale_timeout = get_stale_task_timeout()  # Use config value
         stale_task_ids: list[str] = []
 
         # Count LLM tasks to determine if we're at hard cap


### PR DESCRIPTION


**Key Changes:**

- Updated stale_task_timeout default to 180s for consistency across config and monitoring
- Monitoring now uses the configured stale_task_timeout instead of a hardcoded value
- Added support for loading the completed_at field when reconstructing operation state
- Improved resilience of state rehydration with safer datetime parsing

**Added:**

- Support for loading and parsing the completed_at field in operation state
  restoration, ensuring SharedRedTeamState accurately reflects completion time

**Changed:**

- Default value for stale_task_timeout in operation config builder set to 180s to
  match the field default and ensure consistency across codebase
- Monitoring task cleanup now uses the stale_task_timeout from configuration
  (via get_stale_task_timeout) instead of a hardcoded 180s value, allowing easier
  tuning of task staleness detection

**Removed:**

- Hardcoded stale_task_timeout value in MonitoringMixin cleanup logic, replaced
  with use of configurable value for improved flexibility