### PR TITLE
feat: add detection playbook export and blue team detection guidance

### DIFF
--- a/src/ares/core/dispatcher/_dispatcher.py
+++ b/src/ares/core/dispatcher/_dispatcher.py
@@ -153,6 +153,10 @@ class RedTeamDispatcher(
         # Signal for threaded consumer to request immediate checkpoint
         self._checkpoint_requested = threading.Event()
 
+        # Thread-safe signal for credential access (asyncio.Event is not thread-safe)
+        # Threaded consumer sets this, maintenance loop transfers to asyncio.Event
+        self._credential_access_requested = threading.Event()
+
         # Pending deferred tasks from threaded consumer (processed by main loop)
         # This avoids event loop mismatch when enqueuing from non-main thread
         self._pending_deferred_tasks: list[tuple[str, str, dict, str, int]] = []

--- a/src/ares/core/dispatcher/monitoring.py
+++ b/src/ares/core/dispatcher/monitoring.py
@@ -808,6 +808,13 @@ class MonitoringMixin:
                     await self._checkpoint()
                     last_checkpoint = now
 
+                # Transfer thread-safe credential access signal to asyncio.Event
+                # This wakes up _auto_credential_access immediately instead of waiting 60s
+                if self._credential_access_requested.is_set():
+                    self._credential_access_requested.clear()
+                    self.signal_credential_access()
+                    logger.debug("Credential access signal transferred from threaded consumer")
+
                 # Process pending deferred tasks from threaded consumer
                 # These were queued because the threaded consumer can't access Redis directly
                 await self._process_pending_deferred_tasks()

--- a/src/ares/core/dispatcher/publishing.py
+++ b/src/ares/core/dispatcher/publishing.py
@@ -55,9 +55,12 @@ class PublishingMixin:
         added = self.shared_state.add_credential(credential, source_agent)
 
         if added:
-            # Only signal credential access from main thread - asyncio.Event is not thread-safe
+            # Signal credential access - use thread-safe event from non-main thread
             if threading.current_thread() is threading.main_thread():
                 self.signal_credential_access()
+            else:
+                # Thread-safe signal - maintenance loop will transfer to asyncio.Event
+                self._credential_access_requested.set()
             # Add timeline event for credential discovery
             import uuid
             from datetime import datetime, timezone
@@ -194,9 +197,12 @@ class PublishingMixin:
         added = self.shared_state.add_hash(hash_obj, source_agent)
 
         if added:
-            # Only signal credential access from main thread - asyncio.Event is not thread-safe
+            # Signal credential access - use thread-safe event from non-main thread
             if threading.current_thread() is threading.main_thread():
                 self.signal_credential_access()
+            else:
+                # Thread-safe signal - maintenance loop will transfer to asyncio.Event
+                self._credential_access_requested.set()
             # Add timeline event for hash discovery
             import uuid
             from datetime import datetime, timezone

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -2088,9 +2088,12 @@ class SharedRedTeamState:
                     )
                     self.add_credential(cracked_cred, source_agent)
                     # Signal credential access if dispatcher available
-                    # Only call from main thread - asyncio.Event is not thread-safe
-                    if self._dispatcher and threading.current_thread() is threading.main_thread():
-                        self._dispatcher.signal_credential_access()
+                    if self._dispatcher:
+                        if threading.current_thread() is threading.main_thread():
+                            self._dispatcher.signal_credential_access()
+                        elif hasattr(self._dispatcher, "_credential_access_requested"):
+                            # Thread-safe signal - maintenance loop will transfer to asyncio.Event
+                            self._dispatcher._credential_access_requested.set()
                     # Request checkpoint from dispatcher's maintenance loop
                     # _checkpoint_requested is a threading.Event, safe from any thread
                     if self._dispatcher and hasattr(self._dispatcher, "_checkpoint_requested"):


### PR DESCRIPTION
**Key Changes:**

- Implemented thread-safe signaling for credential access across all dispatcher
  components
- Maintenance loop now reliably transfers thread-safe events to asyncio.Event
- Publishing and state logic updated to use thread-safe signals from non-main
  threads

**Added:**

- Thread-safe credential access event (`_credential_access_requested`) to
  dispatcher for cross-thread signaling

**Changed:**

- Publishing mixin logic to use thread-safe event when signaling credential or
  hash addition from non-main threads, ensuring correct coordination with the
  main thread
- Monitoring mixin's maintenance loop to detect and transfer thread-safe
  credential access requests to the asyncio event, enabling immediate wake-up
  without delay
- Shared state logic to check for and set the thread-safe credential access
  event when called from non-main threads and dispatcher is available

**Reasoning:**

- Addresses issues with non-thread-safe usage of `asyncio.Event` in multi-threaded
  contexts, ensuring reliable and safe signaling of credential events regardless
  of calling thread
- Prevents missed or delayed credential access processing when credentials or
  hashes are added from worker threads, improving system responsiveness