### PR TITLE
feat: add golden ticket escalation logic and mutual exclusion config

### DIFF
--- a/config/multi-agent-production.yaml
+++ b/config/multi-agent-production.yaml
@@ -15,7 +15,11 @@ operation:
   rate_limit_backoff: 15.0
   rate_limit_threshold: 2
   # Stop operation immediately when domain admin is achieved (default: false)
-  stop_on_domain_admin: true
+  # NOTE: stop_on_domain_admin and stop_on_golden_ticket are mutually exclusive
+  # stop_on_domain_admin: true
+  # Stop operation when golden ticket is forged (for child→parent forest escalation)
+  # When true, operation continues past DA to forge golden ticket with ExtraSid
+  stop_on_golden_ticket: true
 
 # Agent configurations
 agents:

--- a/src/ares/core/config.py
+++ b/src/ares/core/config.py
@@ -216,6 +216,9 @@ class OperationConfig:
     crack_task_grace_period: float = 300.0
     # Stop operation immediately when domain admin is achieved
     stop_on_domain_admin: bool = False
+    # Stop operation immediately when golden ticket is forged (for forest escalation)
+    # NOTE: stop_on_domain_admin and stop_on_golden_ticket are mutually exclusive
+    stop_on_golden_ticket: bool = False
 
     # Rate limit retry settings (for worker agents)
     # Delays between retries when rate limited (list of seconds)
@@ -323,6 +326,10 @@ def _load_yaml(path: Path) -> dict[str, Any]:
         return {}
 
 
+class ConfigValidationError(Exception):
+    """Raised when configuration validation fails."""
+
+
 def _build_config(data: dict[str, Any]) -> OperationConfig:
     """Build OperationConfig from loaded data."""
     operation = data.get("operation", {})
@@ -348,7 +355,7 @@ def _build_config(data: dict[str, Any]) -> OperationConfig:
     # Only use explicit redis_url from config, otherwise derive from namespace
     redis_url = operation.get("redis_url") or derive_redis_url(namespace)
 
-    return OperationConfig(
+    config = OperationConfig(
         name=operation.get("name", "ares-multi-agent"),
         namespace=namespace,
         redis_url=redis_url,
@@ -411,6 +418,7 @@ def _build_config(data: dict[str, Any]) -> OperationConfig:
         max_runtime=operation.get("max_runtime", 3600.0),
         crack_task_grace_period=operation.get("crack_task_grace_period", 300.0),
         stop_on_domain_admin=operation.get("stop_on_domain_admin", False),
+        stop_on_golden_ticket=operation.get("stop_on_golden_ticket", False),
         # Rate limit retry settings
         rate_limit_backoff_delays=operation.get(
             "rate_limit_backoff_delays", [5.0, 10.0, 20.0, 40.0, 60.0, 60.0]
@@ -421,6 +429,27 @@ def _build_config(data: dict[str, Any]) -> OperationConfig:
             {"triage": 8, "causation": 14, "lateral": 20, "synthesis": 20},
         ),
     )
+
+    # Validate mutual exclusion of stop conditions
+    _validate_stop_conditions(config)
+
+    return config
+
+
+def _validate_stop_conditions(config: OperationConfig) -> None:
+    """Validate that stop_on_domain_admin and stop_on_golden_ticket are mutually exclusive.
+
+    Raises:
+        ConfigValidationError: If both flags are True.
+    """
+    if config.stop_on_domain_admin and config.stop_on_golden_ticket:
+        raise ConfigValidationError(
+            "stop_on_domain_admin and stop_on_golden_ticket are mutually exclusive. "
+            "Set only one to true:\n"
+            "  - stop_on_domain_admin: Stop when krbtgt hash is obtained (child domain DA)\n"
+            "  - stop_on_golden_ticket: Stop after golden ticket with ExtraSid is forged "
+            "(forest escalation)"
+        )
 
 
 def _resolve_env(value: str) -> str:
@@ -623,6 +652,8 @@ def _apply_env_overrides(config: OperationConfig) -> OperationConfig:
             pass
     if stop_on_da := os.environ.get("ARES_STOP_ON_DOMAIN_ADMIN"):
         config.stop_on_domain_admin = stop_on_da.lower() in ("true", "1", "yes")
+    if stop_on_gt := os.environ.get("ARES_STOP_ON_GOLDEN_TICKET"):
+        config.stop_on_golden_ticket = stop_on_gt.lower() in ("true", "1", "yes")
 
     # Replay overrides
     if replay_mode := os.environ.get("ARES_REPLAY_MODE"):
@@ -678,6 +709,9 @@ def _apply_env_overrides(config: OperationConfig) -> OperationConfig:
                 "configured capabilities/tools."
             )
             config.agents[role] = AgentConfig(model=value)
+
+    # Validate after env overrides (may have changed stop conditions)
+    _validate_stop_conditions(config)
 
     return config
 
@@ -948,6 +982,11 @@ def get_stop_on_domain_admin() -> bool:
     return load_config().stop_on_domain_admin
 
 
+def get_stop_on_golden_ticket() -> bool:
+    """Get whether to stop operation immediately when golden ticket is forged."""
+    return load_config().stop_on_golden_ticket
+
+
 def get_rate_limit_backoff_delays() -> list[float]:
     """Get list of delays (seconds) between rate limit retries."""
     return load_config().rate_limit_backoff_delays
@@ -993,6 +1032,7 @@ __all__ = [
     "DEFAULT_NAMESPACE",
     "DEFAULT_VULNERABILITY_PRIORITIES",
     "AgentConfig",
+    "ConfigValidationError",
     "OperationConfig",
     "clear_config_cache",
     "derive_redis_url",
@@ -1041,6 +1081,7 @@ __all__ = [
     "get_replay_seed",
     "get_stale_task_timeout",
     "get_stop_on_domain_admin",
+    "get_stop_on_golden_ticket",
     "get_task_dispatch_delay",
     "get_unvalidated_confidence_penalty",
     "get_vulnerability_priorities",

--- a/src/ares/core/dispatcher/announcements.py
+++ b/src/ares/core/dispatcher/announcements.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from ares.core.config import get_stop_on_domain_admin
+from ares.core.config import get_stop_on_domain_admin, get_stop_on_golden_ticket
 
 if TYPE_CHECKING:
     from ares.core.dispatcher._dispatcher import RedTeamDispatcher
@@ -62,20 +62,33 @@ class AnnouncementMixin:
         krbtgt_hash: str,
         ticket_path: str,
         source_agent: str,
+        target_domain: str | None = None,
     ) -> None:
         """
         Record that golden ticket has been forged.
 
         Args:
-            domain: The domain.
+            domain: The source domain (where krbtgt was obtained).
             krbtgt_hash: The krbtgt hash used.
             ticket_path: Path to the ticket file.
             source_agent: Agent that forged it.
+            target_domain: The target domain for escalation (parent/forest root).
         """
         self.shared_state.has_golden_ticket = True
+        # Record completion time for accurate report duration
+        if not self.shared_state.completed_at:
+            self.shared_state.completed_at = datetime.now(timezone.utc)
+
+        # Check if we should stop immediately on golden ticket
+        if get_stop_on_golden_ticket():
+            self.shared_state.completed = True
+            logger.info("ARES_STOP_ON_GOLDEN_TICKET enabled - marking operation complete")
 
         await self._checkpoint()
-        logger.success(f"GOLDEN TICKET FORGED for {domain}")
+        if target_domain:
+            logger.success(f"GOLDEN TICKET FORGED: {domain} → {target_domain} (forest escalation)")
+        else:
+            logger.success(f"GOLDEN TICKET FORGED for {domain}")
 
     async def announce_operation_complete(
         self: RedTeamDispatcher,

--- a/src/ares/core/dispatcher/publishing.py
+++ b/src/ares/core/dispatcher/publishing.py
@@ -186,7 +186,58 @@ class PublishingMixin:
                             )
                         except Exception as e:
                             logger.warning(f"Error exploiting delegation with credential: {e}")
-                        # NOTE: Secretsdump handled by _auto_credential_access (~15s interval, signaled on new creds)
+
+                        # IMMEDIATE: Dispatch secretsdump against all DCs
+                        # This saves ~1 minute vs waiting for _auto_credential_access
+                        try:
+                            dc_ips = [h.ip for h in self.shared_state.all_hosts if h.is_dc and h.ip]
+                            if dc_ips:
+                                secretsdump_key = (
+                                    f"{credential.domain}:{credential.username}:secretsdump"
+                                )
+                                if (
+                                    secretsdump_key
+                                    not in self.shared_state.processed_cred_expansion
+                                ):
+                                    if is_threaded:
+                                        sd_task_id = await self.request_credential_access(
+                                            source_agent="orchestrator",
+                                            domain=credential.domain,
+                                            username=credential.username,
+                                            password=credential.password,
+                                            target_ips=dc_ips,
+                                            reason="secretsdump_immediate",
+                                            techniques=["secretsdump"],
+                                            task_queue=effective_task_queue,
+                                        )
+                                    else:
+                                        sd_task_id = await asyncio.wait_for(
+                                            self.request_credential_access(
+                                                source_agent="orchestrator",
+                                                domain=credential.domain,
+                                                username=credential.username,
+                                                password=credential.password,
+                                                target_ips=dc_ips,
+                                                reason="secretsdump_immediate",
+                                                techniques=["secretsdump"],
+                                                task_queue=effective_task_queue,
+                                            ),
+                                            timeout=30.0,
+                                        )
+                                    if sd_task_id:
+                                        self.shared_state.processed_cred_expansion.add(
+                                            secretsdump_key
+                                        )
+                                        logger.info(
+                                            f"🚀 Immediate secretsdump dispatched for "
+                                            f"{credential.domain}\\{credential.username} against {len(dc_ips)} DCs: {sd_task_id}"
+                                        )
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                f"Timeout dispatching immediate secretsdump for {credential.domain}\\{credential.username}"
+                            )
+                        except Exception as e:
+                            logger.warning(f"Failed to dispatch immediate secretsdump: {e}")
                     else:
                         logger.warning(
                             f"Cannot dispatch delegation enum - no task_queue available: "

--- a/src/ares/core/dispatcher/publishing.py
+++ b/src/ares/core/dispatcher/publishing.py
@@ -186,58 +186,7 @@ class PublishingMixin:
                             )
                         except Exception as e:
                             logger.warning(f"Error exploiting delegation with credential: {e}")
