### PR TITLE
feat: add red team operation context to blue agent investigations

### DIFF
--- a/.taskfiles/blue/Taskfile.yaml
+++ b/.taskfiles/blue/Taskfile.yaml
@@ -106,9 +106,11 @@ tasks:
           2>&1 | tee -a "$LOGFILE"
 
   once:
-    desc: "Run blue team agent once and exit (uses 1Password for API keys)"
+    desc: "Run blue team agent once and exit (usage: task blue:once [OPERATION_ID=op-xxx] [LATEST=true])"
     silent: true
     vars:
+      OPERATION_ID: '{{.OPERATION_ID | default ""}}'
+      LATEST: '{{.LATEST | default ""}}'
       ANTHROPIC_API_KEY:
         sh: op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
       DREADNODE_API_KEY:
@@ -142,6 +144,14 @@ tasks:
         LOGFILE="{{.LOG_DIR}}/blue-$(date +%Y%m%d-%H%M%S).log"
         echo "Logging to: $LOGFILE"
 
+        # Build operation context args
+        OP_ARGS=""
+        if [ "{{.LATEST}}" = "true" ]; then
+          OP_ARGS="--args.latest"
+        elif [ -n "{{.OPERATION_ID}}" ]; then
+          OP_ARGS="--args.operation-id {{.OPERATION_ID}}"
+        fi
+
         uv run python -m ares \
           --args.model "{{.MODEL_ARG}}" \
           --args.grafana-url {{.GRAFANA_URL}} \
@@ -149,6 +159,7 @@ tasks:
           --args.max-steps {{.MAX_STEPS_BLUE_ONCE}} \
           --args.report-dir {{.REPORT_DIR}} \
           --args.once \
+          $OP_ARGS \
           --dn-args.server {{.DREADNODE_SERVER_URL}} \
           --dn-args.token "$DREADNODE_API_KEY" \
           --dn-args.organization {{.DREADNODE_ORGANIZATION}} \
@@ -157,9 +168,11 @@ tasks:
           2>&1 | tee -a "$LOGFILE"
 
   once:local:
-    desc: "Run blue team agent once and exit using .env file"
+    desc: "Run blue team agent once and exit using .env file (usage: task blue:once:local [OPERATION_ID=op-xxx] [LATEST=true])"
     silent: true
     vars:
+      OPERATION_ID: '{{.OPERATION_ID | default ""}}'
+      LATEST: '{{.LATEST | default ""}}'
       MODEL_ARG:
         sh: |
           if [ -n "{{.MODEL_ALL}}" ]; then
@@ -187,6 +200,14 @@ tasks:
         LOGFILE="{{.LOG_DIR}}/blue-$(date +%Y%m%d-%H%M%S).log"
         echo "Logging to: $LOGFILE"
 
+        # Build operation context args
+        OP_ARGS=""
+        if [ "{{.LATEST}}" = "true" ]; then
+          OP_ARGS="--args.latest"
+        elif [ -n "{{.OPERATION_ID}}" ]; then
+          OP_ARGS="--args.operation-id {{.OPERATION_ID}}"
+        fi
+
         uv run python -m ares \
           --args.model "{{.MODEL_ARG}}" \
           --args.grafana-url {{.GRAFANA_URL}} \
@@ -194,6 +215,7 @@ tasks:
           --args.max-steps {{.MAX_STEPS_BLUE_ONCE}} \
           --args.report-dir {{.REPORT_DIR}} \
           --args.once \
+          $OP_ARGS \
           --dn-args.server {{.DREADNODE_SERVER_URL}} \
           --dn-args.organization {{.DREADNODE_ORGANIZATION}} \
           --dn-args.workspace {{.DREADNODE_WORKSPACE}} \
@@ -280,6 +302,88 @@ tasks:
         else
           echo "No reports found in {{.REPORT_DIR}}"
         fi
