### PR TITLE
feat: add blue team context compaction and early exit for low/medium severity

### DIFF
--- a/src/ares/core/config.py
+++ b/src/ares/core/config.py
@@ -236,6 +236,24 @@ class OperationConfig:
         }
     )
 
+    # Blue team context compaction settings
+    # Maximum result entries to return from Loki queries (head + tail)
+    max_result_entries: int = 40
+    # Steps between context compaction (0 = disabled)
+    context_compaction_interval: int = 5
+    # Max evidence items before compaction triggers
+    max_evidence_before_compaction: int = 50
+    # Max timeline events before compaction triggers
+    max_timeline_before_compaction: int = 30
+
+    # Early exit for LOW/MEDIUM severity
+    # Minimum steps before early exit is allowed
+    low_medium_early_exit_min_steps: int = 8
+    # Minimum evidence count to allow early exit (if not met, need more queries)
+    low_medium_early_exit_min_evidence: int = 2
+    # Minimum queries for early exit when evidence is sparse
+    low_medium_early_exit_min_queries: int = 4
+
     # Phase detection thresholds (see PRIORITY.md)
     lateral_movement_admin_creds_threshold: int = 3
     lateral_movement_owned_hosts_threshold: int = 5
@@ -1002,6 +1020,41 @@ def get_query_limits_by_stage() -> dict[str, int]:
     return load_config().query_limits_by_stage
 
 
+def get_max_result_entries() -> int:
+    """Get max Loki result entries to return (head + tail entries kept)."""
+    return load_config().max_result_entries
+
+
+def get_context_compaction_interval() -> int:
+    """Get steps between context compaction (0 = disabled)."""
+    return load_config().context_compaction_interval
+
+
+def get_max_evidence_before_compaction() -> int:
+    """Get max evidence items before compaction triggers."""
+    return load_config().max_evidence_before_compaction
+
+
+def get_max_timeline_before_compaction() -> int:
+    """Get max timeline events before compaction triggers."""
+    return load_config().max_timeline_before_compaction
+
+
+def get_low_medium_early_exit_min_steps() -> int:
+    """Get minimum steps before early exit is allowed for LOW/MEDIUM severity."""
+    return load_config().low_medium_early_exit_min_steps
+
+
+def get_low_medium_early_exit_min_evidence() -> int:
+    """Get minimum evidence count to allow early exit for LOW/MEDIUM severity."""
+    return load_config().low_medium_early_exit_min_evidence
+
+
+def get_low_medium_early_exit_min_queries() -> int:
+    """Get minimum queries for early exit when evidence is sparse."""
+    return load_config().low_medium_early_exit_min_queries
+
+
 def get_replay_mode() -> Literal["record", "replay", "off", ""]:
     """Get replay mode (record/replay/empty for off)."""
     return load_config().replay_mode