-
-                        # IMMEDIATE: Dispatch secretsdump against all DCs
-                        # This saves ~1 minute vs waiting for _auto_credential_access
-                        try:
-                            dc_ips = [h.ip for h in self.shared_state.all_hosts if h.is_dc and h.ip]
-                            if dc_ips:
-                                secretsdump_key = (
-                                    f"{credential.domain}:{credential.username}:secretsdump"
-                                )
-                                if (
-                                    secretsdump_key
-                                    not in self.shared_state.processed_cred_expansion
-                                ):
-                                    if is_threaded:
-                                        sd_task_id = await self.request_credential_access(
-                                            source_agent="orchestrator",
-                                            domain=credential.domain,
-                                            username=credential.username,
-                                            password=credential.password,
-                                            target_ips=dc_ips,
-                                            reason="secretsdump_immediate",
-                                            techniques=["secretsdump"],
-                                            task_queue=effective_task_queue,
-                                        )
-                                    else:
-                                        sd_task_id = await asyncio.wait_for(
-                                            self.request_credential_access(
-                                                source_agent="orchestrator",
-                                                domain=credential.domain,
-                                                username=credential.username,
-                                                password=credential.password,
-                                                target_ips=dc_ips,
-                                                reason="secretsdump_immediate",
-                                                techniques=["secretsdump"],
-                                                task_queue=effective_task_queue,
-                                            ),
-                                            timeout=30.0,
-                                        )
-                                    if sd_task_id:
-                                        self.shared_state.processed_cred_expansion.add(
-                                            secretsdump_key
-                                        )
-                                        logger.info(
-                                            f"🚀 Immediate secretsdump dispatched for "
-                                            f"{credential.domain}\\{credential.username} against {len(dc_ips)} DCs: {sd_task_id}"
-                                        )
-                        except asyncio.TimeoutError:
-                            logger.warning(
-                                f"Timeout dispatching immediate secretsdump for {credential.domain}\\{credential.username}"
-                            )
-                        except Exception as e:
-                            logger.warning(f"Failed to dispatch immediate secretsdump: {e}")
+                        # NOTE: Secretsdump handled by _auto_credential_access (~15s interval, signaled on new creds)
                     else:
                         logger.warning(
                             f"Cannot dispatch delegation enum - no task_queue available: "

--- a/src/ares/core/dispatcher/publishing.py
+++ b/src/ares/core/dispatcher/publishing.py
@@ -108,6 +108,13 @@ class PublishingMixin:
                 )
             logger.info(f"Credential published: {credential.domain}\\{credential.username}")
 
+            # Check if this credential has golden ticket capability
+            # (e.g., is local admin on a DC we already know about)
+            if credential.domain:
+                self.shared_state.update_golden_ticket_capability(
+                    credential.username, credential.domain, source_agent
+                )
+
             # Immediate actions for ANY credential with password
             # This includes cracked hashes AND credentials from username_as_password, etc.
             if credential.password and credential.domain:
@@ -459,6 +466,11 @@ class PublishingMixin:
 
             # Auto-detect MSSQL and queue vulnerability for exploitation
             await self._auto_detect_mssql(host, source_agent)
+
+            # If this is a DC, re-check all credentials for golden ticket capability
+            # A credential with local_admin on this DC can now dump NTDS.dit
+            if host.is_dc:
+                await self._recheck_golden_ticket_on_dc_discovery(host, source_agent)
         else:
             logger.debug(f"Host unchanged (exact duplicate): {host.ip} ({host.hostname})")
 
@@ -652,6 +664,51 @@ class PublishingMixin:
         # Sort to prioritize SQL accounts
         sql_creds.sort(key=lambda x: x.get("is_sql_account", "False") != "True")
         return sql_creds[:5]  # Return top 5 candidates
