### PR TITLE
refactor: move escalate_investigation to CompletionTools and improve tool evidence extraction

### DIFF
--- a/src/ares/core/factories/blue_factory.py
+++ b/src/ares/core/factories/blue_factory.py
@@ -38,7 +38,6 @@ from ares.tools.blue import (
     LearningTools,
     QueryTemplateTools,
     QuestionEngineTools,
-    escalate_investigation,
 )
 from ares.tools.shared import MITRELookupTools
 
@@ -539,6 +538,74 @@ def _check_credential_dumping_evidence(state: "InvestigationState", result_data:
         )
 
 
+def _extract_tool_evidence(state: "InvestigationState", result_data: dict) -> None:
+    """Extract attacker tool evidence from query metadata (Pyramid Level 5).
+
+    Query templates set `_red_team_tool` or `_red_team_tools` metadata when
+    they detect specific attacker tools. This function extracts those tools
+    and records them as evidence at Pyramid Level 5 (Tools).
+
+    Args:
+        state: Current investigation state
+        result_data: Query result containing tool metadata
+    """
+    if not state or not result_data:
+        return
+
+    # Get tool(s) from metadata
+    tools: list[str] = []
+    if result_data.get("_red_team_tool"):
+        tools.append(result_data["_red_team_tool"])
+    if result_data.get("_red_team_tools"):
+        tools.extend(result_data["_red_team_tools"])
+
+    if not tools:
+        return
+
+    # Get MITRE technique for association
+    mitre_technique = result_data.get("_mitre_technique", "")
+    mitre_techniques_list = result_data.get("_mitre_techniques", [])
+    if mitre_technique and mitre_technique not in mitre_techniques_list:
+        mitre_techniques_list = [mitre_technique] + mitre_techniques_list
+
+    query_template = result_data.get("_query_template", "unknown_detection")
+
+    # Check existing tool evidence to avoid duplicates
+    existing_tools = {
+        e.value for e in state.evidence if e.type == "tool" and e.pyramid_level.value == 5
+    }
+
+    added_count = 0
+    for tool_name in tools:
+        if tool_name in existing_tools:
+            continue
+
+        evidence = Evidence(
+            id=f"tool-{uuid.uuid4().hex[:8]}",
+            type="tool",
+            value=tool_name,
+            source=f"Auto-extracted from {query_template} detection",
+            timestamp=None,
+            pyramid_level=PyramidLevel(5),  # Tools are Level 5
+            mitre_techniques=mitre_techniques_list[:3],  # Limit to top 3
+            confidence=0.85,  # High confidence since detected by query template
+            validated=True,
+        )
+        state.evidence.append(evidence)
+        existing_tools.add(tool_name)
+        added_count += 1
+
+        # Track techniques from tool detection
+        for tech in mitre_techniques_list[:3]:
+            state.identified_techniques.add(tech)
+
+    if added_count > 0:
+        logger.info(
+            f"🔧 Auto-extracted {added_count} tool(s) from query metadata: "
+            f"{', '.join(tools)} (Pyramid Level 5)"
+        )
+
+
 def _optimize_logql_query(query: str) -> tuple[str, bool]:
     """Optimize a LogQL query by rewriting broad selectors to prevent timeouts.
 
@@ -886,6 +953,10 @@ def _record_query(
             # T1003 CREDENTIAL DUMPING ORCHESTRATION: When any T1003 detected, check all variants
             if result_data and isinstance(result_data, dict):
                 _check_credential_dumping_evidence(_current_state, result_data)
+
+            # TOOL EXTRACTION: Auto-extract attacker tools from query metadata (Pyramid Level 5)
+            if result_data and isinstance(result_data, dict):
+                _extract_tool_evidence(_current_state, result_data)
 
             # Track executed query type for deduplication
             _current_state.executed_query_types.add(tool_name)
@@ -1452,6 +1523,7 @@ def create_investigation_agent(
     # to reduce context window usage (~35 tools → 4 tools).
     # The dispatcher run_detection_query() internally calls any detect_* method,
     # preserving dn.log_metric() observability on each detection query.
+    # Note: escalate_investigation is now a method on CompletionTools (completion_tools).
     tools: list = [
         grafana_tools,
         investigation_tools,
@@ -1463,7 +1535,6 @@ def create_investigation_agent(
         query_template_tools.get_host_activity,
         query_template_tools.get_user_activity,
         learning_tools,
-        escalate_investigation,
     ]
 
     if grafana_mcp_tools:

--- a/src/ares/tools/blue/__init__.py
+++ b/src/ares/tools/blue/__init__.py
@@ -13,12 +13,10 @@ __all__ = [
     "QueryTemplateTools",
     "QuestionEngineTools",
     "connect_grafana_mcp",
-    "escalate_investigation",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "CompletionTools": ("ares.tools.blue.actions", "CompletionTools"),
-    "escalate_investigation": ("ares.tools.blue.actions", "escalate_investigation"),
     "GrafanaTools": ("ares.tools.blue.grafana", "GrafanaTools"),
     "connect_grafana_mcp": ("ares.tools.blue.grafana", "connect_grafana_mcp"),
     "InvestigationTools": ("ares.tools.blue.investigation", "InvestigationTools"),

--- a/src/ares/tools/blue/actions.py
+++ b/src/ares/tools/blue/actions.py
@@ -29,6 +29,105 @@ class CompletionTools(Toolset):  # type: ignore[misc]
         self.state = state
 
     @dn.tool_method  # type: ignore[untyped-decorator]
+    async def escalate_investigation(
+        self,
+        reason: str,
+        severity: str,
+        current_findings: str,
+        immediate_actions: list[str],
+    ) -> str:
+        """Escalate the investigation for human analyst review.
+
+        Call this if:
+        - You identify an active, ongoing attack
+        - The scope exceeds investigation capacity
+        - You need human analyst intervention
+        - Critical infrastructure is at risk
+        - Domain Admin or Golden Ticket activity detected
+
+        Args:
+            reason: Why escalation is needed.
+            severity: critical, high, or medium.
+            current_findings: Summary of what you've found so far.
+            immediate_actions: Actions that should be taken immediately.
+
+        Returns:
+            Confirmation message.
+
+        Example:
+            >>> await escalate_investigation(
+            ...     reason="Active lateral movement detected across 15+ hosts",
+            ...     severity="critical",
+            ...     current_findings="Attacker has Domain Admin credentials and is actively "
+            ...                      "exfiltrating data from file servers.",
+            ...     immediate_actions=[
+            ...         "Isolate compromised domain controller",
+            ...         "Reset all privileged account passwords",
+            ...         "Block C2 IP addresses at firewall"
+            ...     ]
+            ... )
+            'Investigation escalated with severity=critical. Human analyst notified.'
+
+        See Also:
+            complete_investigation: For normal investigation completion.
+        """
+        if not self.state:
+            return "ERROR: No investigation state. Cannot escalate."
+
+        # Set escalation flags on state - THIS IS CRITICAL for report status
+        self.state.escalated = True
+        self.state.escalation_reason = reason
+
+        # Add immediate actions as recommendations
+        if immediate_actions:
+            self.state.recommendations.extend(immediate_actions)
+
+        dn.log_metric("investigation_escalated", 1)
+        dn.tag(f"escalation:{severity}")
+        dn.tag("needs_human_review")
+
+        dn.log_output(
+            "escalation",
+            {
+                "reason": reason,
+                "severity": severity,
+                "findings": current_findings,
+                "immediate_actions": immediate_actions,
+                "escalated_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+        logger.warning(f"Investigation ESCALATED: {reason}")
+
+        # Build formatted escalation output
+        severity_upper = severity.upper()
+        severity_tag = f"[{severity_upper}]"
+
+        lines = [
+            f"⚠️ INVESTIGATION ESCALATED {severity_tag}",
+            SECTION_SEPARATOR,
+            "",
+            "🚨 Escalation Details:",
+            f"  Reason: {reason}",
+            f"  Severity: {severity}",
+            "",
+            "📋 Current Findings:",
+            f"  {current_findings[:200]}{'...' if len(current_findings) > 200 else ''}",
+            "",
+        ]
+
+        if immediate_actions:
+            lines.append("🔥 Immediate Actions Required:")
+            for i, action in enumerate(immediate_actions[:5], 1):
+                lines.append(f"  {i}. {action}")
+            lines.append("")
+
+        lines.append("→ Human analyst has been notified.")
+        lines.append("→ Investigation marked as ESCALATED.")
+
+        return "\n".join(lines)
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
     async def complete_investigation(
         self,
         summary: str,
@@ -325,89 +424,3 @@ class CompletionTools(Toolset):  # type: ignore[misc]
             parts.append(f"  - Validated evidence: {validated_count}/{len(self.state.evidence)}")
 
         self.state.attack_synopsis = "\n".join(parts)
-
-
-@dn.tool  # type: ignore[untyped-decorator]
-async def escalate_investigation(
-    reason: str,
-    severity: str,
-    current_findings: str,
-    immediate_actions: list[str],
-) -> str:
-    """Escalate the investigation for human analyst review.
-
-    Call this if:
-    - You identify an active, ongoing attack
-    - The scope exceeds investigation capacity
-    - You need human analyst intervention
-    - Critical infrastructure is at risk
-
-    Args:
-        reason: Why escalation is needed.
-        severity: critical, high, or medium.
-        current_findings: Summary of what you've found so far.
-        immediate_actions: Actions that should be taken immediately.
-
-    Returns:
-        Confirmation message.
-
-    Example:
-        >>> await escalate_investigation(
-        ...     reason="Active lateral movement detected across 15+ hosts",
-        ...     severity="critical",
-        ...     current_findings="Attacker has Domain Admin credentials and is actively "
-        ...                      "exfiltrating data from file servers.",
-        ...     immediate_actions=[
-        ...         "Isolate compromised domain controller",
-        ...         "Reset all privileged account passwords",
-        ...         "Block C2 IP addresses at firewall"
-        ...     ]
-        ... )
-        'Investigation escalated with severity=critical. Human analyst notified.'
-
-    See Also:
-        complete_investigation: For normal investigation completion.
-    """
-    dn.log_metric("investigation_escalated", 1)
-    dn.tag(f"escalation:{severity}")
-    dn.tag("needs_human_review")
-
-    dn.log_output(
-        "escalation",
-        {
-            "reason": reason,
-            "severity": severity,
-            "findings": current_findings,
-            "immediate_actions": immediate_actions,
-            "escalated_at": datetime.now(timezone.utc).isoformat(),
-        },
-    )
-
-    logger.info(f"Investigation escalated: {reason}")
-
-    # Build formatted escalation output
-    severity_upper = severity.upper()
-    severity_tag = f"[{severity_upper}]"
-
-    lines = [
-        f"⚠️ INVESTIGATION ESCALATED {severity_tag}",
-        SECTION_SEPARATOR,
-        "",
-        "🚨 Escalation Details:",
-        f"  Reason: {reason}",
-        f"  Severity: {severity}",
-        "",
-        "📋 Current Findings:",
-        f"  {current_findings[:200]}{'...' if len(current_findings) > 200 else ''}",
-        "",
-    ]
-
-    if immediate_actions:
-        lines.append("🔥 Immediate Actions Required:")
-        for i, action in enumerate(immediate_actions[:5], 1):
-            lines.append(f"  {i}. {action}")
-        lines.append("")
-
-    lines.append("→ Human analyst has been notified.")
-
-    return "\n".join(lines)

--- a/tests/tools/blue/test_actions.py
+++ b/tests/tools/blue/test_actions.py
@@ -12,7 +12,7 @@ from ares.core.models import (
     PyramidLevel,
     TimelineEvent,
 )
-from ares.tools.blue.actions import CompletionTools, escalate_investigation
+from ares.tools.blue.actions import CompletionTools
 
 
 class TestCompletionTools:
@@ -318,12 +318,35 @@ class TestGenerateFallbackSynopsis:
 
 
 class TestEscalateInvestigation:
-    """Tests for escalate_investigation function."""
+    """Tests for escalate_investigation method on CompletionTools."""
+
+    @pytest.fixture
+    def completion_tools_with_state(
+        self, investigation_state: InvestigationState
+    ) -> CompletionTools:
+        """Create CompletionTools instance with state set."""
+        tools = CompletionTools()
+        tools.set_state(investigation_state)
+        return tools
 
     @pytest.mark.asyncio
-    async def test_escalate_basic(self):
+    async def test_escalate_no_state(self):
+        """Test escalation without state returns error."""
+        tools = CompletionTools()
+        result = await tools.escalate_investigation(
+            reason="Test",
+            severity="high",
+            current_findings="Test",
+            immediate_actions=[],
+        )
+        assert "ERROR" in result
+
+    @pytest.mark.asyncio
+    async def test_escalate_basic(
+        self, completion_tools_with_state: CompletionTools, investigation_state: InvestigationState
+    ):
         """Test basic escalation."""
-        result = await escalate_investigation(
+        result = await completion_tools_with_state.escalate_investigation(
             reason="Active attack in progress",
             severity="critical",
             current_findings="Attacker has domain admin access",
@@ -331,11 +354,16 @@ class TestEscalateInvestigation:
         )
         assert "escalated" in result.lower()
         assert "critical" in result.lower()
+        # Verify state was updated
+        assert investigation_state.escalated is True
+        assert investigation_state.escalation_reason == "Active attack in progress"
 
     @pytest.mark.asyncio
-    async def test_escalate_high_severity(self):
+    async def test_escalate_high_severity(
+        self, completion_tools_with_state: CompletionTools, investigation_state: InvestigationState
+    ):
         """Test high severity escalation."""
-        result = await escalate_investigation(
+        result = await completion_tools_with_state.escalate_investigation(
             reason="Suspicious activity detected",
             severity="high",
             current_findings="Multiple failed login attempts",
@@ -343,11 +371,14 @@ class TestEscalateInvestigation:
         )
         assert "escalated" in result.lower()
         assert "high" in result.lower()
+        assert investigation_state.escalated is True
 
     @pytest.mark.asyncio
-    async def test_escalate_medium_severity(self):
+    async def test_escalate_medium_severity(
+        self, completion_tools_with_state: CompletionTools, investigation_state: InvestigationState
+    ):
         """Test medium severity escalation."""
-        result = await escalate_investigation(
+        result = await completion_tools_with_state.escalate_investigation(
             reason="Needs human review",
             severity="medium",
             current_findings="Uncertain about scope",
@@ -355,17 +386,35 @@ class TestEscalateInvestigation:
         )
         assert "escalated" in result.lower()
         assert "medium" in result.lower()
+        assert investigation_state.escalated is True
 
     @pytest.mark.asyncio
-    async def test_escalate_with_empty_actions(self):
+    async def test_escalate_with_empty_actions(
+        self, completion_tools_with_state: CompletionTools, investigation_state: InvestigationState
+    ):
         """Test escalation with empty actions list."""
-        result = await escalate_investigation(
+        result = await completion_tools_with_state.escalate_investigation(
             reason="Need help",
             severity="high",
             current_findings="Complex situation",
             immediate_actions=[],
         )
         assert "escalated" in result.lower()
+        assert investigation_state.escalated is True
+
+    @pytest.mark.asyncio
+    async def test_escalate_adds_immediate_actions_to_recommendations(
+        self, completion_tools_with_state: CompletionTools, investigation_state: InvestigationState
+    ):
+        """Test that immediate actions are added to recommendations."""
+        await completion_tools_with_state.escalate_investigation(
+            reason="DA detected",
+            severity="critical",
+            current_findings="krbtgt hash extracted",
+            immediate_actions=["Isolate DC", "Reset krbtgt twice"],
+        )
+        assert "Isolate DC" in investigation_state.recommendations
+        assert "Reset krbtgt twice" in investigation_state.recommendations
 
 
 class TestCompletionToolsEdgeCases:


### PR DESCRIPTION


**Key Changes:**

- Refactored escalate_investigation from a standalone function to a method of CompletionTools
- Improved auto-extraction of attacker tool evidence from query metadata at Pyramid Level 5
- Updated imports, exports, and test suite to reflect the new escalation method location

**Added:**

- Tool evidence extraction logic that records attacker tools detected by query templates as
  evidence at Pyramid Level 5, with MITRE technique association and deduplication
- Logger output for auto-extracted tool evidence for improved traceability

**Changed:**

- escalate_investigation is now an async method on CompletionTools, updating state directly
  and providing a formatted escalation output; removed the standalone function
- Updated blue_factory to call the new tool evidence extraction and use escalate_investigation
  as a method, not as a standalone tool
- Adjusted __all__ and lazy imports in blue/__init__.py to remove escalate_investigation export
- Refactored tests to use the new escalate_investigation method on CompletionTools, including
  new tests for state updates and recommendation handling

**Removed:**

- Standalone escalate_investigation function and its direct import/export patterns
- escalate_investigation from the blue toolset aggregation and public __all__ exports