+
+  playbook:
+    desc: "Export detection playbook from red team operation (usage: task blue:playbook [OPERATION_ID=op-xxx] [LATEST=true])"
+    silent: true
+    vars:
+      OPERATION_ID: '{{.OPERATION_ID | default ""}}'
+      LATEST: '{{.LATEST | default ""}}'
+      OUTPUT_DIR: '{{.OUTPUT_DIR | default "./reports"}}'
+      JSON: '{{.JSON | default "false"}}'
+    preconditions:
+      - sh: test -n "{{.OPERATION_ID}}" || test "{{.LATEST}}" = "true"
+        msg: "Either OPERATION_ID or LATEST=true is required. Usage: task blue:playbook OPERATION_ID=op-xxx  OR  task blue:playbook LATEST=true"
+    cmds:
+      - cmd: mkdir -p "{{.OUTPUT_DIR}}"
+        silent: true
+      - |
+        LATEST_FLAG=""
+        if [ "{{.LATEST}}" = "true" ]; then
+          LATEST_FLAG="--latest"
+        fi
+        OP_ID_ARG=""
+        if [ -n "{{.OPERATION_ID}}" ]; then
+          OP_ID_ARG="{{.OPERATION_ID}}"
+        fi
+        JSON_FLAG=""
+        if [ "{{.JSON}}" = "true" ]; then
+          JSON_FLAG="--json-output"
+        fi
+        kubectl exec -i -n {{.K8S_NAMESPACE}} deploy/ares-orchestrator -- python -m ares.cli_ops export-detection $OP_ID_ARG $LATEST_FLAG $JSON_FLAG --output-dir /tmp/reports
+
+        # Get the operation ID if we used --latest
+        if [ -n "$LATEST_FLAG" ]; then
+          RESOLVED_OP_ID=$(kubectl exec -i -n {{.K8S_NAMESPACE}} deploy/ares-orchestrator -- python -m ares.cli_ops list --latest 2>/dev/null | tr -d '\n')
+        else
+          RESOLVED_OP_ID="{{.OPERATION_ID}}"
+        fi
+
+        # Copy playbook files from pod to local machine
+        if [ -n "$RESOLVED_OP_ID" ]; then
+          ORCH_POD=$(kubectl get pods -n {{.K8S_NAMESPACE}} -l app.kubernetes.io/name=ares-orchestrator -o jsonpath='{.items[0].metadata.name}')
+          kubectl cp "{{.K8S_NAMESPACE}}/${ORCH_POD}:/tmp/reports/${RESOLVED_OP_ID}_detection_playbook.json" "{{.OUTPUT_DIR}}/${RESOLVED_OP_ID}_detection_playbook.json" 2>/dev/null || true
+          kubectl cp "{{.K8S_NAMESPACE}}/${ORCH_POD}:/tmp/reports/${RESOLVED_OP_ID}_detection_playbook.md" "{{.OUTPUT_DIR}}/${RESOLVED_OP_ID}_detection_playbook.md" 2>/dev/null || true
+          if [ -f "{{.OUTPUT_DIR}}/${RESOLVED_OP_ID}_detection_playbook.json" ]; then
+            echo "Detection playbook saved to: {{.OUTPUT_DIR}}/${RESOLVED_OP_ID}_detection_playbook.json"
+            echo "Detection playbook saved to: {{.OUTPUT_DIR}}/${RESOLVED_OP_ID}_detection_playbook.md"
+          fi
+        fi
+
+  playbook:local:
+    desc: "Export detection playbook locally using .env file (usage: task blue:playbook:local [OPERATION_ID=op-xxx] [LATEST=true])"
+    silent: true
+    vars:
+      OPERATION_ID: '{{.OPERATION_ID | default ""}}'
+      LATEST: '{{.LATEST | default ""}}'
+      OUTPUT_DIR: '{{.OUTPUT_DIR | default "./reports"}}'
+      JSON: '{{.JSON | default "false"}}'
+    preconditions:
+      - sh: test -f .env
+        msg: ".env file not found"
+      - sh: test -n "{{.OPERATION_ID}}" || test "{{.LATEST}}" = "true"
+        msg: "Either OPERATION_ID or LATEST=true is required. Usage: task blue:playbook:local OPERATION_ID=op-xxx  OR  task blue:playbook:local LATEST=true"
+    cmds:
+      - cmd: mkdir -p "{{.OUTPUT_DIR}}"
+        silent: true
+      - |
+        set -a
+        . ./.env
+        set +a
+
+        LATEST_FLAG=""
+        if [ "{{.LATEST}}" = "true" ]; then
+          LATEST_FLAG="--latest"
+        fi
+        OP_ID_ARG=""
+        if [ -n "{{.OPERATION_ID}}" ]; then
+          OP_ID_ARG="{{.OPERATION_ID}}"
+        fi
+        JSON_FLAG=""
+        if [ "{{.JSON}}" = "true" ]; then
+          JSON_FLAG="--json-output"
+        fi
+        uv run python -m ares.cli_ops export-detection $OP_ID_ARG $LATEST_FLAG $JSON_FLAG --output-dir "{{.OUTPUT_DIR}}"
 
   reports:consolidate:
     desc: Generate a consolidated report from all investigation reports in a directory