+
+    async def _recheck_golden_ticket_on_dc_discovery(
+        self: RedTeamDispatcher,
+        host: Host,
+        source_agent: str,
+    ) -> None:
+        """Re-check all credentials for golden ticket capability when a DC is discovered.
+
+        When a new DC is identified, any existing credential with local_admin on that
+        DC now has golden ticket capability (can dump NTDS.dit to get krbtgt hash).
+
+        Args:
+            host: The newly discovered DC host.
+            source_agent: Agent that discovered the DC.
+        """
+        # Only process if this is a DC
+        if not host.is_dc:
+            return
+
+        found_capable = False
+
+        # Check all credentials to see if they have admin access on this DC
+        for cred in self.shared_state.all_credentials:
+            if cred.domain and self.shared_state.update_golden_ticket_capability(
+                cred.username, cred.domain, source_agent
+            ):
+                found_capable = True
+
+        # Also check cracked hashes that have passwords
+        for hash_obj in self.shared_state.all_hashes:
+            if (
+                hash_obj.cracked_password
+                and hash_obj.domain
+                and self.shared_state.update_golden_ticket_capability(
+                    hash_obj.username, hash_obj.domain, source_agent
+                )
+            ):
+                found_capable = True
+
+        # Checkpoint if we found new capabilities
+        if found_capable:
+            if threading.current_thread() is threading.main_thread():
+                await self._checkpoint()
+            else:
+                self._checkpoint_requested.set()
 
     def _ensure_credential_in_state(
         self: RedTeamDispatcher,
@@ -920,7 +977,40 @@ class PublishingMixin:
                 self._checkpoint_requested.set()
             logger.info(f"Vulnerability published: {vuln.vuln_type} on {vuln.target}")
 
+            # Check for golden ticket capability when local_admin vuln is discovered
+            if vuln.vuln_type == "local_admin":
+                await self._check_golden_ticket_on_local_admin(vuln, source_agent)
+
         return added
+
+    async def _check_golden_ticket_on_local_admin(
+        self: RedTeamDispatcher,
+        vuln: VulnerabilityInfo,
+        source_agent: str,
+    ) -> None:
+        """Check if a local_admin vulnerability enables golden ticket capability.
+
+        When a user has local admin on a DC, they can dump NTDS.dit to get krbtgt hash.
+
+        Args:
+            vuln: The local_admin vulnerability.
+            source_agent: Agent that discovered it.
+        """
+        # Extract principal info from the vulnerability
+        details = vuln.details if isinstance(vuln.details, dict) else {}
+        username = details.get("username", "")
+        domain = details.get("domain", "")
+
+        if not username:
+            return
+
+        # Check if this grants golden ticket capability
+        if self.shared_state.update_golden_ticket_capability(username, domain, source_agent):
+            # Checkpoint to persist the updated capability tracking
+            if threading.current_thread() is threading.main_thread():
+                await self._checkpoint()
+            else:
+                self._checkpoint_requested.set()
 
     async def _exploit_delegation_with_credential(
         self: RedTeamDispatcher,

--- a/src/ares/core/factories/red_agents.py
+++ b/src/ares/core/factories/red_agents.py
@@ -17,7 +17,13 @@ from dreadnode.agent.stop import tool_use
 from loguru import logger
 
 from ares.core.capability_registry import FilteredToolset, get_enabled_tools
-from ares.core.config import get_agent_config, get_max_context_tokens, get_min_messages_to_keep
+from ares.core.config import (
+    get_agent_config,
+    get_max_context_tokens,
+    get_min_messages_to_keep,
+    get_stop_on_domain_admin,
+    get_stop_on_golden_ticket,
+)
 from ares.core.dispatcher import RedTeamDispatcher
 from ares.core.models import AgentInfo, AgentRole, SharedRedTeamState
 from ares.core.templates import get_template_loader
@@ -412,9 +418,16 @@ def create_role_hooks(
         # NOTE: We check on BOTH StepStart AND ToolEnd to minimize latency.
         # StepStart only fires at the beginning of steps (after LLM generation),
         # but ToolEnd fires after every tool execution, catching DA sooner.
+        # IMPORTANT: Only fires if stop_on_domain_admin=True in config. If
+        # stop_on_golden_ticket=True, we continue past DA to forge golden ticket.
         async def stop_on_external_domain_admin(event: StepStart | ToolEnd) -> Finish | None:
             """Stop orchestrator when Domain Admin is achieved by worker agents."""
             if not isinstance(event, (StepStart, ToolEnd)):
+                return None
+
+            # Only stop on DA if stop_on_domain_admin is enabled
+            # If stop_on_golden_ticket is enabled, we continue past DA
+            if not get_stop_on_domain_admin():
                 return None
 
             if shared_state.has_domain_admin:
@@ -428,6 +441,29 @@ def create_role_hooks(
             return None
 
         hooks.append(stop_on_external_domain_admin)
+
+        # Stop orchestrator when Golden Ticket is forged (for forest escalation)
+        # This fires when stop_on_golden_ticket=True and has_golden_ticket is set
+        async def stop_on_external_golden_ticket(event: StepStart | ToolEnd) -> Finish | None:
+            """Stop orchestrator when Golden Ticket is forged by worker agents."""
+            if not isinstance(event, (StepStart, ToolEnd)):
+                return None
+
+            # Only stop on golden ticket if stop_on_golden_ticket is enabled
+            if not get_stop_on_golden_ticket():
+                return None
+
+            if shared_state.has_golden_ticket:
+                event_type = "StepStart" if isinstance(event, StepStart) else "ToolEnd"
+                logger.success(
+                    f"🎫 Golden Ticket detected (forged externally, {event_type}) - "
+                    "stopping orchestrator agent"
+                )
+                return Finish(reason="Golden Ticket forged by worker agent")
+
+            return None
+
+        hooks.append(stop_on_external_golden_ticket)
 
     elif role == AgentRole.CRACKER:
         # Cracker broadcasts cracked credentials

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -782,6 +782,12 @@ class SharedRedTeamState:
         default_factory=set
     )  # "domain:user:pwdhash" - expansion loop triggered
 
+    # Golden ticket capability tracking
+    # Key: "domain:username" (lowercase), Value: list of capability info dicts
+    # Each dict: {domain, reason, dc_host, dc_ip}
+    # reason: "local_admin_on_dc" (has admin on a DC, can dump NTDS.dit)
+    golden_ticket_capable_creds: dict[str, list[dict]] = field(default_factory=dict)
+
     # Agent registry
     registered_agents: dict[str, AgentInfo] = field(default_factory=dict)
 
@@ -1207,12 +1213,29 @@ class SharedRedTeamState:
                 if gmsa.get("account", "").lower() not in existing_accounts:
                     self.gmsa_accounts.append(gmsa)
 
+            # Load golden ticket capable credentials
+            gt_capable = await self._backend.get_golden_ticket_capable_creds()
+            for cred_key, capabilities in gt_capable.items():
+                if cred_key not in self.golden_ticket_capable_creds:
+                    self.golden_ticket_capable_creds[cred_key] = capabilities
+                else:
+                    # Merge capabilities
+                    existing_keys = {
+                        f"{c.get('dc_ip')}:{c.get('reason')}"
+                        for c in self.golden_ticket_capable_creds[cred_key]
+                    }
+                    for cap in capabilities:
+                        cap_key = f"{cap.get('dc_ip')}:{cap.get('reason')}"
+                        if cap_key not in existing_keys:
+                            self.golden_ticket_capable_creds[cred_key].append(cap)
+
             logger.info(
                 f"Loaded persistence tracking from Redis: "
                 f"{len(self.golden_tickets)} golden tickets, "
                 f"{len(self.adminsd_holder_backdoors)} backdoors, "
                 f"{len(self.acl_chains)} ACL chains, "
-                f"{len(self.gmsa_accounts)} gMSA accounts"
+                f"{len(self.gmsa_accounts)} gMSA accounts, "
+                f"{len(self.golden_ticket_capable_creds)} golden ticket capable creds"
             )
         except Exception as e:
             logger.warning(f"Failed to load persistence tracking from backend: {e}")
@@ -2694,6 +2717,214 @@ class SharedRedTeamState:
             for vid, v in self.discovered_vulnerabilities.items()
             if vid not in self.exploited_vulnerabilities
         ]
+
+    # =========================================================================
+    # Golden Ticket Capability Detection
+    # =========================================================================
+
+    def check_golden_ticket_capability(self, username: str, domain: str) -> list[dict[str, str]]:
+        """Check if a credential can obtain krbtgt hash (golden ticket capability).
+
+        A credential can forge a golden ticket if it has local admin access on a
+        Domain Controller. This allows dumping NTDS.dit to extract the krbtgt hash.
+
+        ACCURACY NOTE: We ONLY return True for verified conditions:
+        1. The credential has a local_admin vulnerability on a host
+        2. That host is confirmed as a DC (is_dc=True in all_hosts)
+        3. The DC's domain matches the credential's domain (or is resolvable)
+
+        We do NOT assume golden ticket capability based on:
+        - Generic "admin" flags without confirmed DC access
+        - Membership in groups without verified DC admin rights
+        - Untested/unverified access claims
+
+        Args:
+            username: The username to check.
+            domain: The domain of the credential.
+
+        Returns:
+            List of capability dicts, each with:
+            - domain: The domain where krbtgt can be obtained
+            - reason: "local_admin_on_dc"
+            - dc_host: DC hostname
+            - dc_ip: DC IP address
+        """
+        capabilities: list[dict[str, str]] = []
+        username_lower = username.lower()
+        domain_lower = domain.lower()
+
+        # Build a map of DC hosts: hostname -> Host, ip -> Host
+        dc_hosts_by_name: dict[str, Host] = {}
+        dc_hosts_by_ip: dict[str, Host] = {}
+        for host in self.all_hosts:
+            if host.is_dc:
+                if host.hostname:
+                    # Store by short name and FQDN
+                    dc_hosts_by_name[host.hostname.lower()] = host
+                    short_name = host.hostname.split(".")[0].lower()
+                    dc_hosts_by_name[short_name] = host
+                if host.ip:
+                    dc_hosts_by_ip[host.ip] = host
+
+        # Check all local_admin vulnerabilities for this user
+        for vuln in self.discovered_vulnerabilities.values():
+            if vuln.vuln_type != "local_admin":
+                continue
+
+            # Get the principal from the vulnerability
+            principal = vuln.details.get("username", "").lower()
+            principal_domain = vuln.details.get("domain", "").lower()
+
+            # Also check the principal field directly (may include domain)
+            vuln_principal = str(vuln.details.get("principal", "")).lower()
+            if "@" in vuln_principal:
+                parts = vuln_principal.split("@")
+                if len(parts) == 2:
+                    principal = parts[0]
+                    principal_domain = parts[1]
+            elif "\\" in vuln_principal:
+                parts = vuln_principal.split("\\")
+                if len(parts) == 2:
+                    principal_domain = parts[0]
+                    principal = parts[1]
+
+            # Match username (case-insensitive)
+            if principal != username_lower:
+                continue
+
+            # Match domain if specified (handle NetBIOS vs FQDN)
+            if (
+                principal_domain
+                and domain_lower
+                and not self._domains_match(principal_domain, domain_lower)
+            ):
+                continue
+
+            # Get the target host from the vulnerability
+            target = vuln.target.lower()
+
+            # Check if target is a DC
+            dc_host = dc_hosts_by_name.get(target) or dc_hosts_by_ip.get(target)
+            if not dc_host:
+                # Try matching by partial hostname
+                for name, host in dc_hosts_by_name.items():
+                    if target in name or name in target:
+                        dc_host = host
+                        break
+
+            if dc_host:
+                # Determine the domain of this DC
+                dc_domain = ""
+                if dc_host.hostname and "." in dc_host.hostname:
+                    # Extract domain from FQDN: winterfell.north.sevenkingdoms.local -> north.sevenkingdoms.local
+                    parts = dc_host.hostname.lower().split(".", 1)
+                    if len(parts) > 1:
+                        dc_domain = parts[1]
+
+                # Also check domain_controllers cache
+                for cached_domain, cached_ip in self.domain_controllers.items():
+                    if cached_ip == dc_host.ip:
+                        dc_domain = cached_domain
+                        break
+
+                capabilities.append(
+                    {
+                        "domain": dc_domain or domain_lower,
+                        "reason": "local_admin_on_dc",
+                        "dc_host": dc_host.hostname or dc_host.ip,
+                        "dc_ip": dc_host.ip,
+                    }
+                )
+
+        return capabilities
+
+    def _domains_match(self, domain1: str, domain2: str) -> bool:
+        """Check if two domain identifiers refer to the same domain.
+
+        Handles NetBIOS name vs FQDN comparison using netbios_to_fqdn mapping.
+        """
+        d1 = domain1.lower()
+        d2 = domain2.lower()
+
+        if d1 == d2:
+            return True
+
+        # Check if one is NetBIOS and maps to the other
+        d1_fqdn = self.netbios_to_fqdn.get(d1, d1)
+        d2_fqdn = self.netbios_to_fqdn.get(d2, d2)
+
+        if d1_fqdn == d2_fqdn:
+            return True
+
+        # Check if one is a prefix of the other (north vs north.sevenkingdoms.local)
+        return d1_fqdn.startswith(d2 + ".") or d2_fqdn.startswith(d1 + ".")
+
+    def update_golden_ticket_capability(
+        self, username: str, domain: str, source_agent: str = ""
+    ) -> bool:
+        """Update golden ticket capability tracking for a credential.
+
+        Should be called when:
+        1. A new credential is published
+        2. A new local_admin vulnerability is discovered
+        3. A new DC host is identified
+
+        Args:
+            username: The username to check.
+            domain: The domain of the credential.
+            source_agent: Agent that triggered the check.
+
+        Returns:
+            True if new capability was detected, False otherwise.
+        """
+        cred_key = f"{domain.lower()}:{username.lower()}"
+
+        # Check current capabilities
+        capabilities = self.check_golden_ticket_capability(username, domain)
+
+        if not capabilities:
+            return False
+
+        # Check if this is new capability
+        existing = self.golden_ticket_capable_creds.get(cred_key, [])
+        existing_keys = {f"{c.get('dc_ip')}:{c.get('reason')}" for c in existing}
+
+        new_capabilities = []
+        for cap in capabilities:
+            cap_key = f"{cap.get('dc_ip')}:{cap.get('reason')}"
+            if cap_key not in existing_keys:
+                new_capabilities.append(cap)
+
+        if new_capabilities:
+            updated_capabilities = existing + new_capabilities
+            self.golden_ticket_capable_creds[cred_key] = updated_capabilities
+            logger.info(
+                f"🎫 GOLDEN TICKET CAPABILITY: {domain}\\{username} can obtain krbtgt "
+                f"via {new_capabilities[0].get('reason')} on {new_capabilities[0].get('dc_host')}"
+            )
+
+            # Persist to Redis backend if available
+            if self._can_persist_to_backend():
+                import asyncio
+
+                loop = asyncio.get_running_loop()
+                task = loop.create_task(
+                    self._backend.add_golden_ticket_capable_cred(cred_key, updated_capabilities)
+                )
+                self._track_background_task(task, f"add_golden_ticket_capable_cred({cred_key})")
+
+            return True
+
+        return False
+
+    def get_golden_ticket_capable_credentials(self) -> list[tuple[str, list[dict]]]:
+        """Get all credentials with golden ticket capability.
+
+        Returns:
+            List of (cred_key, capabilities) tuples where cred_key is "domain:username"
+            and capabilities is the list of ways they can obtain krbtgt.
+        """
+        return list(self.golden_ticket_capable_creds.items())
 
     def get_agent_credentials(self, agent_name: str) -> list[Credential]:
         """Get credentials discovered by a specific agent."""

--- a/src/ares/core/state_backend.py
+++ b/src/ares/core/state_backend.py
@@ -799,6 +799,44 @@ class RedisStateBackend:
         """Get golden ticket status."""
         return await self.get_meta("has_golden_ticket", default=False)
 
+    async def set_golden_ticket_capable_creds(self, creds: dict[str, list[dict]]) -> bool:
+        """Set golden ticket capable credentials.
+
+        Args:
+            creds: Dict mapping "domain:username" to list of capability dicts
+
+        Returns:
+            True if set successfully
+        """
+        return await self.set_meta("golden_ticket_capable_creds", creds)
+
+    async def get_golden_ticket_capable_creds(self) -> dict[str, list[dict]]:
+        """Get golden ticket capable credentials.
+
+        Returns:
+            Dict mapping "domain:username" to list of capability dicts
+        """
+        result = await self.get_meta("golden_ticket_capable_creds", default={})
+        return result if isinstance(result, dict) else {}
+
+    async def add_golden_ticket_capable_cred(self, cred_key: str, capabilities: list[dict]) -> bool:
+        """Add or update a credential's golden ticket capabilities.
+
+        Args:
+            cred_key: "domain:username" key
+            capabilities: List of capability dicts
+
+        Returns:
+            True if updated successfully
+        """
+        try:
+            current = await self.get_golden_ticket_capable_creds()
+            current[cred_key] = capabilities
+            return await self.set_golden_ticket_capable_creds(current)
+        except Exception as e:
+            logger.warning(f"Failed to add golden ticket capable cred {cred_key}: {e}")
+            return False
+
     async def set_completed(self, completed: bool) -> None:
         """Set operation completion status."""
         await self.set_meta("completed", completed)

--- a/tests/core/factories/test_red_agents.py
+++ b/tests/core/factories/test_red_agents.py
@@ -567,8 +567,18 @@ class TestStopOnExternalDomainAdmin:
         return event
 
     @pytest.mark.asyncio
-    async def test_returns_finish_on_step_start_when_da_achieved(self):
+    async def test_returns_finish_on_step_start_when_da_achieved(self, monkeypatch):
         """Test that hook returns Finish on StepStart when has_domain_admin=True."""
+        # Enable stop_on_domain_admin config (required for DA hook to fire)
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: False,
+        )
+
         shared_state = SharedRedTeamState(operation_id="test-op")
         shared_state.has_domain_admin = True
         shared_state.domain_admin_path = "kerberoast -> secretsdump -> krbtgt"
@@ -594,12 +604,22 @@ class TestStopOnExternalDomainAdmin:
         assert "Domain Admin achieved" in finish_results[0].reason
 
     @pytest.mark.asyncio
-    async def test_returns_finish_on_tool_end_when_da_achieved(self):
+    async def test_returns_finish_on_tool_end_when_da_achieved(self, monkeypatch):
         """Test that hook returns Finish on ToolEnd when has_domain_admin=True.
 
         This is critical for reducing latency - we check DA after every tool
         execution, not just at step boundaries.
         """
+        # Enable stop_on_domain_admin config (required for DA hook to fire)
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: False,
+        )
+
         shared_state = SharedRedTeamState(operation_id="test-op")
         shared_state.has_domain_admin = True
         shared_state.domain_admin_path = "secretsdump -> krbtgt"