@@ -1041,6 +1094,7 @@ __all__ = [
     "get_agent_task_timeout",
     "get_bonus_queries_for_evidence",
     "get_bonus_queries_for_pyramid_l4",
+    "get_context_compaction_interval",
     "get_crack_task_grace_period",
     "get_critical_priority_threshold",
     "get_default_max_retries",
@@ -1049,17 +1103,23 @@ __all__ = [
     "get_deferred_task_max_age",
     "get_lateral_movement_admin_creds_threshold",
     "get_lateral_movement_owned_hosts_threshold",
+    "get_low_medium_early_exit_min_evidence",
+    "get_low_medium_early_exit_min_queries",
+    "get_low_medium_early_exit_min_steps",
     "get_max_concurrent_tasks",
     "get_max_context_tokens",
     "get_max_deferred_per_type",
     "get_max_deferred_total",
     "get_max_duplicate_queries",
+    "get_max_evidence_before_compaction",
     "get_max_output_chars",
     "get_max_queries_critical",
     "get_max_queries_per_investigation",
     "get_max_redis_consecutive_failures",
+    "get_max_result_entries",
     "get_max_runtime",
     "get_max_stored_results",
+    "get_max_timeline_before_compaction",
     "get_max_total_queries",
     "get_max_vulnerability_failures",
     "get_min_messages_to_keep",

--- a/src/ares/core/factories/blue_factory.py
+++ b/src/ares/core/factories/blue_factory.py
@@ -16,9 +16,16 @@ from loguru import logger
 from ares.core.config import (
     get_bonus_queries_for_evidence,
     get_bonus_queries_for_pyramid_l4,
+    get_context_compaction_interval,
+    get_low_medium_early_exit_min_evidence,
+    get_low_medium_early_exit_min_queries,
+    get_low_medium_early_exit_min_steps,
     get_max_duplicate_queries,
+    get_max_evidence_before_compaction,
     get_max_queries_critical,
     get_max_queries_per_investigation,
+    get_max_result_entries,
+    get_max_timeline_before_compaction,
     get_max_total_queries,
     get_query_limits_by_stage,
 )
@@ -53,6 +60,8 @@ _seen_queries: dict[str, int] = {}  # Track query -> count to detect loops
 _current_state: "InvestigationState | None" = None
 _bonus_queries_granted = 0  # Track bonus queries granted
 _in_resilient_execution = False  # Flag to bypass duplicate check during retries/chunks
+_compaction_step_count = 0  # Track steps for periodic compaction
+_last_compaction_step = 0  # Last step when compaction ran
 
 # Evidence type to follow-up detection methods mapping for auto-chaining
 EVIDENCE_CHAIN_MAP: dict[str, list[str]] = {
@@ -667,7 +676,9 @@ def reset_query_tracking():
         _seen_queries, \
         _current_state, \
         _bonus_queries_granted, \
-        _in_resilient_execution
+        _in_resilient_execution, \
+        _compaction_step_count, \
+        _last_compaction_step
     _total_queries = 0
     _total_queries_attempted = 0
     _consecutive_queries = []
@@ -677,6 +688,8 @@ def reset_query_tracking():
     _current_state = None
     _bonus_queries_granted = 0
     _in_resilient_execution = False
+    _compaction_step_count = 0
+    _last_compaction_step = 0
     reset_resilient_executor()
     reset_evidence_validation()  # Reset evidence validation state
 
@@ -1140,6 +1153,9 @@ def _compact_loki_result(result: Any) -> Any:
     This function parses event_data XML into a clean dict and drops
     the redundant 'message' and raw XML, cutting ~60-70% of tokens
     while keeping all security-relevant fields.
+
+    Additionally, truncates results to max_result_entries (default 40)
+    to prevent context window overflow.
     """
     # MCP tools return list[ContentText] — extract the text payload
     if isinstance(result, list) and len(result) > 0:
@@ -1196,13 +1212,55 @@ def _compact_loki_result(result: Any) -> Any:
 
         compacted.append({"timestamp": timestamp, "line": compact_line})
 
+    # TRUNCATE to max_result_entries to prevent context overflow
+    # Keep first 75% (head) + last 25% (tail) for temporal coverage
+    max_entries = get_max_result_entries()
+    total_entries = len(compacted)
+    truncated = False
+
+    if total_entries > max_entries:
+        head_count = int(max_entries * 0.75)  # 30 for default 40
+        tail_count = max_entries - head_count  # 10 for default 40
+
+        head = compacted[:head_count]
+        tail = compacted[-tail_count:]
+        dropped_count = total_entries - max_entries
+
+        # Add a truncation marker
+        truncation_marker = {
+            "timestamp": "",
+            "line": {
+                "_truncated": True,
+                "_message": f"[{dropped_count} entries omitted - showing first {head_count} + last {tail_count} of {total_entries}]",
+            },
+        }
+        compacted = head + [truncation_marker] + tail
+        truncated = True
+
     original_chars = len(text)
-    compact_json = json_mod.dumps({"data": compacted, "count": len(compacted)})
+    output_data = {
+        "data": compacted,
+        "count": len(compacted),
+        "total_entries": total_entries,
+    }
+    if truncated:
+        output_data["truncated"] = True
+        output_data["dropped_count"] = total_entries - max_entries
+
+    compact_json = json_mod.dumps(output_data)
     saved_pct = (1 - len(compact_json) / original_chars) * 100 if original_chars else 0
-    logger.info(
-        f"📦 Compacted Loki result: {original_chars:,} → {len(compact_json):,} chars "
-        f"({saved_pct:.0f}% reduction, {len(compacted)} entries)"
-    )
+
+    if truncated:
+        logger.info(
+            f"📦 Compacted Loki result: {original_chars:,} → {len(compact_json):,} chars "
+            f"({saved_pct:.0f}% reduction, {total_entries} → {len(compacted)} entries, "
+            f"⚠️ {total_entries - max_entries} entries truncated)"
+        )
+    else:
+        logger.info(
+            f"📦 Compacted Loki result: {original_chars:,} → {len(compact_json):,} chars "
+            f"({saved_pct:.0f}% reduction, {len(compacted)} entries)"
+        )
 
     # Return in the same format the SDK expects
     if isinstance(result, list) and hasattr(result[0], "text"):
@@ -1341,6 +1399,146 @@ async def log_tool_result(event: ToolEnd):
             logger.info(f"✅ Tool {tool_name} completed")
 
 
+def _compact_evidence(state: "InvestigationState") -> int:
+    """Deduplicate and compact evidence items.
+
+    Returns number of items removed.
+    """
+    if not state.evidence:
+        return 0
+
+    seen_values: dict[str, Evidence] = {}
+    to_remove = []
+
+    for evidence in state.evidence:
+        key = f"{evidence.type}:{evidence.value.lower()}"
+        if key in seen_values:
+            existing = seen_values[key]
+            # Keep the one with higher confidence or more MITRE techniques
+            if evidence.confidence > existing.confidence or len(evidence.mitre_techniques) > len(
+                existing.mitre_techniques
+            ):
+                to_remove.append(existing)
+                seen_values[key] = evidence
+            else:
+                to_remove.append(evidence)
+        else:
+            seen_values[key] = evidence
+
+    for item in to_remove:
+        if item in state.evidence:
+            state.evidence.remove(item)
+
+    return len(to_remove)
+
+
+def _compact_timeline(state: "InvestigationState", max_events: int = 30) -> int:
+    """Compact timeline by summarizing middle events.
+
+    Keeps first 5 and last 10 events, summarizes middle.
+    Returns number of events compacted.
+    """
+    from ares.core.models import TimelineEvent
+
+    if len(state.timeline) <= max_events:
+        return 0
+
+    head_count = 5
+    tail_count = 10
+    keep_count = head_count + tail_count
+
+    if len(state.timeline) <= keep_count:
+        return 0
+
+    head = state.timeline[:head_count]
+    tail = state.timeline[-tail_count:]
+    middle = state.timeline[head_count:-tail_count]
+    compacted_count = len(middle)
+
+    # Create a summary event for the middle section
+    if middle:
+        # Extract unique techniques and hosts from middle events
+        techniques = set()
+        evidence_ids = set()
+        for event in middle:
+            techniques.update(event.mitre_techniques)
+            evidence_ids.update(event.evidence_ids)
+
+        summary_event = TimelineEvent(
+            id="tl-compact-summary",
+            timestamp=middle[0].timestamp,
+            description=f"[{compacted_count} events compacted: {middle[0].description[:50]}... to ...{middle[-1].description[:50]}]",
+            evidence_ids=list(evidence_ids)[:10],  # Limit to avoid bloat
+            mitre_techniques=list(techniques)[:5],
+            confidence=0.8,
+            source="compaction",
+        )
+
+        state.timeline = head + [summary_event] + tail
+        return compacted_count
+
+    return 0
+
+
+async def periodic_context_compaction(event: ToolEnd):
+    """Periodically compact investigation context to manage token usage.
+
+    Runs every N steps (configurable) and performs:
+    1. Evidence deduplication
+    2. Timeline compaction (summarize middle events)
+
+    This prevents context window overflow during long investigations.
+    """
+    global _compaction_step_count, _last_compaction_step
+
+    if not _current_state:
+        return
+
+    _compaction_step_count += 1
+
+    interval = get_context_compaction_interval()
+    if interval <= 0:
+        return  # Disabled
+
+    # Check if we should run compaction
+    steps_since_last = _compaction_step_count - _last_compaction_step
+    if steps_since_last < interval:
+        return
+
+    # Check thresholds
+    evidence_threshold = get_max_evidence_before_compaction()
+    timeline_threshold = get_max_timeline_before_compaction()
+
+    evidence_count = len(_current_state.evidence)
+    timeline_count = len(_current_state.timeline)
+
+    needs_compaction = evidence_count > evidence_threshold or timeline_count > timeline_threshold
+
+    if not needs_compaction:
+        return
+
+    logger.info(
+        f"🗜️ Context compaction triggered at step {_compaction_step_count} "
+        f"(evidence: {evidence_count}, timeline: {timeline_count})"
+    )
+
+    # Compact evidence
+    evidence_removed = _compact_evidence(_current_state)
+    if evidence_removed > 0:
+        logger.info(f"🗜️ Removed {evidence_removed} duplicate evidence items")
+
+    # Compact timeline
+    timeline_compacted = _compact_timeline(_current_state, max_events=timeline_threshold)
+    if timeline_compacted > 0:
+        logger.info(f"🗜️ Compacted {timeline_compacted} timeline events into summary")
+
+    _last_compaction_step = _compaction_step_count
+
+    dn.log_metric("context_compaction_runs", 1, mode="count")
+    dn.log_metric("evidence_compacted", evidence_removed, mode="count")
+    dn.log_metric("timeline_compacted", timeline_compacted, mode="count")
+
+
 unstall_hook = retry_with_feedback(
     event_type=AgentStalled,
     feedback=(
@@ -1427,6 +1625,60 @@ def max_tool_calls_stop(max_calls: int = 20) -> StopCondition:
         return False
 
     return StopCondition(stop, name="stop_on_max_tool_calls")
+
+
+def low_medium_severity_early_exit_stop() -> StopCondition:
+    """Stop condition for early exit on LOW/MEDIUM severity alerts.
+
+    For lower-severity alerts, we don't need exhaustive investigation.
+    Exit early if:
+    - Severity is LOW or MEDIUM
+    - Minimum steps reached (default 8)
+    - Either sufficient evidence found OR minimum queries executed
+
+    This prevents wasting cycles on low-priority alerts while still
+    ensuring basic investigation coverage.
+    """
+    from collections.abc import Sequence
+
+    def stop(events: Sequence[AgentEvent]) -> bool:
+        if not _current_state:
+            return False
+
+        # Only apply to LOW/MEDIUM severity
+        severity = _current_state.alert.get("labels", {}).get("severity", "").lower()
+        if severity not in ("low", "medium", "warning", "info"):
+            return False
+
+        # Count steps (ToolEnd events)
+        step_count = sum(
+            1 for e in events if isinstance(e, ToolEnd) and hasattr(e, "tool_call") and e.tool_call
+        )
+
+        min_steps = get_low_medium_early_exit_min_steps()
+        min_evidence = get_low_medium_early_exit_min_evidence()
+        min_queries = get_low_medium_early_exit_min_queries()
+
+        if step_count < min_steps:
+            return False
+
+        evidence_count = len(_current_state.evidence) if _current_state else 0
+        queries_run = _total_queries
+
+        # Early exit if:
+        # - Enough evidence found, OR
+        # - Enough queries run (even if no evidence - that's a finding too)
+        if evidence_count >= min_evidence or queries_run >= min_queries:
+            logger.info(
+                f"⏱️ EARLY EXIT: {severity.upper()} severity, {step_count} steps, "
+                f"{evidence_count} evidence, {queries_run} queries - "
+                "sufficient investigation for this severity level"
+            )
+            return True
+
+        return False
+
+    return StopCondition(stop, name="stop_on_low_medium_early_exit")
 
 
 def create_investigation_agent(
@@ -1567,11 +1819,13 @@ def create_investigation_agent(
         hooks=[
             log_tool_usage,
             log_tool_result,
+            periodic_context_compaction,  # Compact evidence/timeline periodically
             unstall_hook,
         ],
         stop_conditions=[
             tool_use("complete_investigation"),
             tool_use("escalate_investigation"),
+            low_medium_severity_early_exit_stop(),  # Early exit for LOW/MEDIUM severity
             query_limit_hit_stop(),  # Stop immediately when query limit is hit
             max_queries_stop(max_queries=12),  # Was 5 - force stop after 12 queries
             max_tool_calls_stop(max_calls=50),  # Was 20 - force stop after 50 total tool calls

--- a/tests/core/factories/test_blue_factory.py
+++ b/tests/core/factories/test_blue_factory.py
@@ -19,6 +19,9 @@ from ares.core.factories.blue_factory import (
     _calculate_bonus_queries,
     _check_duplicate_query,
     _check_query_limit,
+    _compact_evidence,
+    _compact_loki_result,
+    _compact_timeline,
     _count_successful_query,
     _extract_result_count,
     _get_query_limit,
@@ -32,8 +35,10 @@ from ares.core.factories.blue_factory import (
     filter_essential_mcp_tools,
     log_tool_result,
     log_tool_usage,
+    low_medium_severity_early_exit_stop,
     max_queries_stop,
     max_tool_calls_stop,
+    periodic_context_compaction,
     query_limit_hit_stop,
     reset_query_tracking,
     set_investigation_state,
@@ -1524,3 +1529,889 @@ class TestUserChainMap:
 
         assert "administrator" in USER_CHAIN_MAP
         assert "detect_lateral_movement" in USER_CHAIN_MAP["administrator"]
+
+
+# ============================================================================
+# Context Compaction Tests (new blue-compaction feature)
+# ============================================================================
+
+
+class TestCompactEvidence:
+    """Tests for _compact_evidence function."""
+
+    def test_empty_evidence_returns_zero(self, investigation_state: InvestigationState):
+        """Test that empty evidence list returns 0."""
+
+        investigation_state.evidence = []
+        removed = _compact_evidence(investigation_state)
+        assert removed == 0
+
+    def test_no_duplicates_returns_zero(self, investigation_state: InvestigationState):
+        """Test that no duplicates means nothing removed."""
+
+        investigation_state.evidence = [
+            Evidence(
+                id="ev-1",
+                type="ip",
+                value="192.168.1.1",
+                source="test",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+            Evidence(
+                id="ev-2",
+                type="ip",
+                value="192.168.1.2",
+                source="test",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+        ]
+        removed = _compact_evidence(investigation_state)
+        assert removed == 0
+        assert len(investigation_state.evidence) == 2
+
+    def test_removes_duplicate_by_type_value(self, investigation_state: InvestigationState):
+        """Test that duplicates are detected by type:value key."""
+
+        investigation_state.evidence = [
+            Evidence(
+                id="ev-1",
+                type="ip",
+                value="192.168.1.1",
+                source="test1",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+            Evidence(
+                id="ev-2",
+                type="ip",
+                value="192.168.1.1",  # Same value
+                source="test2",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.7,
+            ),
+        ]
+        removed = _compact_evidence(investigation_state)
+        assert removed == 1
+        assert len(investigation_state.evidence) == 1
+
+    def test_keeps_higher_confidence(self, investigation_state: InvestigationState):
+        """Test that higher confidence evidence is kept."""
+
+        investigation_state.evidence = [
+            Evidence(
+                id="ev-1",
+                type="ip",
+                value="192.168.1.1",
+                source="test1",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.5,  # Lower confidence
+            ),
+            Evidence(
+                id="ev-2",
+                type="ip",
+                value="192.168.1.1",
+                source="test2",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.9,  # Higher confidence - should be kept
+            ),
+        ]
+        removed = _compact_evidence(investigation_state)
+        assert removed == 1
+        assert investigation_state.evidence[0].id == "ev-2"
+        assert investigation_state.evidence[0].confidence == 0.9
+
+    def test_keeps_more_mitre_techniques(self, investigation_state: InvestigationState):
+        """Test that evidence with more MITRE techniques is kept when confidence is equal."""
+
+        investigation_state.evidence = [
+            Evidence(
+                id="ev-1",
+                type="hash",
+                value="abc123",
+                source="test1",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.HASH_VALUES,
+                mitre_techniques=["T1003"],  # Fewer techniques
+                confidence=0.8,
+            ),
+            Evidence(
+                id="ev-2",
+                type="hash",
+                value="ABC123",  # Same (case-insensitive)
+                source="test2",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.HASH_VALUES,
+                mitre_techniques=["T1003", "T1059", "T1078"],  # More techniques - should be kept
+                confidence=0.8,
+            ),
+        ]
+        removed = _compact_evidence(investigation_state)
+        assert removed == 1
+        assert investigation_state.evidence[0].id == "ev-2"
+        assert len(investigation_state.evidence[0].mitre_techniques) == 3
+
+    def test_case_insensitive_value_comparison(self, investigation_state: InvestigationState):
+        """Test that value comparison is case-insensitive."""
+
+        investigation_state.evidence = [
+            Evidence(
+                id="ev-1",
+                type="user",
+                value="JOHN.DOE",
+                source="test1",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.NETWORK_HOST_ARTIFACTS,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+            Evidence(
+                id="ev-2",
+                type="user",
+                value="john.doe",  # Same user, different case
+                source="test2",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.NETWORK_HOST_ARTIFACTS,
+                mitre_techniques=[],
+                confidence=0.7,
+            ),
+        ]
+        removed = _compact_evidence(investigation_state)
+        assert removed == 1
+        assert len(investigation_state.evidence) == 1
+
+    def test_different_types_not_deduplicated(self, investigation_state: InvestigationState):
+        """Test that same value with different types are not considered duplicates."""
+
+        investigation_state.evidence = [
+            Evidence(
+                id="ev-1",
+                type="ip",
+                value="192.168.1.1",
+                source="test1",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+            Evidence(
+                id="ev-2",
+                type="host",  # Different type
+                value="192.168.1.1",
+                source="test2",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+        ]
+        removed = _compact_evidence(investigation_state)
+        assert removed == 0
+        assert len(investigation_state.evidence) == 2
+
+
+class TestCompactTimeline:
+    """Tests for _compact_timeline function."""
+
+    def test_no_compaction_under_threshold(self, investigation_state: InvestigationState):
+        """Test that no compaction happens when under threshold."""
+        from ares.core.models import TimelineEvent
+
+        investigation_state.timeline = [
+            TimelineEvent(
+                id=f"tl-{i}",
+                timestamp=datetime.now(timezone.utc),
+                description=f"Event {i}",
+                mitre_techniques=[],
+                confidence=0.8,
+                source="test",
+            )
+            for i in range(10)
+        ]
+        compacted = _compact_timeline(investigation_state, max_events=30)
+        assert compacted == 0
+        assert len(investigation_state.timeline) == 10
+
+    def test_no_compaction_at_keep_count(self, investigation_state: InvestigationState):
+        """Test no compaction when timeline equals head+tail count (15)."""
+        from ares.core.models import TimelineEvent
+
+        # head_count=5, tail_count=10, so 15 events won't trigger compaction
+        investigation_state.timeline = [
+            TimelineEvent(
+                id=f"tl-{i}",
+                timestamp=datetime.now(timezone.utc),
+                description=f"Event {i}",
+                mitre_techniques=[],
+                confidence=0.8,
+                source="test",
+            )
+            for i in range(15)
+        ]
+        compacted = _compact_timeline(investigation_state, max_events=10)
+        assert compacted == 0
+
+    def test_compacts_middle_events(self, investigation_state: InvestigationState):
+        """Test that middle events are compacted into a summary."""
+        from ares.core.models import TimelineEvent
+
+        # Create 25 events - should compact middle (events 5-14)
+        investigation_state.timeline = [
+            TimelineEvent(
+                id=f"tl-{i}",
+                timestamp=datetime.now(timezone.utc),
+                description=f"Event {i} happened here with details",
+                evidence_ids=[f"ev-{i}"],
+                mitre_techniques=[f"T100{i % 10}"],
+                confidence=0.8,
+                source="test",
+            )
+            for i in range(25)
+        ]
+        compacted = _compact_timeline(investigation_state, max_events=20)
+        assert compacted == 10  # Middle 10 events compacted
+
+        # Should have: 5 head + 1 summary + 10 tail = 16 events
+        assert len(investigation_state.timeline) == 16
+
+        # Verify summary event exists
+        summary = investigation_state.timeline[5]
+        assert summary.id == "tl-compact-summary"
+        assert summary.source == "compaction"
+        assert "10 events compacted" in summary.description
+
+    def test_preserves_head_and_tail(self, investigation_state: InvestigationState):
+        """Test that head and tail events are preserved."""
+        from ares.core.models import TimelineEvent
+
+        investigation_state.timeline = [
+            TimelineEvent(
+                id=f"tl-{i}",
+                timestamp=datetime.now(timezone.utc),
+                description=f"Event {i}",
+                mitre_techniques=[],
+                confidence=0.8,
+                source="test",
+            )
+            for i in range(30)
+        ]
+        _compact_timeline(investigation_state, max_events=20)
+
+        # First 5 should be preserved
+        for i in range(5):
+            assert investigation_state.timeline[i].id == f"tl-{i}"
+
+        # Last 10 should be preserved (indices 20-29 from original)
+        for i, orig_idx in enumerate(range(20, 30)):
+            # Account for summary event at index 5
+            timeline_idx = 6 + i
+            assert investigation_state.timeline[timeline_idx].id == f"tl-{orig_idx}"
+
+    def test_summary_aggregates_techniques(self, investigation_state: InvestigationState):
+        """Test that summary event aggregates MITRE techniques."""
+        from ares.core.models import TimelineEvent
+
+        investigation_state.timeline = [
+            TimelineEvent(
+                id=f"tl-{i}",
+                timestamp=datetime.now(timezone.utc),
+                description=f"Event {i}",
+                mitre_techniques=[f"T100{i}"] if i >= 5 and i < 15 else [],
+                confidence=0.8,
+                source="test",
+            )
+            for i in range(25)
+        ]
+        _compact_timeline(investigation_state, max_events=20)
+
+        summary = investigation_state.timeline[5]
+        # Should have aggregated techniques from middle events (capped at 5)
+        assert len(summary.mitre_techniques) <= 5
+        assert len(summary.mitre_techniques) > 0
+
+    def test_summary_aggregates_evidence_ids(self, investigation_state: InvestigationState):
+        """Test that summary event aggregates evidence IDs."""
+        from ares.core.models import TimelineEvent
+
+        investigation_state.timeline = [
+            TimelineEvent(
+                id=f"tl-{i}",
+                timestamp=datetime.now(timezone.utc),
+                description=f"Event {i}",
+                evidence_ids=[f"ev-{i}"],
+                mitre_techniques=[],
+                confidence=0.8,
+                source="test",
+            )
+            for i in range(25)
+        ]
+        _compact_timeline(investigation_state, max_events=20)
+
+        summary = investigation_state.timeline[5]
+        # Should have aggregated evidence IDs from middle events (capped at 10)
+        assert len(summary.evidence_ids) <= 10
+        assert len(summary.evidence_ids) > 0
+
+
+class TestCompactLokiResultTruncation:
+    """Tests for _compact_loki_result truncation logic."""
+
+    def test_no_truncation_under_limit(self):
+        """Test that results under the limit are not truncated."""
+        import json
+
+        # Create result with 10 entries (under default 40)
+        entries = [
+            {"timestamp": f"2024-01-01T{i:02d}:00:00Z", "line": f'{{"event_id": 4624, "idx": {i}}}'}
+            for i in range(10)
+        ]
+        result_text = json.dumps({"data": entries})
+
+        # Mock ContentText-like object
+        mock_content = MagicMock()
+        mock_content.text = result_text
+
+        compacted = _compact_loki_result([mock_content])
+        compacted_data = json.loads(compacted[0].text)
+
+        assert compacted_data.get("truncated") is None
+        assert "dropped_count" not in compacted_data
+
+    def test_truncation_over_limit(self, monkeypatch):
+        """Test that results over the limit are truncated with head+tail."""
+        import json
+
+        # Mock config to use a smaller limit for testing
+        monkeypatch.setattr("ares.core.factories.blue_factory.get_max_result_entries", lambda: 10)
+
+        # Create result with 25 entries (over limit of 10)
+        entries = [
+            {"timestamp": f"2024-01-01T{i:02d}:00:00Z", "line": f'{{"event_id": 4624, "idx": {i}}}'}
+            for i in range(25)
+        ]
+        result_text = json.dumps({"data": entries})
+
+        mock_content = MagicMock()
+        mock_content.text = result_text
+
+        compacted = _compact_loki_result([mock_content])
+        compacted_data = json.loads(compacted[0].text)
+
+        assert compacted_data["truncated"] is True
+        assert compacted_data["total_entries"] == 25
+        assert compacted_data["dropped_count"] == 15  # 25 - 10
+
+    def test_truncation_preserves_head_and_tail(self, monkeypatch):
+        """Test that truncation keeps head (75%) and tail (25%) entries."""
+        import json
+
+        monkeypatch.setattr("ares.core.factories.blue_factory.get_max_result_entries", lambda: 8)
+
+        # Create 20 entries with unique identifiers
+        entries = [
+            {"timestamp": f"2024-01-01T{i:02d}:00:00Z", "line": f'{{"idx": {i}}}'}
+            for i in range(20)
+        ]
+        result_text = json.dumps({"data": entries})
+
+        mock_content = MagicMock()
+        mock_content.text = result_text
+
+        compacted = _compact_loki_result([mock_content])
+        compacted_data = json.loads(compacted[0].text)
+
+        # With limit 8: head=6 (75%), tail=2 (25%)
+        data = compacted_data["data"]
+        # Should have 6 head + 1 truncation marker + 2 tail = 9 entries
+        assert len(data) == 9
+
+        # Verify head entries (indices 0-5)
+        for i in range(6):
+            assert data[i]["line"]["idx"] == i
+
+        # Verify truncation marker
+        assert data[6]["line"]["_truncated"] is True
+        assert "entries omitted" in data[6]["line"]["_message"]
+
+        # Verify tail entries (indices 18, 19 from original)
+        assert data[7]["line"]["idx"] == 18
+        assert data[8]["line"]["idx"] == 19
+
+    def test_returns_original_for_non_json(self):
+        """Test that non-JSON results are returned unchanged."""
+
+        result = "not json data"
+        compacted = _compact_loki_result(result)
+        assert compacted == result
+
+    def test_returns_original_for_empty_list(self):
+        """Test that empty list is returned unchanged."""
+
+        result = []
+        compacted = _compact_loki_result(result)
+        assert compacted == result
+
+
+class TestLowMediumSeverityEarlyExitStop:
+    """Tests for low_medium_severity_early_exit_stop stop condition."""
+
+    def test_returns_stop_condition(self):
+        """Test that a StopCondition is returned."""
+        from dreadnode.agent.stop import StopCondition
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        assert isinstance(stop_condition, StopCondition)
+        assert callable(stop_condition.func)
+        assert stop_condition.name == "stop_on_low_medium_early_exit"
+
+    def test_does_not_stop_without_state(self):
+        """Test does not stop when no investigation state is set."""
+        import ares.core.factories.blue_factory as factory
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+        )
+
+        reset_query_tracking()
+        factory._current_state = None
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        result = stop_condition.func([])
+        assert result is False
+
+    def test_does_not_stop_for_critical_severity(self, investigation_state: InvestigationState):
+        """Test does not stop for CRITICAL severity alerts."""
+        from dreadnode.agent.events import ToolEnd
+
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        investigation_state.alert["labels"]["severity"] = "critical"
+        set_investigation_state(investigation_state)
+
+        # Create mock tool end events
+        events = []
+        for i in range(15):
+            mock_event = MagicMock(spec=ToolEnd)
+            mock_tool_call = MagicMock()
+            mock_tool_call.name = f"tool_{i}"
+            mock_event.tool_call = mock_tool_call
+            events.append(mock_event)
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        result = stop_condition.func(events)
+        assert result is False
+
+    def test_does_not_stop_for_high_severity(self, investigation_state: InvestigationState):
+        """Test does not stop for HIGH severity alerts."""
+        from dreadnode.agent.events import ToolEnd
+
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        investigation_state.alert["labels"]["severity"] = "high"
+        set_investigation_state(investigation_state)
+
+        events = [MagicMock(spec=ToolEnd) for _ in range(15)]
+        for e in events:
+            e.tool_call = MagicMock()
+            e.tool_call.name = "test"
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        result = stop_condition.func(events)
+        assert result is False
+
+    def test_stops_for_low_severity_with_evidence(self, investigation_state: InvestigationState):
+        """Test stops for LOW severity when min steps and evidence reached."""
+        from dreadnode.agent.events import ToolEnd
+
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        investigation_state.alert["labels"]["severity"] = "low"
+        investigation_state.evidence = [
+            Evidence(
+                id="ev-1",
+                type="ip",
+                value="192.168.1.1",
+                source="test",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+            Evidence(
+                id="ev-2",
+                type="ip",
+                value="192.168.1.2",
+                source="test",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+        ]
+        set_investigation_state(investigation_state)
+
+        # Create 10 mock tool end events (above min_steps=8)
+        events = []
+        for i in range(10):
+            mock_event = MagicMock(spec=ToolEnd)
+            mock_event.tool_call = MagicMock()
+            mock_event.tool_call.name = f"tool_{i}"
+            events.append(mock_event)
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        result = stop_condition.func(events)
+        assert result is True
+
+    def test_stops_for_medium_severity_with_queries(self, investigation_state: InvestigationState):
+        """Test stops for MEDIUM severity when min queries reached."""
+        from dreadnode.agent.events import ToolEnd
+
+        import ares.core.factories.blue_factory as factory
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        investigation_state.alert["labels"]["severity"] = "medium"
+        investigation_state.evidence = []  # No evidence
+        set_investigation_state(investigation_state)
+
+        # Set _total_queries to meet threshold
+        factory._total_queries = 5  # Above min_queries=4
+
+        events = [MagicMock(spec=ToolEnd) for _ in range(10)]
+        for e in events:
+            e.tool_call = MagicMock()
+            e.tool_call.name = "test"
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        result = stop_condition.func(events)
+        assert result is True
+
+    def test_does_not_stop_under_min_steps(self, investigation_state: InvestigationState):
+        """Test does not stop when under minimum steps."""
+        from dreadnode.agent.events import ToolEnd
+
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        investigation_state.alert["labels"]["severity"] = "low"
+        investigation_state.evidence = [
+            Evidence(
+                id="ev-1",
+                type="ip",
+                value="192.168.1.1",
+                source="test",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            ),
+        ] * 5  # Plenty of evidence
+        set_investigation_state(investigation_state)
+
+        # Only 3 steps (under min_steps=8)
+        events = [MagicMock(spec=ToolEnd) for _ in range(3)]
+        for e in events:
+            e.tool_call = MagicMock()
+            e.tool_call.name = "test"
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        result = stop_condition.func(events)
+        assert result is False
+
+    def test_stops_for_warning_severity(self, investigation_state: InvestigationState):
+        """Test stops for WARNING severity (treated like LOW/MEDIUM)."""
+        from dreadnode.agent.events import ToolEnd
+
+        import ares.core.factories.blue_factory as factory
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        investigation_state.alert["labels"]["severity"] = "warning"
+        factory._total_queries = 5
+        set_investigation_state(investigation_state)
+
+        events = [MagicMock(spec=ToolEnd) for _ in range(10)]
+        for e in events:
+            e.tool_call = MagicMock()
+            e.tool_call.name = "test"
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        result = stop_condition.func(events)
+        assert result is True
+
+    def test_stops_for_info_severity(self, investigation_state: InvestigationState):
+        """Test stops for INFO severity (treated like LOW/MEDIUM)."""
+        from dreadnode.agent.events import ToolEnd
+
+        import ares.core.factories.blue_factory as factory
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        investigation_state.alert["labels"]["severity"] = "info"
+        factory._total_queries = 5
+        set_investigation_state(investigation_state)
+
+        events = [MagicMock(spec=ToolEnd) for _ in range(10)]
+        for e in events:
+            e.tool_call = MagicMock()
+            e.tool_call.name = "test"
+
+        stop_condition = low_medium_severity_early_exit_stop()
+        result = stop_condition.func(events)
+        assert result is True
+
+
+class TestPeriodicContextCompaction:
+    """Tests for periodic_context_compaction hook."""
+
+    @pytest.mark.asyncio
+    async def test_increments_step_count(self, investigation_state: InvestigationState):
+        """Test that step count is incremented on each call."""
+        import ares.core.factories.blue_factory as factory
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        set_investigation_state(investigation_state)
+
+        mock_event = MagicMock()
+        mock_event.tool_call = MagicMock()
+
+        initial_count = factory._compaction_step_count
+
+        await periodic_context_compaction(mock_event)
+
+        assert factory._compaction_step_count == initial_count + 1
+
+    @pytest.mark.asyncio
+    async def test_no_compaction_without_state(self):
+        """Test that compaction doesn't happen without investigation state."""
+        import ares.core.factories.blue_factory as factory
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+        )
+
+        reset_query_tracking()
+        factory._current_state = None
+
+        mock_event = MagicMock()
+        await periodic_context_compaction(mock_event)
+        # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_no_compaction_when_disabled(
+        self, investigation_state: InvestigationState, monkeypatch
+    ):
+        """Test that compaction is skipped when interval is 0."""
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        set_investigation_state(investigation_state)
+        monkeypatch.setattr(
+            "ares.core.factories.blue_factory.get_context_compaction_interval", lambda: 0
+        )
+
+        mock_event = MagicMock()
+        await periodic_context_compaction(mock_event)
+        # Should not raise, compaction disabled
+
+    @pytest.mark.asyncio
+    async def test_no_compaction_before_interval(
+        self, investigation_state: InvestigationState, monkeypatch
+    ):
+        """Test that compaction doesn't happen before interval steps."""
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        set_investigation_state(investigation_state)
+        monkeypatch.setattr(
+            "ares.core.factories.blue_factory.get_context_compaction_interval", lambda: 10
+        )
+
+        # Add lots of evidence to trigger compaction if interval was met
+        investigation_state.evidence = [
+            Evidence(
+                id=f"ev-{i}",
+                type="ip",
+                value=f"192.168.1.{i}",
+                source="test",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            )
+            for i in range(100)
+        ]
+
+        mock_event = MagicMock()
+        # Only 3 steps - under interval of 10
+        for _ in range(3):
+            await periodic_context_compaction(mock_event)
+
+        # Evidence should not be compacted yet
+        assert len(investigation_state.evidence) == 100
+
+    @pytest.mark.asyncio
+    async def test_no_compaction_under_threshold(
+        self, investigation_state: InvestigationState, monkeypatch
+    ):
+        """Test that compaction doesn't happen when under thresholds."""
+        from ares.core.factories.blue_factory import (
+            reset_query_tracking,
+            set_investigation_state,
+        )
+
+        reset_query_tracking()
+        set_investigation_state(investigation_state)
+        monkeypatch.setattr(
+            "ares.core.factories.blue_factory.get_context_compaction_interval", lambda: 1
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.blue_factory.get_max_evidence_before_compaction", lambda: 100
+        )
+        monkeypatch.setattr(
+            "ares.core.factories.blue_factory.get_max_timeline_before_compaction", lambda: 100
+        )
+
+        # Add small amount of evidence (under threshold)
+        investigation_state.evidence = [
+            Evidence(
+                id=f"ev-{i}",
+                type="ip",
+                value=f"192.168.1.{i}",
+                source="test",
+                timestamp=datetime.now(timezone.utc),
+                pyramid_level=PyramidLevel.IP_ADDRESSES,
+                mitre_techniques=[],
+                confidence=0.8,
+            )
+            for i in range(10)
+        ]
+
+        mock_event = MagicMock()
+        await periodic_context_compaction(mock_event)
+
+        # No compaction should have happened
+        assert len(investigation_state.evidence) == 10
+
+
+class TestCompactionStateReset:
+    """Tests for compaction state reset in reset_query_tracking."""
+
+    def test_reset_clears_compaction_counters(self):
+        """Test that reset_query_tracking clears compaction counters."""
+        import ares.core.factories.blue_factory as factory
+        from ares.core.factories.blue_factory import reset_query_tracking
+
+        # Set some compaction state
+        factory._compaction_step_count = 50
+        factory._last_compaction_step = 45
+
+        reset_query_tracking()
+
+        assert factory._compaction_step_count == 0
+        assert factory._last_compaction_step == 0
+
+
+class TestCompactionConfigGetters:
+    """Tests for new config getter functions."""
+
+    def test_get_max_result_entries(self):
+        """Test get_max_result_entries returns positive integer."""
+        from ares.core.config import get_max_result_entries
+
+        value = get_max_result_entries()
+        assert isinstance(value, int)
+        assert value > 0
+
+    def test_get_context_compaction_interval(self):
+        """Test get_context_compaction_interval returns non-negative integer."""
+        from ares.core.config import get_context_compaction_interval
+
+        value = get_context_compaction_interval()
+        assert isinstance(value, int)
+        assert value >= 0
+
+    def test_get_max_evidence_before_compaction(self):
+        """Test get_max_evidence_before_compaction returns positive integer."""
+        from ares.core.config import get_max_evidence_before_compaction
+
+        value = get_max_evidence_before_compaction()
+        assert isinstance(value, int)
+        assert value > 0
+
+    def test_get_max_timeline_before_compaction(self):
+        """Test get_max_timeline_before_compaction returns positive integer."""
+        from ares.core.config import get_max_timeline_before_compaction
+
+        value = get_max_timeline_before_compaction()
+        assert isinstance(value, int)
+        assert value > 0
+
+    def test_get_low_medium_early_exit_min_steps(self):
+        """Test get_low_medium_early_exit_min_steps returns positive integer."""
+        from ares.core.config import get_low_medium_early_exit_min_steps
+
+        value = get_low_medium_early_exit_min_steps()
+        assert isinstance(value, int)
+        assert value > 0
+
+    def test_get_low_medium_early_exit_min_evidence(self):
+        """Test get_low_medium_early_exit_min_evidence returns positive integer."""
+        from ares.core.config import get_low_medium_early_exit_min_evidence
+
+        value = get_low_medium_early_exit_min_evidence()
+        assert isinstance(value, int)
+        assert value > 0
+
+    def test_get_low_medium_early_exit_min_queries(self):
+        """Test get_low_medium_early_exit_min_queries returns positive integer."""
+        from ares.core.config import get_low_medium_early_exit_min_queries
+
+        value = get_low_medium_early_exit_min_queries()
+        assert isinstance(value, int)
+        assert value > 0


### PR DESCRIPTION

**Key Changes:**

- Introduced context compaction for evidence and timeline to control token usage
- Added early exit stop condition for low/medium severity investigations
- Implemented result truncation for large Loki query outputs
- Comprehensive tests for compaction and early exit features

**Added:**

- Configurable context compaction parameters to `OperationConfig`, including
  max result entries, compaction intervals, and thresholds for evidence and
  timeline size
- Getter functions in `config.py` for new compaction and early exit settings
- Context compaction logic in `blue_factory.py`:
  - Evidence deduplication by type/value with confidence/technique tie-break
  - Timeline compaction that summarizes middle events, preserving head/tail
  - Periodic compaction hook (`periodic_context_compaction`) to run at
    configurable step intervals
- Loki result truncation in `_compact_loki_result`, limiting output to
  configurable max entries (head + tail) with truncation marker
- Early exit stop condition for low/medium severity alerts, based on steps,
  evidence, and queries
- Extensive tests for evidence/timeline compaction, Loki truncation,
  stop condition, and new config getters

**Changed:**

- Investigation agent now includes periodic context compaction hook and
  low/medium severity early exit stop condition in its lifecycle
- `reset_query_tracking` resets compaction step counters to ensure clean
  state per investigation
- `_compact_loki_result` provides additional metadata and log details
  when truncation occurs

**Removed:**

- None