--- a/src/ares/agents/blue/soc_investigator.py
+++ b/src/ares/agents/blue/soc_investigator.py
@@ -84,11 +84,13 @@ class WatchdogTimer:
         logger.debug("Watchdog cancelled")
 
 
-def build_initial_prompt(alert: dict) -> str:
+def build_initial_prompt(alert: dict, attack_context: dict | None = None) -> str:
     """Build the initial prompt with alert context.
 
     Args:
         alert: Alert dictionary from Grafana Alertmanager.
+        attack_context: Optional red team operation context for focused hunting.
+            Contains attack_window_start, attack_window_end, techniques_used, etc.
 
     Returns:
         Formatted prompt string for agent initialization.
@@ -120,6 +122,35 @@ def build_initial_prompt(alert: dict) -> str:
     # Current time for reference
     current_time = datetime.now(timezone.utc)
 
+    # Build attack context for template
+    attack_window_start = None
+    attack_window_end = None
+    techniques_used = []
+    priority_queries = []
+    operation_id = None
+
+    if attack_context:
+        operation_id = attack_context.get("operation_id")
+        if attack_context.get("attack_window_start"):
+            attack_window_start = (
+                attack_context["attack_window_start"].isoformat().replace("+00:00", "Z")
+            )
+        if attack_context.get("attack_window_end"):
+            attack_window_end = (
+                attack_context["attack_window_end"].isoformat().replace("+00:00", "Z")
+            )
+        techniques_used = attack_context.get("techniques_used", [])
+        # Convert priority queries to serializable format
+        priority_queries = [
+            {
+                "technique_id": q.technique_id,
+                "description": q.description,
+                "query": q.logql,
+                "priority": q.priority,
+            }
+            for q in attack_context.get("priority_queries", [])
+        ]
+
     loader = get_template_loader()
     return loader.render(
         "agent/initial_alert_prompt.md.jinja",
@@ -139,6 +170,12 @@ def build_initial_prompt(alert: dict) -> str:
         current_time_minus_2h=(current_time - timedelta(hours=2))
         .isoformat()
         .replace("+00:00", "Z"),
+        # Red team operation context
+        operation_id=operation_id,
+        attack_window_start=attack_window_start,
+        attack_window_end=attack_window_end,
+        techniques_used=techniques_used,
+        priority_queries=priority_queries,
     )
 
 
@@ -154,6 +191,7 @@ class InvestigationOrchestrator:
         mitre_client: Client for MITRE ATT&CK data lookups.
         report_dir: Directory path for generated reports.
         max_steps: Maximum number of agent steps per investigation.
+        attack_context: Optional red team operation context for focused hunting.
     """
 
     def __init__(
@@ -164,6 +202,7 @@ class InvestigationOrchestrator:
         mitre_client: MITREAttackClient,
         report_dir: Path,
         max_steps: int = 30,
+        attack_context: dict | None = None,
     ):
         self.model = model
         self.grafana_url = grafana_url
@@ -171,6 +210,7 @@ class InvestigationOrchestrator:
         self.mitre_client = mitre_client
         self.report_dir = report_dir
         self.max_steps = max_steps
+        self.attack_context = attack_context
         self._mcp_client = None
         self._mcp_tools = None
         # Grafana tools for annotations
@@ -310,7 +350,7 @@ class InvestigationOrchestrator:
 
             self._create_alert_timeline_event(state, alert)
 