@@ -624,8 +644,18 @@ class TestStopOnExternalDomainAdmin:
         assert "Domain Admin achieved" in finish_results[0].reason
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_da_not_achieved(self):
+    async def test_returns_none_when_da_not_achieved(self, monkeypatch):
         """Test that hook returns None when has_domain_admin=False."""
+        # Enable stop_on_domain_admin config
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: False,
+        )
+
         shared_state = SharedRedTeamState(operation_id="test-op")
         shared_state.has_domain_admin = False
 
@@ -647,8 +677,18 @@ class TestStopOnExternalDomainAdmin:
                     pass
 
     @pytest.mark.asyncio
-    async def test_only_orchestrator_has_da_stop_hook(self):
+    async def test_only_orchestrator_has_da_stop_hook(self, monkeypatch):
         """Test that only ORCHESTRATOR role has the stop_on_external_domain_admin hook."""
+        # Enable stop_on_domain_admin config
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: False,
+        )
+
         shared_state = SharedRedTeamState(operation_id="test-op")
         shared_state.has_domain_admin = True
 
@@ -677,3 +717,230 @@ class TestStopOnExternalDomainAdmin:
                     pass
 
             assert finish_count == 0, f"Worker role {role} should not have DA stop hook"
+
+
+class TestStopOnExternalGoldenTicket:
+    """Tests for stop_on_external_golden_ticket hook.
+
+    This hook stops the orchestrator when a Golden Ticket is forged externally
+    (by a worker agent), but only when stop_on_golden_ticket=True in config.
+    """
+
+    def _make_step_start_event(self) -> MagicMock:
+        """Helper to create a mock StepStart event."""
+        return MagicMock(spec=StepStart)
+
+    def _make_tool_end_event(self, tool_name: str = "get_status") -> MagicMock:
+        """Helper to create a mock ToolEnd event."""
+        event = MagicMock(spec=ToolEnd)
+        event.tool_call = MagicMock()
+        event.tool_call.name = tool_name
+        event.message = MagicMock()
+        event.message.content = "OK"
+        return event
+
+    @pytest.mark.asyncio
+    async def test_returns_finish_when_golden_ticket_forged_and_config_enabled(self, monkeypatch):
+        """Test hook returns Finish when has_golden_ticket=True and config enabled."""
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: False,
+        )
+
+        shared_state = SharedRedTeamState(operation_id="test-op")
+        shared_state.has_golden_ticket = True
+
+        dispatcher = MagicMock(spec=RedTeamDispatcher)
+        dispatcher.shared_state = shared_state
+
+        hooks = create_role_hooks(AgentRole.ORCHESTRATOR, dispatcher, shared_state)
+        event = self._make_step_start_event()
+
+        finish_results = []
+        for hook in hooks:
+            try:
+                result = await hook(event)
+                if isinstance(result, Finish):
+                    finish_results.append(result)
+            except TypeError:
+                pass
+
+        assert len(finish_results) >= 1, "Should return Finish when GT forged"
+        assert "Golden Ticket" in finish_results[0].reason
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_config_disabled(self, monkeypatch):
+        """Test hook returns None when stop_on_golden_ticket=False."""
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: False,
+        )
+
+        shared_state = SharedRedTeamState(operation_id="test-op")
+        shared_state.has_golden_ticket = True
+
+        dispatcher = MagicMock(spec=RedTeamDispatcher)
+        dispatcher.shared_state = shared_state
+
+        hooks = create_role_hooks(AgentRole.ORCHESTRATOR, dispatcher, shared_state)
+        event = self._make_step_start_event()
+
+        for hook in hooks:
+            try:
+                result = await hook(event)
+                if isinstance(result, Finish) and "Golden Ticket" in str(result.reason):
+                    pytest.fail("Should not return Finish when config disabled")
+            except TypeError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_golden_ticket(self, monkeypatch):
+        """Test hook returns None when has_golden_ticket=False."""
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: False,
+        )
+
+        shared_state = SharedRedTeamState(operation_id="test-op")
+        shared_state.has_golden_ticket = False
+
+        dispatcher = MagicMock(spec=RedTeamDispatcher)
+        dispatcher.shared_state = shared_state
+
+        hooks = create_role_hooks(AgentRole.ORCHESTRATOR, dispatcher, shared_state)
+        event = self._make_step_start_event()
+
+        for hook in hooks:
+            try:
+                result = await hook(event)
+                assert not isinstance(result, Finish), "Should not Finish without GT"
+            except TypeError:
+                pass
+
+
+class TestStopOnDomainAdminConfigRespect:
+    """Tests that stop_on_external_domain_admin respects config setting.
+
+    The DA hook should only fire when stop_on_domain_admin=True.
+    When stop_on_golden_ticket=True, we continue past DA to forge golden ticket.
+    """
+
+    def _make_step_start_event(self) -> MagicMock:
+        """Helper to create a mock StepStart event."""
+        return MagicMock(spec=StepStart)
+
+    @pytest.mark.asyncio
+    async def test_da_hook_fires_when_stop_on_da_enabled(self, monkeypatch):
+        """Test DA hook fires when stop_on_domain_admin=True."""
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: False,
+        )
+
+        shared_state = SharedRedTeamState(operation_id="test-op")
+        shared_state.has_domain_admin = True
+
+        dispatcher = MagicMock(spec=RedTeamDispatcher)
+        dispatcher.shared_state = shared_state
+
+        hooks = create_role_hooks(AgentRole.ORCHESTRATOR, dispatcher, shared_state)
+        event = self._make_step_start_event()
+
+        finish_results = []
+        for hook in hooks:
+            try:
+                result = await hook(event)
+                if isinstance(result, Finish) and "Domain Admin" in str(result.reason):
+                    finish_results.append(result)
+            except TypeError:
+                pass
+
+        assert len(finish_results) >= 1, "DA hook should fire when config enabled"
+
+    @pytest.mark.asyncio
+    async def test_da_hook_does_not_fire_when_disabled(self, monkeypatch):
+        """Test DA hook does NOT fire when stop_on_domain_admin=False.
+
+        This is critical for forest escalation: we need to continue past DA
+        to forge the golden ticket with ExtraSid.
+        """
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: True,
+        )
+
+        shared_state = SharedRedTeamState(operation_id="test-op")
+        shared_state.has_domain_admin = True
+        shared_state.has_golden_ticket = False  # Not forged yet
+
+        dispatcher = MagicMock(spec=RedTeamDispatcher)
+        dispatcher.shared_state = shared_state
+
+        hooks = create_role_hooks(AgentRole.ORCHESTRATOR, dispatcher, shared_state)
+        event = self._make_step_start_event()
+
+        for hook in hooks:
+            try:
+                result = await hook(event)
+                if isinstance(result, Finish) and "Domain Admin" in str(result.reason):
+                    pytest.fail("DA hook should NOT fire when stop_on_domain_admin=False")
+            except TypeError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_golden_ticket_stops_after_da_when_configured(self, monkeypatch):
+        """Test that when stop_on_golden_ticket=True, we stop on GT not DA."""
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_domain_admin",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.red_agents.get_stop_on_golden_ticket",
+            lambda: True,
+        )
+
+        shared_state = SharedRedTeamState(operation_id="test-op")
+        shared_state.has_domain_admin = True
+        shared_state.has_golden_ticket = True
+
+        dispatcher = MagicMock(spec=RedTeamDispatcher)
+        dispatcher.shared_state = shared_state
+
+        hooks = create_role_hooks(AgentRole.ORCHESTRATOR, dispatcher, shared_state)
+        event = self._make_step_start_event()
+
+        finish_reasons = []
+        for hook in hooks:
+            try:
+                result = await hook(event)
+                if isinstance(result, Finish):
+                    finish_reasons.append(result.reason)
+            except TypeError:
+                pass
+
+        # Should have Golden Ticket finish, not Domain Admin
+        gt_finishes = [r for r in finish_reasons if "Golden Ticket" in r]
+        da_finishes = [r for r in finish_reasons if "Domain Admin" in r]
+
+        assert len(gt_finishes) >= 1, "Should stop on Golden Ticket"
+        assert len(da_finishes) == 0, "Should NOT stop on Domain Admin"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -476,5 +476,145 @@ class TestContextManagementSettings:
             assert config.max_output_chars == 3000
 
 
