### PR TITLE
feat: add user-centric credential and attack chain reporting

### DIFF
--- a/src/ares/cli_ops.py
+++ b/src/ares/cli_ops.py
@@ -2157,6 +2157,216 @@ async def inject_vulnerability(
         sys.exit(1)
 
 
+@app.command(name="loot-users")
+async def loot_users(
+    operation_id: Annotated[str | None, cyclopts.Parameter(help="Operation ID")] = None,
+    *,
+    latest: Annotated[
+        bool, cyclopts.Parameter(help="Use the latest operation (prefer running)")
+    ] = False,
+    redis_url: Annotated[str, cyclopts.Parameter(help="Redis URL (default: from config)")] = "",
+    json_output: Annotated[bool, cyclopts.Parameter(help="Output as JSON")] = False,
+    admin_only: Annotated[
+        bool, cyclopts.Parameter(help="Only show users with admin credentials")
+    ] = False,
+    show_chains: Annotated[
+        bool, cyclopts.Parameter(help="Show attack chains for each credential/hash")
+    ] = False,
+    domain: Annotated[str, cyclopts.Parameter(help="Filter by domain (case-insensitive)")] = "",
+) -> None:
+    """Display user summaries with credentials, hashes, and attack paths.
+
+    Shows a user-centric view of discovered credentials and hashes, including
+    how each credential was obtained (attack chain) and aggregated privilege info.
+
+    Examples:
+        ares-ops loot-users op-20250128-123456
+        ares-ops loot-users --latest
+        ares-ops loot-users --latest --admin-only
+        ares-ops loot-users --latest --show-chains
+        ares-ops loot-users --latest --domain contoso.local
+    """
+    from ares.reports.user_summary import generate_user_summaries
+
+    resolved_redis_url = redis_url or get_redis_url()
+
+    # Resolve operation ID
+    if latest and not operation_id:
+        operation_id = await _resolve_latest_operation(resolved_redis_url)
+        if not operation_id:
+            logger.error("No operations found")
+            sys.exit(1)
+        logger.info(f"Using latest operation: {operation_id}")
+    elif not operation_id:
+        logger.error("Either operation_id or --latest is required")
+        sys.exit(1)
+
+    try:
+        client = await create_verified_redis_client(resolved_redis_url)
+        state = await _load_state_from_redis(client, operation_id)
+        await client.aclose()
+
+        if state is None:
+            logger.error(f"Operation {operation_id} not found")
+            sys.exit(1)
+
+        # Generate user summaries
+        summaries = generate_user_summaries(state)
+
+        # Apply filters
+        if admin_only:
+            summaries = [s for s in summaries if s.is_admin]
+
+        if domain:
+            domain_lower = domain.lower()
+            summaries = [s for s in summaries if s.domain.lower() == domain_lower]
+
+        if json_output:
+            _print_user_summaries_json(summaries, operation_id, state)
+        else:
+            _print_user_summaries(summaries, operation_id, state, show_chains=show_chains)
+
+    except Exception as e:
+        logger.error(f"Failed to generate user summaries: {e}")
+        sys.exit(1)
+
+
+def _print_user_summaries_json(
+    summaries: list,
+    operation_id: str,
+    state,
+) -> None:
+    """Print user summaries as JSON."""
+    import json as json_module
+
+    output = {
+        "operation_id": operation_id,
+        "has_domain_admin": state.has_domain_admin,
+        "domain_admin_path": state.domain_admin_path,
+        "user_count": len(summaries),
+        "users": [],
+    }
+
+    for s in summaries:
+        user_data = {
+            "username": s.username,
+            "domain": s.domain,
+            "is_admin": s.is_admin,
+            "description": s.description,
+            "discovery_sources": list(s.discovery_sources),
+            "max_attack_depth": s.max_attack_depth,
+            "credentials": [
+                {
+                    "id": c.id,
+                    "password": c.password,
+                    "source": c.source,
+                    "is_admin": c.is_admin,
+                    "attack_step": c.attack_step,
+                    "parent_id": c.parent_id,
+                }
+                for c in s.credentials
+            ],
+            "hashes": [
+                {
+                    "id": h.id,
+                    "hash_type": h.hash_type,
+                    "hash_value": h.hash_value,
+                    "cracked_password": h.cracked_password,
+                    "source": h.source,
+                    "attack_step": h.attack_step,
+                    "parent_id": h.parent_id,
+                }
+                for h in s.hashes
+            ],
+            "attack_chains": {
+                item_id: [
+                    {
+                        "step": step.step_number,
+                        "type": step.item_type,
+                        "username": step.username,
+                        "domain": step.domain,
+                        "source": step.source,
+                    }
+                    for step in chain
+                ]
+                for item_id, chain in s.attack_chains.items()
+            },
+        }
+        if s.first_discovered_at:
+            user_data["first_discovered_at"] = s.first_discovered_at.isoformat()
+        output["users"].append(user_data)
+
+    print(json_module.dumps(output, indent=2, default=str))
+
+
+def _print_user_summaries(
+    summaries: list,
+    operation_id: str,
+    state,
+    *,
+    show_chains: bool = False,
+) -> None:
+    """Print user summaries in human-readable format."""
+    from ares.reports.user_summary import format_attack_chain
+
+    print(f"Operation: {operation_id}")
+    if state.has_domain_admin:
+        print("*** DOMAIN ADMIN ACHIEVED ***")
+        if state.domain_admin_path:
+            print(f"  Path: {state.domain_admin_path}")
+    print()
+
+    admin_count = sum(1 for s in summaries if s.is_admin)
+    print(f"User Summaries ({len(summaries)} users, {admin_count} admins)")
+    print("=" * 60)
+    print()
+
+    for s in summaries:
+        # User header
+        admin_marker = " [ADMIN]" if s.is_admin else ""
+        print(f"{s.display_name}{admin_marker}")
+        if s.description:
+            print(f"  Description: {s.description}")
+
+        # Sources
+        if s.discovery_sources:
+            sources_str = ", ".join(
+                _normalize_source_label(src) for src in sorted(s.discovery_sources)
+            )
+            print(f"  Discovered via: {sources_str}")
+
+        # Attack depth
+        if s.max_attack_depth > 0:
+            print(f"  Max attack depth: {s.max_attack_depth}")
+
+        # Credentials
+        if s.credentials:
+            print(f"  Credentials ({len(s.credentials)}):")
+            for c in s.credentials:
+                admin_str = " (admin)" if c.is_admin else ""
+                source_str = f" [{_normalize_source_label(c.source)}]" if c.source else ""
+                print(f"    - {c.password}{admin_str}{source_str}")
+                if show_chains and c.id in s.attack_chains:
+                    chain = s.attack_chains[c.id]
+                    chain_str = format_attack_chain(chain, compact=True)
+                    print(f"      Chain: {chain_str}")
+
+        # Hashes
+        if s.hashes:
+            print(f"  Hashes ({len(s.hashes)}):")
+            for h in s.hashes:
+                cracked_str = f" (cracked: {h.cracked_password})" if h.cracked_password else ""
+                source_str = f" [{_normalize_source_label(h.source)}]" if h.source else ""
+                hash_display = h.hash_value[:32] + "..." if len(h.hash_value) > 32 else h.hash_value
+                print(f"    - {h.hash_type}:{hash_display}{cracked_str}{source_str}")
+                if show_chains and h.id in s.attack_chains:
+                    chain = s.attack_chains[h.id]
+                    chain_str = format_attack_chain(chain, compact=True)
+                    print(f"      Chain: {chain_str}")
+
+        print()  # Blank line between users
+
+
 def main() -> None:
     """Entry point for ares-ops CLI."""
     try:

--- a/src/ares/reports/__init__.py
+++ b/src/ares/reports/__init__.py
@@ -8,13 +8,25 @@ from ares.reports.blueteam import (
 )
 from ares.reports.investigation import MarkdownReportGenerator
 from ares.reports.redteam import RedTeamReportGenerator, generate_comprehensive_report
+from ares.reports.user_summary import (
+    AttackChainStep,
+    UserSummary,
+    format_attack_chain,
+    generate_user_summaries,
+    trace_attack_chain,
+)
 
 __all__ = [
+    "AttackChainStep",
     "BlueTeamOperation",
     "BlueTeamReportGenerator",
     "MarkdownReportGenerator",
     "RedTeamReportGenerator",
+    "UserSummary",
     "create_operation_from_investigations",
+    "format_attack_chain",
     "generate_comprehensive_report",
     "generate_operation_report",
+    "generate_user_summaries",
+    "trace_attack_chain",
 ]

--- a/src/ares/reports/user_summary.py
+++ b/src/ares/reports/user_summary.py
@@ -1,0 +1,286 @@
+"""User summary generation for consolidating credentials, hashes, and attack paths."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from ares.core.models import Credential, Hash, SharedRedTeamState
+
+
+@dataclass
+class AttackChainStep:
+    """A single step in an attack chain."""
+
+    step_number: int
+    item_type: str  # "credential" or "hash"
+    username: str
+    domain: str
+    source: str
+    item_id: str
+
+    def format(self, include_id: bool = False) -> str:
+        """Format this step for display."""
+        user_str = f"{self.domain}\\{self.username}" if self.domain else self.username
+        result = f"[{self.step_number}] {self.source} -> {user_str}"
+        if include_id:
+            result += f" ({self.item_id[:8]})"
+        return result
+
+
+@dataclass
+class UserSummary:
+    """Consolidated view of a user with all credentials, hashes, and attack paths.
+
+    Attributes:
+        username: The username.
+        domain: The domain.
+        is_admin: Whether any credential for this user is admin.
+        description: User description from LDAP (if available).
+        credentials: All credentials discovered for this user.
+        hashes: All hashes discovered for this user.
+        discovery_sources: Set of sources that discovered credentials/hashes.
+        first_discovered_at: Earliest discovery timestamp.
+        attack_chains: Attack chain for each credential/hash showing how it was obtained.
+        max_attack_depth: Maximum depth in the attack graph (longest chain).
+    """
+
+    username: str
+    domain: str
+    is_admin: bool = False
+    description: str = ""
+    credentials: list[Credential] = field(default_factory=list)
+    hashes: list[Hash] = field(default_factory=list)
+    discovery_sources: set[str] = field(default_factory=set)
+    first_discovered_at: datetime | None = None
+    attack_chains: dict[str, list[AttackChainStep]] = field(default_factory=dict)
+    max_attack_depth: int = 0
+
+    @property
+    def user_key(self) -> str:
+        """Normalized key for deduplication."""
+        return f"{self.domain.lower()}\\{self.username.lower()}"
+
+    @property
+    def display_name(self) -> str:
+        """User display string."""
+        if self.domain:
+            return f"{self.domain}\\{self.username}"
+        return self.username
+
+    def has_cleartext(self) -> bool:
+        """Check if any credential has a cleartext password."""
+        return len(self.credentials) > 0
+
+    def has_hash(self) -> bool:
+        """Check if any hash is available."""
+        return len(self.hashes) > 0
+
+
+def _build_item_index(
+    credentials: list[Credential],
+    hashes: list[Hash],
+) -> dict[str, Credential | Hash]:
+    """Build a lookup index by item ID for chain tracing."""
+    index: dict[str, Credential | Hash] = {}
+    for cred in credentials:
+        if cred.id:
+            index[cred.id] = cred
+    for h in hashes:
+        if h.id:
+            index[h.id] = h
+    return index
+
+
+def trace_attack_chain(
+    item: Credential | Hash,
+    item_index: dict[str, Credential | Hash],
+) -> list[AttackChainStep]:
+    """Trace the attack chain from initial access to this item.
+
+    Walks backward through parent_id links to construct the full path.
+
+    Args:
+        item: The credential or hash to trace from.
+        item_index: Lookup index of all credentials and hashes by ID.
+
+    Returns:
+        List of AttackChainStep from initial access (step 0) to the target item.
+    """
+    chain: list[AttackChainStep] = []
+    visited: set[str] = set()
+    current: Credential | Hash | None = item
+
+    while current is not None:
+        item_id = current.id
+        if not item_id or item_id in visited:
+            break
+        visited.add(item_id)
+
+        # Determine item type
+        item_type = "credential" if hasattr(current, "password") else "hash"
+
+        step = AttackChainStep(
+            step_number=current.attack_step,
+            item_type=item_type,
+            username=current.username,
+            domain=current.domain,
+            source=current.source or "unknown",
+            item_id=item_id,
+        )
+        chain.append(step)
+
+        # Follow parent link
+        parent_id = current.parent_id
+        current = item_index[parent_id] if parent_id and parent_id in item_index else None
+
+    # Reverse to get initial access first
+    return list(reversed(chain))
+
+
+def generate_user_summaries(state: SharedRedTeamState) -> list[UserSummary]:
+    """Generate user summaries from shared state.
+
+    Aggregates all credentials and hashes per user, traces attack chains,
+    and computes derived metrics.
+
+    Args:
+        state: The shared red team state containing all discovered items.
+
+    Returns:
+        List of UserSummary objects sorted by domain then username.
+    """
+    # Build index for chain tracing
+    item_index = _build_item_index(state.all_credentials, state.all_hashes)
+
+    # Group credentials and hashes by user key
+    creds_by_user: dict[str, list[Credential]] = defaultdict(list)
+    hashes_by_user: dict[str, list[Hash]] = defaultdict(list)
+    user_info: dict[str, dict] = {}  # user_key -> {domain, username, is_admin, description}
+
+    for cred in state.all_credentials:
+        key = f"{cred.domain.lower()}\\{cred.username.lower()}"
+        creds_by_user[key].append(cred)
+        if key not in user_info:
+            user_info[key] = {
+                "domain": cred.domain,
+                "username": cred.username,
+                "is_admin": cred.is_admin,
+                "description": "",
+            }
+        elif cred.is_admin:
+            user_info[key]["is_admin"] = True
+
+    for h in state.all_hashes:
+        key = f"{h.domain.lower()}\\{h.username.lower()}"
+        hashes_by_user[key].append(h)
+        if key not in user_info:
+            user_info[key] = {
+                "domain": h.domain,
+                "username": h.username,
+                "is_admin": False,
+                "description": "",
+            }
+
+    # Enrich with User objects if available
+    for user in state.all_users:
+        key = f"{user.domain.lower()}\\{user.username.lower()}"
+        if key in user_info:
+            if user.description:
+                user_info[key]["description"] = user.description
+            if user.is_admin:
+                user_info[key]["is_admin"] = True
+        else:
+            # User exists but no credentials/hashes - skip for now
+            # (could add option to include all users later)
+            pass
+
+    # Build summaries
+    summaries: list[UserSummary] = []
+    all_user_keys = set(creds_by_user.keys()) | set(hashes_by_user.keys())
+
+    for key in all_user_keys:
+        info = user_info.get(key, {})
+        creds = creds_by_user.get(key, [])
+        hashes = hashes_by_user.get(key, [])
+
+        # Collect discovery sources
+        sources: set[str] = set()
+        for c in creds:
+            if c.source:
+                sources.add(c.source)
+        for h in hashes:
+            if h.source:
+                sources.add(h.source)
+
+        # Find earliest discovery time
+        first_discovered: datetime | None = None
+        for h in hashes:
+            if h.discovered_at and (first_discovered is None or h.discovered_at < first_discovered):
+                first_discovered = h.discovered_at
+
+        # Trace attack chains for each credential/hash
+        attack_chains: dict[str, list[AttackChainStep]] = {}
+        max_depth = 0
+
+        for c in creds:
+            if c.id:
+                chain = trace_attack_chain(c, item_index)
+                if chain:
+                    attack_chains[c.id] = chain
+                    max_depth = max(max_depth, c.attack_step)
+
+        for h in hashes:
+            if h.id:
+                chain = trace_attack_chain(h, item_index)
+                if chain:
+                    attack_chains[h.id] = chain
+                    max_depth = max(max_depth, h.attack_step)
+
+        summary = UserSummary(
+            username=info.get("username", key.split("\\")[-1]),
+            domain=info.get("domain", key.split("\\")[0] if "\\" in key else ""),
+            is_admin=info.get("is_admin", False),
+            description=info.get("description", ""),
+            credentials=creds,
+            hashes=hashes,
+            discovery_sources=sources,
+            first_discovered_at=first_discovered,
+            attack_chains=attack_chains,
+            max_attack_depth=max_depth,
+        )
+        summaries.append(summary)
+
+    # Sort by domain, then username
+    summaries.sort(key=lambda s: (s.domain.lower(), s.username.lower()))
+
+    return summaries
+
+
+def format_attack_chain(chain: list[AttackChainStep], compact: bool = True) -> str:
+    """Format an attack chain for display.
+
+    Args:
+        chain: List of attack chain steps.
+        compact: If True, use compact single-line format.
+
+    Returns:
+        Formatted string representation of the attack chain.
+    """
+    if not chain:
+        return "(no chain data)"
+
+    if compact:
+        # Compact: source1 -> source2 -> source3
+        sources = [step.source for step in chain]
+        return " -> ".join(sources)
+
+    # Verbose: multi-line with details
+    lines = []
+    for step in chain:
+        lines.append(step.format())
+    return "\n".join(lines)

--- a/tests/reports/test_user_summary.py
+++ b/tests/reports/test_user_summary.py
@@ -1,0 +1,338 @@
+"""Tests for the user summary report generator."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from ares.core.models import (
+    Credential,
+    Hash,
+    SharedRedTeamState,
+    Target,
+    User,
+)
+from ares.reports.user_summary import (
+    AttackChainStep,
+    UserSummary,
+    format_attack_chain,
+    generate_user_summaries,
+    trace_attack_chain,
+)
+
+
+class TestUserSummaryGeneration:
+    """Tests for user summary generation."""
+
+    @pytest.fixture
+    def state_with_chain(self, sample_target: Target) -> SharedRedTeamState:
+        """Create state with attack chain data."""
+        state = SharedRedTeamState(operation_id=f"op-{uuid.uuid4().hex[:8]}")
+        state.target = sample_target
+
+        # Create attack chain: initial cred -> hash -> cracked cred
+        initial_cred = Credential(
+            id="cred-001",
+            username="svc_backup",
+            password="Password123!",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="manual-inject",
+            is_admin=False,
+            parent_id=None,
+            attack_step=0,
+        )
+
+        dumped_hash = Hash(
+            id="hash-001",
+            username="admin",
+            hash_value="aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0",
+            hash_type="NTLM",
+            domain="contoso.local",
+            source="secretsdump",  # pragma: allowlist secret
+            parent_id="cred-001",
+            attack_step=1,
+            discovered_at=datetime.now(timezone.utc),
+        )
+
+        cracked_cred = Credential(
+            id="cred-002",
+            username="admin",
+            password="Cr4cked!",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="hashcat",
+            is_admin=True,
+            parent_id="hash-001",
+            attack_step=2,
+        )
+
+        state.all_credentials = [initial_cred, cracked_cred]
+        state.all_hashes = [dumped_hash]
+        state.all_users = [
+            User(username="svc_backup", domain="contoso.local", is_admin=False),
+            User(username="admin", domain="contoso.local", is_admin=True),
+        ]
+
+        return state
+
+    def test_generate_returns_list(self, red_team_state: SharedRedTeamState) -> None:
+        """Test generate_user_summaries returns a list."""
+        summaries = generate_user_summaries(red_team_state)
+        assert isinstance(summaries, list)
+
+    def test_empty_state_returns_empty_list(self, sample_target: Target) -> None:
+        """Test empty state returns empty list."""
+        state = SharedRedTeamState(operation_id="op-test")
+        state.target = sample_target
+        summaries = generate_user_summaries(state)
+        assert summaries == []
+
+    def test_aggregates_by_user(self, state_with_chain: SharedRedTeamState) -> None:
+        """Test credentials and hashes are aggregated by user."""
+        summaries = generate_user_summaries(state_with_chain)
+
+        # Should have 2 users: svc_backup and admin
+        assert len(summaries) == 2
+
+        # Find each user
+        svc_user = next((s for s in summaries if s.username == "svc_backup"), None)
+        admin_user = next((s for s in summaries if s.username == "admin"), None)
+
+        assert svc_user is not None
+        assert admin_user is not None
+
+        # svc_backup has 1 credential, no hashes
+        assert len(svc_user.credentials) == 1
+        assert len(svc_user.hashes) == 0
+
+        # admin has 1 credential and 1 hash
+        assert len(admin_user.credentials) == 1
+        assert len(admin_user.hashes) == 1
+
+    def test_admin_status_aggregated(self, state_with_chain: SharedRedTeamState) -> None:
+        """Test admin status is properly aggregated."""
+        summaries = generate_user_summaries(state_with_chain)
+
+        admin_user = next((s for s in summaries if s.username == "admin"), None)
+        svc_user = next((s for s in summaries if s.username == "svc_backup"), None)
+
+        assert admin_user is not None
+        assert admin_user.is_admin is True
+
+        assert svc_user is not None
+        assert svc_user.is_admin is False
+
+    def test_discovery_sources_collected(self, state_with_chain: SharedRedTeamState) -> None:
+        """Test discovery sources are collected."""
+        summaries = generate_user_summaries(state_with_chain)
+
+        admin_user = next((s for s in summaries if s.username == "admin"), None)
+        assert admin_user is not None
+        assert "secretsdump" in admin_user.discovery_sources  # pragma: allowlist secret
+        assert "hashcat" in admin_user.discovery_sources
+
+    def test_attack_chains_traced(self, state_with_chain: SharedRedTeamState) -> None:
+        """Test attack chains are traced."""
+        summaries = generate_user_summaries(state_with_chain)
+
+        admin_user = next((s for s in summaries if s.username == "admin"), None)
+        assert admin_user is not None
+
+        # Should have attack chains for the hash and credential
+        assert len(admin_user.attack_chains) >= 1
+
+        # The cracked credential (cred-002) should have a chain back to initial cred
+        if "cred-002" in admin_user.attack_chains:
+            chain = admin_user.attack_chains["cred-002"]
+            assert len(chain) >= 2  # At least hash-001 and cred-001
+
+    def test_max_attack_depth(self, state_with_chain: SharedRedTeamState) -> None:
+        """Test max attack depth is calculated."""
+        summaries = generate_user_summaries(state_with_chain)
+
+        admin_user = next((s for s in summaries if s.username == "admin"), None)
+        assert admin_user is not None
+        assert admin_user.max_attack_depth >= 1  # At least depth 1 from secretsdump
+
+
+class TestTraceAttackChain:
+    """Tests for attack chain tracing."""
+
+    def test_single_item_chain(self) -> None:
+        """Test tracing a single item with no parent."""
+        cred = Credential(
+            id="cred-001",
+            username="testuser",
+            password="pass",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="manual",
+            parent_id=None,
+            attack_step=0,
+        )
+        item_index = {cred.id: cred}
+
+        chain = trace_attack_chain(cred, item_index)
+        assert len(chain) == 1
+        assert chain[0].username == "testuser"
+        assert chain[0].step_number == 0
+
+    def test_multi_step_chain(self) -> None:
+        """Test tracing a multi-step chain."""
+        cred1 = Credential(
+            id="cred-001",
+            username="user1",
+            password="pass1",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="manual",
+            parent_id=None,
+            attack_step=0,
+        )
+        hash1 = Hash(
+            id="hash-001",
+            username="user2",
+            hash_value="abc123",
+            hash_type="NTLM",
+            domain="contoso.local",
+            source="secretsdump",  # pragma: allowlist secret
+            parent_id="cred-001",
+            attack_step=1,
+        )
+        cred2 = Credential(
+            id="cred-002",
+            username="user2",
+            password="cracked",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="hashcat",
+            parent_id="hash-001",
+            attack_step=2,
+        )
+
+        item_index = {cred1.id: cred1, hash1.id: hash1, cred2.id: cred2}
+
+        chain = trace_attack_chain(cred2, item_index)
+        assert len(chain) == 3
+        # Chain should be in order: cred1 -> hash1 -> cred2
+        assert chain[0].username == "user1"
+        assert chain[0].step_number == 0
+        assert chain[1].username == "user2"
+        assert chain[1].step_number == 1
+        assert chain[2].username == "user2"
+        assert chain[2].step_number == 2
+
+    def test_broken_chain(self) -> None:
+        """Test tracing with missing parent."""
+        cred = Credential(
+            id="cred-002",
+            username="testuser",
+            password="pass",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="hashcat",
+            parent_id="missing-parent",  # Parent doesn't exist
+            attack_step=1,
+        )
+        item_index = {cred.id: cred}
+
+        chain = trace_attack_chain(cred, item_index)
+        # Should still return the single item
+        assert len(chain) == 1
+        assert chain[0].username == "testuser"
+
+
+class TestFormatAttackChain:
+    """Tests for attack chain formatting."""
+
+    def test_empty_chain(self) -> None:
+        """Test formatting empty chain."""
+        result = format_attack_chain([], compact=True)
+        assert result == "(no chain data)"
+
+    def test_compact_format(self) -> None:
+        """Test compact chain formatting."""
+        chain = [
+            AttackChainStep(
+                step_number=0,
+                item_type="credential",
+                username="user1",
+                domain="contoso.local",
+                source="manual",
+                item_id="cred-001",
+            ),
+            AttackChainStep(
+                step_number=1,
+                item_type="hash",
+                username="user2",
+                domain="contoso.local",
+                source="secretsdump",  # pragma: allowlist secret
+                item_id="hash-001",
+            ),
+        ]
+
+        result = format_attack_chain(chain, compact=True)
+        assert "manual" in result
+        assert "secretsdump" in result  # pragma: allowlist secret
+        assert " -> " in result
+
+    def test_verbose_format(self) -> None:
+        """Test verbose chain formatting."""
+        chain = [
+            AttackChainStep(
+                step_number=0,
+                item_type="credential",
+                username="user1",
+                domain="contoso.local",
+                source="manual",
+                item_id="cred-001",
+            ),
+        ]
+
+        result = format_attack_chain(chain, compact=False)
+        assert "[0]" in result
+        assert "manual" in result
+        assert "user1" in result
+
+
+class TestUserSummaryProperties:
+    """Tests for UserSummary dataclass properties."""
+
+    def test_user_key(self) -> None:
+        """Test user_key property."""
+        summary = UserSummary(username="TestUser", domain="CONTOSO.LOCAL")
+        assert summary.user_key == "contoso.local\\testuser"
+
+    def test_display_name_with_domain(self) -> None:
+        """Test display_name with domain."""
+        summary = UserSummary(username="testuser", domain="contoso.local")
+        assert summary.display_name == "contoso.local\\testuser"
+
+    def test_display_name_without_domain(self) -> None:
+        """Test display_name without domain."""
+        summary = UserSummary(username="testuser", domain="")
+        assert summary.display_name == "testuser"
+
+    def test_has_cleartext(self) -> None:
+        """Test has_cleartext method."""
+        summary = UserSummary(username="testuser", domain="contoso.local")
+        assert summary.has_cleartext() is False
+
+        summary.credentials = [
+            Credential(
+                username="testuser",
+                password="pass",  # pragma: allowlist secret
+                domain="contoso.local",
+            )
+        ]
+        assert summary.has_cleartext() is True
+
+    def test_has_hash(self) -> None:
+        """Test has_hash method."""
+        summary = UserSummary(username="testuser", domain="contoso.local")
+        assert summary.has_hash() is False
+
+        summary.hashes = [
+            Hash(
+                username="testuser",
+                hash_value="abc123",
+                hash_type="NTLM",
+                domain="contoso.local",
+            )
+        ]
+        assert summary.has_hash() is True


### PR DESCRIPTION

**Key Changes:**

- Introduced a new `loot-users` CLI command for user-focused credential and hash summaries
- Implemented user summary aggregation and attack chain tracing in the reporting module
- Added comprehensive tests for user summary generation, attack chain logic, and formatting

**Added:**

- User-centric CLI command `loot-users` to display aggregated user credential, hash, and attack path information, with options to filter by admin status, domain, and output format (`src/ares/cli_ops.py`)
- User summary report module, including:
  - `UserSummary` dataclass for consolidated user view
  - `AttackChainStep` for representing steps in attack chains
  - `generate_user_summaries`, `trace_attack_chain`, and `format_attack_chain` utilities for aggregating and displaying data (`src/ares/reports/user_summary.py`)
- CLI output helpers for pretty-printing user summaries and attack chains, with JSON and human-readable formats
- Unit tests covering user summary generation, attack chain tracing, formatting, and dataclass properties (`tests/reports/test_user_summary.py`)

**Changed:**

- Updated report module exports to include new user summary and attack chain utilities (`src/ares/reports/__init__.py`)