-            initial_prompt = build_initial_prompt(alert)
+            initial_prompt = build_initial_prompt(alert, self.attack_context)
 
             with dn.run(tags=["soc-investigation", alert_name]):
                 dn.log_params(

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -43,6 +43,9 @@ class Args:
         max_steps: Maximum agent steps per investigation.
         report_dir: Directory for markdown reports.
         once: Process current alerts once and exit (default: run forever).
+        operation_id: Red team operation ID to focus investigation on.
+        latest: Use the latest red team operation (prefer running).
+        redis_url: Redis URL for loading red team operation state.
     """
 
     model: str = ""
@@ -52,6 +55,9 @@ class Args:
     max_steps: int = 150
     report_dir: str = "./reports"  # Relative to CWD
     once: bool = False  # Process current alerts once and exit
+    operation_id: str = ""  # Red team operation to focus on
+    latest: bool = False  # Use latest red team operation
+    redis_url: str = ""  # Redis URL for red team state
 
 
 @dataclass
@@ -176,6 +182,68 @@ async def main(
     tactics_count = len(mitre_client._tactics)
     logger.success(f"Loaded {techniques_count} techniques, {tactics_count} tactics")
 
+    # Load red team operation context if specified
+    attack_context = None
+    if args.operation_id or args.latest:
+        from ares.core.config import get_redis_url
+        from ares.core.redis_client import create_verified_redis_client
+        from ares.eval.detection_playbook import create_detection_playbook
+
+        redis_url = args.redis_url or get_redis_url()
+        logger.info("Loading red team operation context from Redis...")
+
+        try:
+            client = await create_verified_redis_client(redis_url, decode_responses=False)
+
+            # Resolve operation ID
+            operation_id = args.operation_id
+            if args.latest and not operation_id:
+                # Find latest operation
+                meta_keys = await client.keys("ares:op:*:meta")
+                if meta_keys:
+                    latest_op = None
+                    for key in meta_keys:
+                        key_str = key.decode() if isinstance(key, bytes) else key
+                        parts = key_str.split(":")
+                        if len(parts) >= 3:
+                            op_id = parts[2]
+                            if not latest_op or op_id > latest_op:
+                                latest_op = op_id
+                    if latest_op:
+                        operation_id = latest_op
+
+            if operation_id:
+                from ares.cli_ops import _load_state_from_redis
+
+                state = await _load_state_from_redis(client, operation_id)
+                if state:
+                    playbook = create_detection_playbook(state)
+                    attack_context = {
+                        "operation_id": operation_id,
+                        "playbook": playbook,
+                        "attack_window_start": playbook.attack_window_start,
+                        "attack_window_end": playbook.attack_window_end,
+                        "techniques_used": playbook.techniques_used,
+                        "priority_queries": playbook.priority_queries[:10],
+                        "detection_targets": playbook.detection_targets[:20],
+                    }
+                    logger.success(f"Loaded red team operation: {operation_id}")
+                    logger.info(
+                        f"Attack window: {playbook.attack_window_start.strftime('%Y-%m-%d %H:%M')} "
+                        f"to {playbook.attack_window_end.strftime('%Y-%m-%d %H:%M')}"
+                    )
+                    logger.info(f"Techniques used: {len(playbook.techniques_used)}")
+                    logger.info(f"Priority queries: {len(playbook.priority_queries)}")
+                else:
+                    logger.warning(f"No state found for operation: {operation_id}")
+            else:
+                logger.warning("No red team operations found in Redis")
+
+            await client.aclose()
+        except Exception as e:
+            logger.warning(f"Failed to load red team operation: {e}")
+            logger.warning("Continuing without attack context")
+
     report_dir = Path(args.report_dir).resolve()
     report_dir.mkdir(parents=True, exist_ok=True)
     logger.info(f"Reports: {report_dir}")
@@ -187,6 +255,7 @@ async def main(
         mitre_client=mitre_client,
         report_dir=report_dir,
         max_steps=args.max_steps,
+        attack_context=attack_context,
     )
 
     grafana = GrafanaTools(

--- a/src/ares/templates/agent/initial_alert_prompt.md.jinja
+++ b/src/ares/templates/agent/initial_alert_prompt.md.jinja
@@ -72,6 +72,43 @@ These are HIGH PRIORITY and must be investigated to understand the full attack c
 
 ## 🚨 CRITICAL: USE THESE EXACT TIME VALUES 🚨
 
+{% if attack_window_start and attack_window_end %}
+## 🎯 RED TEAM OPERATION CONTEXT - FOCUSED HUNTING MODE 🎯
+
+**You are investigating a KNOWN red team operation: {{ operation_id }}**
+
+**ATTACK WINDOW**: {{ attack_window_start }} to {{ attack_window_end }}
+**FOCUS YOUR QUERIES ON THIS WINDOW** - The red team was active during this time.
+
+{% if techniques_used %}
+### Known Techniques Used by Red Team
+The following MITRE ATT&CK techniques were used in this operation:
+{% for tech in techniques_used %}
+- **{{ tech }}**
+{% endfor %}
+
+**HUNT FOR EVIDENCE OF THESE SPECIFIC TECHNIQUES**
+{% endif %}
+
+{% if priority_queries %}
+### Priority Detection Queries
+These queries are tailored to detect the specific attack activity:
+{% for q in priority_queries[:5] %}
+**[{{ q.priority | upper }}] {{ q.technique_id }}**: {{ q.description }}
+```
+{{ q.query }}
+```
+{% endfor %}
+{% endif %}
+
+**Investigation Strategy:**
+1. Focus queries on the attack window: {{ attack_window_start }} to {{ attack_window_end }}
+2. Look for evidence of the known techniques listed above
+3. Use the priority queries as starting points
+4. Correlate findings with expected red team activity
+
+---
+{% else %}
 **CURRENT TIME**: {{ current_time }}
 **QUERY START (1h ago)**: {{ current_time_minus_1h }}
 **QUERY START (2h ago)**: {{ current_time_minus_2h }}
@@ -79,6 +116,7 @@ These are HIGH PRIORITY and must be investigated to understand the full attack c
 The alert's `startsAt` ({{ starts_at }}) may be HOURS or DAYS old.
 **DO NOT** query around the alert timestamp.
 **DO** query from {{ current_time_minus_2h }} to {{ current_time }}.
+{% endif %}
 
 ---
 

--- a/src/ares/tools/blue/grafana.py
+++ b/src/ares/tools/blue/grafana.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import subprocess  # nosec B404
 from pathlib import Path
-from typing import Any, Self, cast
+from typing import Any
 
 import dreadnode as dn
 import httpx
@@ -53,24 +53,16 @@ atexit.register(_cleanup_mcp_pool)
 
 
 class MCPConnectionPool:
-    """Singleton connection pool for MCP client reuse across investigations.
+    """Connection pool for MCP client reuse across investigations.
 
     This eliminates the 60-second connection overhead per investigation
-    by reusing the same MCP client connection.
+    by reusing the same MCP client connection. All state is class-level.
     """
 
-    _instance: "MCPConnectionPool | None" = None
     _client: Any = None
     _lock: asyncio.Lock | None = None
     _grafana_url: str | None = None
     _grafana_api_key: str | None = None
-
-    def __new__(cls) -> Self:
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-            # Don't create asyncio.Lock here - it's event-loop-specific
-            # and must be created in the async context where it's used
-        return cast("Self", cls._instance)
 
     @classmethod
     async def get_client(


### PR DESCRIPTION


**Key Changes:**

- Enabled blue agent to focus investigations using red team operation context
- Added Taskfile commands to export detection playbooks for targeted hunting
- Enhanced agent prompts with attack window, techniques, and priority queries

**Added:**

- Red team operation context loading in blue agent - Main process can now accept
  `--args.operation-id`, `--args.latest`, and `--args.redis-url` to pull
  operation state from Redis and pass attack context to investigations
- New `playbook` and `playbook:local` Taskfile commands to export detection
  playbooks for a given operation, supporting both cluster and local modes with
  usage instructions and flexible output options
- Attack context variables and logic in `build_initial_prompt` and
  `InvestigationOrchestrator` to inject focused hunting instructions and
  data into agent initialization and templates

**Changed:**

- Enhanced agent prompt template to include a "Focused Hunting Mode" section
  when attack context is present, listing attack window, techniques, and
  priority queries, with investigator strategy guidance
- Updated `blue:once` and `blue:once:local` Taskfile commands to accept
  `OPERATION_ID` and `LATEST` arguments, passing them to the agent and
  dynamically constructing CLI arguments for operation context
- Modified `MCPConnectionPool` to simplify singleton logic and class docstring

**Removed:**

- Singleton instance tracking in `MCPConnectionPool` class, relying on
  class-level state instead