### PR TITLE
feat: add automatic replay system initialization for orchestrator and worker

### DIFF
--- a/src/ares/core/config.py
+++ b/src/ares/core/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from loguru import logger
@@ -250,13 +250,13 @@ class OperationConfig:
 
     # Replay settings (for deterministic runs)
     # Mode: "record" to capture, "replay" to use cached, "" for off
-    replay_mode: str = ""
+    replay_mode: Literal["record", "replay", "off", ""] = ""
     # Path to JSONL file for recording/replay
     replay_file: str = ""
     # Seed for deterministic value generation (UUIDs, timestamps)
     replay_seed: int = 42
     # Behavior on cache miss in replay: "error", "live", "skip"
-    replay_fallback: str = "error"
+    replay_fallback: Literal["error", "live", "skip"] = "error"
 
 
 # Default config file locations (searched in order)
@@ -657,7 +657,7 @@ def _apply_env_overrides(config: OperationConfig) -> OperationConfig:
 
     # Replay overrides
     if replay_mode := os.environ.get("ARES_REPLAY_MODE"):
-        config.replay_mode = replay_mode.lower()
+        config.replay_mode = replay_mode.lower()  # type: ignore[assignment]
     if replay_file := os.environ.get("ARES_REPLAY_FILE"):
         config.replay_file = replay_file
     if replay_seed := os.environ.get("ARES_REPLAY_SEED"):
@@ -670,7 +670,7 @@ def _apply_env_overrides(config: OperationConfig) -> OperationConfig:
         "live",
         "skip",
     ):
-        config.replay_fallback = replay_fallback.lower()
+        config.replay_fallback = replay_fallback.lower()  # type: ignore[assignment]
 
     # Model overrides (Viper-style precedence: role-specific > orchestrator/worker > global)
     global_model = os.environ.get("ARES_MODEL")
@@ -1002,7 +1002,7 @@ def get_query_limits_by_stage() -> dict[str, int]:
     return load_config().query_limits_by_stage
 
 
-def get_replay_mode() -> str:
+def get_replay_mode() -> Literal["record", "replay", "off", ""]:
     """Get replay mode (record/replay/empty for off)."""
     return load_config().replay_mode
 
@@ -1017,7 +1017,7 @@ def get_replay_seed() -> int:
     return load_config().replay_seed
 
 
-def get_replay_fallback() -> str:
+def get_replay_fallback() -> Literal["error", "live", "skip"]:
     """Get replay fallback behavior (error/live/skip)."""
     return load_config().replay_fallback
 

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -610,6 +610,32 @@ async def run_multi_agent_operation(
 
     apply_rigging_patches()
 
+    # Initialize replay system if configured
+    from ares.core.config import (
+        get_replay_fallback,
+        get_replay_file,
+        get_replay_mode,
+        get_replay_seed,
+    )
+    from ares.core.replay import initialize_replay
+
+    replay_mode = get_replay_mode()
+    if replay_mode:
+        replay_file = get_replay_file()
+        if replay_file:
+            from pathlib import Path
+
+            base_path = Path(replay_file).parent
+            base_path.mkdir(parents=True, exist_ok=True)
+            replay_file = str(base_path / "orchestrator.jsonl")
+
+        initialize_replay(
+            mode=replay_mode,
+            path=replay_file,
+            seed=get_replay_seed(),
+            fallback=get_replay_fallback(),
+        )
+
     # Resolve max runtime from parameter, env, or default
     resolved_max_runtime = max_runtime if max_runtime is not None else get_max_runtime()
     # Resolve config defaults
@@ -993,6 +1019,10 @@ async def run_multi_agent_operation(
         raise
 
     finally:
+        from ares.core.replay import shutdown_replay
+
+        shutdown_replay()
+
         # Cleanup - cancel all tasks and suppress CancelledError
         for task in tasks:
             task.cancel()

--- a/src/ares/core/worker/_worker.py
+++ b/src/ares/core/worker/_worker.py
@@ -2132,6 +2132,33 @@ async def run_worker(
 
     configure_litellm_env()
 
+    # Initialize replay system if configured
+    from ares.core.config import (
+        get_replay_fallback,
+        get_replay_file,
+        get_replay_mode,
+        get_replay_seed,
+    )
+    from ares.core.replay import initialize_replay
+
+    replay_mode = get_replay_mode()
+    if replay_mode:
+        replay_file = get_replay_file()
+        if replay_file:
+            from pathlib import Path
+
+            base_path = Path(replay_file).parent
+            base_path.mkdir(parents=True, exist_ok=True)
+            # Per-role file to avoid conflicts between worker pods
+            replay_file = str(base_path / f"{role.value}.jsonl")
+
+        initialize_replay(
+            mode=replay_mode,
+            path=replay_file,
+            seed=get_replay_seed(),
+            fallback=get_replay_fallback(),
+        )
+
     # Resolve config defaults
     redis_url = redis_url or get_redis_url()
     resolved_model = (
@@ -2291,6 +2318,10 @@ async def run_worker(
             await worker.start()
             pointer_switched = worker.pointer_switched
         finally:
+            from ares.core.replay import shutdown_replay
+
+            shutdown_replay()
+
             if task_queue:
                 await task_queue.disconnect()
             await dispatcher.stop()
@@ -2306,6 +2337,10 @@ async def run_worker(
             )
             await asyncio.sleep(delay)
             operation_id = None
+            # Reset replay normalization context for new operation
+            from ares.core.replay.wrappers import reset_normalization_context
+
+            reset_normalization_context()
             continue
 
         break


### PR DESCRIPTION
**Key Changes:**

- Added automatic initialization and shutdown of the replay system in both
  orchestrator and worker runtimes
- Ensured replay file directories are created as needed before initialization
- Provided per-role replay files for workers to avoid conflicts
- Updated config typing for replay modes and fallback values for improved safety

**Added:**

- Replay system initialization and shutdown in orchestrator and worker entry
  points, calling `initialize_replay` and `shutdown_replay` at appropriate
  lifecycle moments
- Creation of replay file directories if they do not exist, ensuring robust
  file handling
- Per-role replay file naming for worker processes to prevent file conflicts
- Reset of replay normalization context when workers start a new operation

**Changed:**

- Updated type hints for replay-related config values to use `Literal` for
  allowed values, improving static type checking and clarity
- Modified config environment override logic to support new type hints and
  suppress mypy assignment errors where necessary
- Updated replay file assignment logic to ensure correct path handling