+class TestStopConditionsValidation:
+    """Tests for stop_on_domain_admin and stop_on_golden_ticket mutual exclusion."""
+
+    def test_stop_on_golden_ticket_default_false(self):
+        """Test stop_on_golden_ticket defaults to False."""
+        from ares.core.config import OperationConfig
+
+        config = OperationConfig()
+        assert config.stop_on_golden_ticket is False
+
+    def test_stop_on_domain_admin_and_golden_ticket_mutually_exclusive(self):
+        """Test that both stop conditions cannot be enabled simultaneously."""
+        from ares.core.config import ConfigValidationError, _build_config
+
+        config_data = {
+            "operation": {
+                "stop_on_domain_admin": True,
+                "stop_on_golden_ticket": True,
+            }
+        }
+
+        with pytest.raises(ConfigValidationError) as exc_info:
+            _build_config(config_data)
+
+        assert "mutually exclusive" in str(exc_info.value)
+        assert "stop_on_domain_admin" in str(exc_info.value)
+        assert "stop_on_golden_ticket" in str(exc_info.value)
+
+    def test_stop_on_domain_admin_alone_valid(self):
+        """Test that stop_on_domain_admin alone is valid."""
+        from ares.core.config import _build_config
+
+        config_data = {
+            "operation": {
+                "stop_on_domain_admin": True,
+                "stop_on_golden_ticket": False,
+            }
+        }
+
+        config = _build_config(config_data)
+        assert config.stop_on_domain_admin is True
+        assert config.stop_on_golden_ticket is False
+
+    def test_stop_on_golden_ticket_alone_valid(self):
+        """Test that stop_on_golden_ticket alone is valid."""
+        from ares.core.config import _build_config
+
+        config_data = {
+            "operation": {
+                "stop_on_domain_admin": False,
+                "stop_on_golden_ticket": True,
+            }
+        }
+
+        config = _build_config(config_data)
+        assert config.stop_on_domain_admin is False
+        assert config.stop_on_golden_ticket is True
+
+    def test_both_false_valid(self):
+        """Test that both conditions disabled is valid."""
+        from ares.core.config import _build_config
+
+        config_data = {
+            "operation": {
+                "stop_on_domain_admin": False,
+                "stop_on_golden_ticket": False,
+            }
+        }
+
+        config = _build_config(config_data)
+        assert config.stop_on_domain_admin is False
+        assert config.stop_on_golden_ticket is False
+
+    def test_env_override_stop_on_golden_ticket(self):
+        """Test ARES_STOP_ON_GOLDEN_TICKET environment override."""
+        config_data = {"agents": {}}
+
+        with patch.dict(
+            os.environ,
+            {"ARES_STOP_ON_GOLDEN_TICKET": "true"},
+            clear=False,
+        ):
+            from ares.core.config import _build_config
+
+            config = _build_config(config_data)
+            config = _apply_env_overrides(config)
+
+            assert config.stop_on_golden_ticket is True
+
+    def test_env_override_mutual_exclusion_validation(self):
+        """Test that env overrides also validate mutual exclusion."""
+        config_data = {
+            "operation": {
+                "stop_on_domain_admin": True,
+            }
+        }
+
+        with patch.dict(
+            os.environ,
+            {"ARES_STOP_ON_GOLDEN_TICKET": "true"},
+            clear=False,
+        ):
+            from ares.core.config import ConfigValidationError, _build_config
+
+            config = _build_config(config_data)
+
+            with pytest.raises(ConfigValidationError):
+                _apply_env_overrides(config)
+
+    def test_get_stop_on_golden_ticket_function(self):
+        """Test get_stop_on_golden_ticket helper function."""
+        from ares.core.config import clear_config_cache, get_stop_on_golden_ticket
+
+        clear_config_cache()
+
+        # Override both to ensure a clean slate (config file may have either set)
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith("ARES_")}
+        clean_env["ARES_STOP_ON_GOLDEN_TICKET"] = "false"
+        clean_env["ARES_STOP_ON_DOMAIN_ADMIN"] = "false"
+        with patch.dict(os.environ, clean_env, clear=True):
+            clear_config_cache()
+            result = get_stop_on_golden_ticket()
+            assert result is False
+
+    def test_get_stop_on_golden_ticket_with_env(self):
+        """Test get_stop_on_golden_ticket with env variable set."""
+        from ares.core.config import clear_config_cache, get_stop_on_golden_ticket
+
+        # Clear any existing config, and also disable stop_on_domain_admin
+        # since the two are mutually exclusive
+        clean_env = {k: v for k, v in os.environ.items() if not k.startswith("ARES_")}
+        clean_env["ARES_STOP_ON_GOLDEN_TICKET"] = "true"
+        clean_env["ARES_STOP_ON_DOMAIN_ADMIN"] = "false"
+
+        with patch.dict(os.environ, clean_env, clear=True):
+            clear_config_cache()
+            result = get_stop_on_golden_ticket()
+            assert result is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1733,3 +1733,278 @@ class TestDomainAdminAutoDetection:
         state.add_hash(hash_obj, "secretsdump")
 
         assert state.has_domain_admin is False
+
+
+class TestGoldenTicketCapabilityDetection:
+    """Tests for golden ticket capability detection.
+
+    Golden ticket capability is detected when a credential has local_admin
+    access on a Domain Controller (can dump NTDS.dit to get krbtgt hash).
+    """
+
+    def test_check_golden_ticket_capability_empty_state(self) -> None:
+        """Test that empty state returns no capabilities."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        capabilities = state.check_golden_ticket_capability("admin", "contoso.local")
+
+        assert capabilities == []
+
+    def test_check_golden_ticket_capability_with_dc_admin(self) -> None:
+        """Test that local_admin on DC grants golden ticket capability."""
+        from ares.core.models import Host, SharedRedTeamState, VulnerabilityInfo
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add a DC host
+        dc_host = Host(
+            ip="192.168.58.10",
+            hostname="dc01.contoso.local",
+            is_dc=True,
+        )
+        state.all_hosts.append(dc_host)
+
+        # Add local_admin vulnerability on that DC
+        vuln = VulnerabilityInfo(
+            vuln_id="vuln-001",
+            vuln_type="local_admin",
+            target="dc01.contoso.local",
+            discovered_by="recon",
+            details={"username": "admin", "domain": "contoso.local"},
+        )
+        state.discovered_vulnerabilities["vuln-001"] = vuln
+
+        capabilities = state.check_golden_ticket_capability("admin", "contoso.local")
+
+        assert len(capabilities) == 1
+        assert capabilities[0]["reason"] == "local_admin_on_dc"
+        assert capabilities[0]["dc_host"] == "dc01.contoso.local"
+        assert capabilities[0]["dc_ip"] == "192.168.58.10"
+
+    def test_check_golden_ticket_capability_no_dc_access(self) -> None:
+        """Test that local_admin on non-DC doesn't grant capability."""
+        from ares.core.models import Host, SharedRedTeamState, VulnerabilityInfo
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add a non-DC host
+        host = Host(
+            ip="192.168.58.20",
+            hostname="ws01.contoso.local",
+            is_dc=False,
+        )
+        state.all_hosts.append(host)
+
+        # Add local_admin vulnerability on that host
+        vuln = VulnerabilityInfo(
+            vuln_id="vuln-001",
+            vuln_type="local_admin",
+            target="ws01.contoso.local",
+            discovered_by="recon",
+            details={"username": "admin", "domain": "contoso.local"},
+        )
+        state.discovered_vulnerabilities["vuln-001"] = vuln
+
+        capabilities = state.check_golden_ticket_capability("admin", "contoso.local")
+
+        assert capabilities == []
+
+    def test_check_golden_ticket_capability_wrong_user(self) -> None:
+        """Test that capability is only returned for matching user."""
+        from ares.core.models import Host, SharedRedTeamState, VulnerabilityInfo
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add DC
+        dc_host = Host(
+            ip="192.168.58.10",
+            hostname="dc01.contoso.local",
+            is_dc=True,
+        )
+        state.all_hosts.append(dc_host)
+
+        # Add local_admin for different user
+        vuln = VulnerabilityInfo(
+            vuln_id="vuln-001",
+            vuln_type="local_admin",
+            target="dc01.contoso.local",
+            discovered_by="recon",
+            details={"username": "other_user", "domain": "contoso.local"},
+        )
+        state.discovered_vulnerabilities["vuln-001"] = vuln
+
+        # Check for admin (different user)
+        capabilities = state.check_golden_ticket_capability("admin", "contoso.local")
+
+        assert capabilities == []
+
+    def test_update_golden_ticket_capability_new(self) -> None:
+        """Test that update_golden_ticket_capability detects new capability."""
+        from ares.core.models import Host, SharedRedTeamState, VulnerabilityInfo
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add DC
+        dc_host = Host(
+            ip="192.168.58.10",
+            hostname="dc01.contoso.local",
+            is_dc=True,
+        )
+        state.all_hosts.append(dc_host)
+
+        # Add local_admin vulnerability
+        vuln = VulnerabilityInfo(
+            vuln_id="vuln-001",
+            vuln_type="local_admin",
+            target="dc01.contoso.local",
+            discovered_by="recon",
+            details={"username": "admin", "domain": "contoso.local"},
+        )
+        state.discovered_vulnerabilities["vuln-001"] = vuln
+
+        result = state.update_golden_ticket_capability("admin", "contoso.local", "recon")
+
+        assert result is True
+        assert "contoso.local:admin" in state.golden_ticket_capable_creds
+        assert len(state.golden_ticket_capable_creds["contoso.local:admin"]) == 1
+
+    def test_update_golden_ticket_capability_duplicate(self) -> None:
+        """Test that duplicate capability returns False."""
+        from ares.core.models import Host, SharedRedTeamState, VulnerabilityInfo
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add DC
+        dc_host = Host(
+            ip="192.168.58.10",
+            hostname="dc01.contoso.local",
+            is_dc=True,
+        )
+        state.all_hosts.append(dc_host)
+
+        # Add local_admin vulnerability
+        vuln = VulnerabilityInfo(
+            vuln_id="vuln-001",
+            vuln_type="local_admin",
+            target="dc01.contoso.local",
+            discovered_by="recon",
+            details={"username": "admin", "domain": "contoso.local"},
+        )
+        state.discovered_vulnerabilities["vuln-001"] = vuln
+
+        # First call - should return True
+        result1 = state.update_golden_ticket_capability("admin", "contoso.local", "recon")
+        assert result1 is True
+
+        # Second call - should return False (already tracked)
+        result2 = state.update_golden_ticket_capability("admin", "contoso.local", "recon")
+        assert result2 is False
+
+    def test_get_golden_ticket_capable_credentials(self) -> None:
+        """Test retrieving all golden ticket capable credentials."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Manually add some capabilities
+        state.golden_ticket_capable_creds = {
+            "contoso.local:admin": [
+                {
+                    "domain": "contoso.local",
+                    "reason": "local_admin_on_dc",
+                    "dc_host": "dc01",
+                    "dc_ip": "192.168.58.10",
+                }
+            ],
+            "fabrikam.local:svc_backup": [
+                {
+                    "domain": "fabrikam.local",
+                    "reason": "local_admin_on_dc",
+                    "dc_host": "dc02",
+                    "dc_ip": "192.168.58.20",
+                }
+            ],
+        }
+
+        result = state.get_golden_ticket_capable_credentials()
+
+        assert len(result) == 2
+        cred_keys = [r[0] for r in result]
+        assert "contoso.local:admin" in cred_keys
+        assert "fabrikam.local:svc_backup" in cred_keys
+
+    def test_domains_match_exact(self) -> None:
+        """Test _domains_match with exact match."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        assert state._domains_match("contoso.local", "contoso.local") is True
+        assert state._domains_match("contoso.local", "fabrikam.local") is False
+
+    def test_domains_match_netbios_to_fqdn(self) -> None:
+        """Test _domains_match resolves NetBIOS to FQDN."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.netbios_to_fqdn = {"contoso": "contoso.local"}
+
+        assert state._domains_match("contoso", "contoso.local") is True
+        assert state._domains_match("CONTOSO", "contoso.local") is True
+
+    def test_domains_match_prefix(self) -> None:
+        """Test _domains_match handles prefix matching."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # "north" should match "north.sevenkingdoms.local"
+        assert state._domains_match("north", "north.sevenkingdoms.local") is True
+        # But "north" should not match "south.sevenkingdoms.local"
+        assert state._domains_match("north", "south.sevenkingdoms.local") is False
+
+    def test_golden_ticket_capable_creds_field_default(self) -> None:
+        """Test golden_ticket_capable_creds field has empty dict default."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        assert state.golden_ticket_capable_creds == {}
+
+    def test_multiple_dc_capabilities(self) -> None:
+        """Test user with admin on multiple DCs gets multiple capabilities."""
+        from ares.core.models import Host, SharedRedTeamState, VulnerabilityInfo
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add two DCs
+        dc1 = Host(ip="192.168.58.10", hostname="dc01.contoso.local", is_dc=True)
+        dc2 = Host(ip="192.168.58.11", hostname="dc02.contoso.local", is_dc=True)
+        state.all_hosts.extend([dc1, dc2])
+
+        # Add local_admin on both DCs for same user
+        vuln1 = VulnerabilityInfo(
+            vuln_id="vuln-001",
+            vuln_type="local_admin",
+            target="dc01.contoso.local",
+            discovered_by="recon",
+            details={"username": "admin", "domain": "contoso.local"},
+        )
+        vuln2 = VulnerabilityInfo(
+            vuln_id="vuln-002",
+            vuln_type="local_admin",
+            target="dc02.contoso.local",
+            discovered_by="recon",
+            details={"username": "admin", "domain": "contoso.local"},
+        )
+        state.discovered_vulnerabilities["vuln-001"] = vuln1
+        state.discovered_vulnerabilities["vuln-002"] = vuln2
+
+        capabilities = state.check_golden_ticket_capability("admin", "contoso.local")
+
+        assert len(capabilities) == 2
+        dc_ips = {cap["dc_ip"] for cap in capabilities}
+        assert "192.168.58.10" in dc_ips
+        assert "192.168.58.11" in dc_ips

--- a/tests/core/test_state_backend.py
+++ b/tests/core/test_state_backend.py
@@ -1226,3 +1226,207 @@ class TestEvidenceValidationRedis:
         # Access via module to get the current deque (not the snapshot from import)
         assert len(ev_module._recent_results) == 1
         assert ev_module._recent_results[0].query_id == "q-0005"
+
+
+# ============================================================================
+# Golden Ticket Capability Backend Tests
+# ============================================================================
+
+
+class TestGoldenTicketCapabilityBackend:
+    """Tests for golden ticket capability credential persistence."""
+
+    @pytest.fixture
+    def mock_redis(self):
+        """Create a mock Redis client."""
+        mock = MagicMock()
+        mock.hset = AsyncMock(return_value=1)
+        mock.hget = AsyncMock(return_value=None)
+        mock.expire = AsyncMock()
+        return mock
+
+    @pytest.fixture
+    def backend(self, mock_redis):
+        """Create a backend instance with mocked Redis."""
+        return RedisStateBackend(mock_redis, "op-test-123")
+
+    @pytest.mark.asyncio
+    async def test_set_golden_ticket_capable_creds(self, backend, mock_redis):
+        """Test storing golden ticket capable credentials."""
+        creds = {
+            "contoso.local:admin": [
+                {
+                    "domain": "contoso.local",
+                    "reason": "local_admin_on_dc",
+                    "dc_host": "dc01.contoso.local",
+                    "dc_ip": "192.168.58.10",
+                }
+            ]
+        }
+
+        result = await backend.set_golden_ticket_capable_creds(creds)
+
+        assert result is True
+        mock_redis.hset.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_get_golden_ticket_capable_creds_empty(self, backend, mock_redis):
+        """Test getting golden ticket capable creds when empty."""
+        mock_redis.hget.return_value = None
+
+        result = await backend.get_golden_ticket_capable_creds()
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_get_golden_ticket_capable_creds_with_data(self, backend, mock_redis):
+        """Test getting golden ticket capable creds with stored data."""
+        stored_data = json.dumps(
+            {
+                "contoso.local:admin": [
+                    {
+                        "domain": "contoso.local",
+                        "reason": "local_admin_on_dc",
+                        "dc_host": "dc01",
+                        "dc_ip": "192.168.58.10",
+                    }
+                ]
+            }
+        )
+        mock_redis.hget.return_value = stored_data
+
+        result = await backend.get_golden_ticket_capable_creds()
+
+        assert "contoso.local:admin" in result
+        assert result["contoso.local:admin"][0]["reason"] == "local_admin_on_dc"
+
+    @pytest.mark.asyncio
+    async def test_add_golden_ticket_capable_cred(self, backend, mock_redis):
+        """Test adding a single golden ticket capable credential."""
+        # Mock existing empty state
+        mock_redis.hget.return_value = json.dumps({})
+
+        capabilities = [
+            {
+                "domain": "contoso.local",
+                "reason": "local_admin_on_dc",
+                "dc_host": "dc01",
+                "dc_ip": "192.168.58.10",
+            }
+        ]
+
+        result = await backend.add_golden_ticket_capable_cred("contoso.local:admin", capabilities)
+
+        assert result is True
+        mock_redis.hset.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_add_golden_ticket_capable_cred_to_existing(self, backend, mock_redis):
+        """Test adding to existing golden ticket capable credentials."""
+        # Mock existing data
+        existing = {
+            "contoso.local:admin": [
+                {
+                    "domain": "contoso.local",
+                    "reason": "local_admin_on_dc",
+                    "dc_host": "dc01",
+                    "dc_ip": "192.168.58.10",
+                }
+            ]
+        }
+        mock_redis.hget.return_value = json.dumps(existing)
+
+        new_capabilities = [
+            {
+                "domain": "fabrikam.local",
+                "reason": "local_admin_on_dc",
+                "dc_host": "dc02",
+                "dc_ip": "192.168.58.20",
+            }
+        ]
+
+        result = await backend.add_golden_ticket_capable_cred(
+            "fabrikam.local:svc_backup", new_capabilities
+        )
+
+        assert result is True
+        # Verify hset was called with both credentials
+        mock_redis.hset.assert_called()
+
+
+class TestSharedStateGoldenTicketCapabilityLoading:
+    """Tests for loading golden ticket capabilities from Redis backend."""
+
+    @pytest.mark.asyncio
+    async def test_load_golden_ticket_capable_creds_from_backend(self):
+        """Test loading golden ticket capable credentials from backend."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="op-test")
+
+        mock_backend = AsyncMock()
+        mock_backend.get_golden_tickets = AsyncMock(return_value=[])
+        mock_backend.get_adminsd_backdoors = AsyncMock(return_value=[])
+        mock_backend.get_acl_chains = AsyncMock(return_value=[])
+        mock_backend.get_gmsa_accounts = AsyncMock(return_value=[])
+        mock_backend.get_golden_ticket_capable_creds = AsyncMock(
+            return_value={
+                "contoso.local:admin": [
+                    {
+                        "domain": "contoso.local",
+                        "reason": "local_admin_on_dc",
+                        "dc_host": "dc01",
+                        "dc_ip": "192.168.58.10",
+                    }
+                ]
+            }
+        )
+
+        state.set_backend(mock_backend)
+        await state.load_persistence_tracking_from_backend()
+
+        assert "contoso.local:admin" in state.golden_ticket_capable_creds
+        assert len(state.golden_ticket_capable_creds["contoso.local:admin"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_load_golden_ticket_capable_creds_merges_existing(self):
+        """Test that loading merges with existing in-memory capabilities."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="op-test")
+
+        # Pre-populate with existing capability
+        state.golden_ticket_capable_creds = {
+            "contoso.local:admin": [
+                {
+                    "domain": "contoso.local",
+                    "reason": "local_admin_on_dc",
+                    "dc_host": "dc01",
+                    "dc_ip": "192.168.58.10",
+                }
+            ]
+        }
+
+        mock_backend = AsyncMock()
+        mock_backend.get_golden_tickets = AsyncMock(return_value=[])
+        mock_backend.get_adminsd_backdoors = AsyncMock(return_value=[])
+        mock_backend.get_acl_chains = AsyncMock(return_value=[])
+        mock_backend.get_gmsa_accounts = AsyncMock(return_value=[])
+        mock_backend.get_golden_ticket_capable_creds = AsyncMock(
+            return_value={
+                "contoso.local:admin": [
+                    {
+                        "domain": "contoso.local",
+                        "reason": "local_admin_on_dc",
+                        "dc_host": "dc02",  # Different DC
+                        "dc_ip": "192.168.58.11",
+                    }
+                ]
+            }
+        )
+
+        state.set_backend(mock_backend)
+        await state.load_persistence_tracking_from_backend()
+
+        # Should have both capabilities merged
+        assert len(state.golden_ticket_capable_creds["contoso.local:admin"]) == 2


### PR DESCRIPTION

**Key Changes:**

- Added golden ticket escalation support with new stop condition logic
- Introduced mutual exclusion config for stop_on_domain_admin and stop_on_golden_ticket
- Implemented robust golden ticket capability detection and persistence
- Removed user-centric loot summary CLI and report code

**Added:**

- New config option `stop_on_golden_ticket` with mutual exclusion validation against
  `stop_on_domain_admin` (config file, env var, and runtime validation)
- Golden ticket escalation logic: orchestrator and dispatcher now handle
  stopping operation after golden ticket is forged (for forest escalation)
- Comprehensive golden ticket capability tracking in shared state, including
  detection when credentials have local admin on DCs and persistence in Redis
- Helper functions and backend methods for reading, writing, and merging
  golden ticket capability metadata

**Changed:**

- Dispatcher and publishing pipeline to update and checkpoint golden ticket
  capabilities whenever relevant credentials, vulnerabilities, or DCs are
  discovered
- Orchestrator agent hooks to respect new stop_on_golden_ticket setting and
  only stop on domain admin or golden ticket as configured
- Unit tests for config, orchestrator hooks, shared state, and backend to cover
  all new escalation and capability scenarios, including mutual exclusion logic
- `OperationConfig` and related config helpers to enforce and expose new stop
  condition and validation error
- Refactored agent factory logic to handle both escalation modes and prevent
  simultaneous triggering

**Removed:**

- User-centric loot summary CLI command and all related reporting logic
  (`loot-users` command and `ares.reports.user_summary`)
- All related tests for the removed user summary reporting features
- Exports of user summary functions and classes from the reports package