### PR TITLE
docs: update documentation for multi-agent red team architecture and codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,27 @@ Agent SDK and MITRE ATT&CK framework.
 - CI-compatible with JSON output, exit codes, and configurable pass thresholds
 - Dataset evaluation for batch scoring across multiple scenarios
 
-### Red Team - Penetration Testing
+### Red Team - Multi-Agent Penetration Testing
+
+**Multi-Agent Architecture:**
+
+- Orchestrator coordinates 7 specialized worker agents via Redis
+- Each agent runs in its own Kubernetes pod with role-specific tools
+- Shared state enables credential/hash broadcasting across agents
+- Phase-aware task prioritization
+  (initial access → enumeration → privesc → lateral → DA)
+
+**Agent Roles:**
+
+- **RECON**: Network scanning, BloodHound, user/share enumeration
+- **CREDENTIAL_ACCESS**: secretsdump, kerberoasting, AS-REP roasting, password spray
+- **CRACKER**: Offline hash cracking with hashcat/john
+- **ACL**: BloodHound path analysis, ACL abuse (shadow credentials, WriteDACL)
+- **PRIVESC**: ADCS (ESC1-8), delegation attacks, MSSQL exploitation
+- **LATERAL**: PSExec/WMI/WinRM, credential harvesting from compromised hosts
+- **COERCION**: Responder, ntlmrelayx, PetitPotam
+
+**Attack Capabilities:**
 
 - Autonomous Active Directory enumeration
 - Credential harvesting (secretsdump, kerberoasting, AS-REP roasting)
@@ -96,7 +116,7 @@ task blue:poll
 ```bash
 # Confirm installation
 uv run python -m ares --help
-# Should display available commands: investigate-alert, evaluate
+# Should display available commands: investigate-alert, multi-agent, worker, evaluate, evaluate-dataset, version
 ```
 
 **Without 1Password:**
@@ -149,6 +169,18 @@ task blue:reports:latest      # Show latest report
 | `task blue:reports:clean`            | Delete all reports (asks for confirmation)                   |
 | `task blue:mitre:test`               | Test MITRE ATT&CK data loading                               |
 
+**Red Team Tasks (Multi-Agent):**
+
+| Command                                | Description                                                  |
+| -------------------------------------- | ------------------------------------------------------------ |
+| `task red:multi TARGET=<name>`         | Run multi-agent red team operation                           |
+| `task red:multi:status LATEST=true`    | Check operation status                                       |
+| `task red:multi:loot LATEST=true`      | Show discovered credentials, hashes, hosts                   |
+| `task red:multi:list`                  | List all operations                                          |
+| `task remote:logs ROLE=orchestrator`   | Tail orchestrator logs                                       |
+| `task remote:sync:full`                | Sync local code to K8s pods                                  |
+| `task red:multi:sync:align`            | Full sync + Redis clear + pod rollout                        |
+
 See [Taskfile Usage Guide](docs/taskfile_usage.md) for detailed documentation.
 
 ### Direct CLI Usage (Advanced)
@@ -184,6 +216,21 @@ uv run python -m ares investigate-alert test-alerts/example-alert.json \
   --args.model claude-sonnet-4-20250514 \
   --args.grafana-url https://grafana.example.com \
   --args.max-steps 30
+```
+
+#### Red Team - Multi-Agent Operation
+
+Run a coordinated multi-agent penetration test:
+
+```bash
+# Run multi-agent operation
+uv run ares multi-agent contoso.local "192.168.58.10,192.168.58.11" \
+  --args.model gpt-4o \
+  --multi-args.redis-url redis://redis:6379
+
+# Run a worker agent (typically started by K8s, but can be run manually)
+uv run ares worker lateral op-12345678 \
+  --worker-args.redis-url redis://redis:6379
 ```
 
 ### Command-Line Options
@@ -304,34 +351,55 @@ Example report location: `reports/inv-<id>-<timestamp>.md`
 
 ## Red Team Operation Workflow
 
-The red team agent follows a priority-driven attack workflow:
+The multi-agent red team system follows a phase-driven attack workflow:
 
-### Priority 0: ADCS Vulnerabilities
+### Phase 1: Initial Access
 
-When certificate template vulnerabilities (ESC1-15) are discovered, immediately
-exploit them for potential direct path to Domain Admin.
+- RECON scans networks, enumerates hosts/users/shares
+- COERCION starts Responder for LLMNR/NBT-NS poisoning
+- CREDENTIAL_ACCESS attempts password spraying
 
-### Priority 1: KRBTGT Hash
+### Phase 2: Enumeration (First Credentials)
 
-When a krbtgt hash is found, generate golden tickets for persistent domain
-access and cross-domain escalation.
+- RECON runs BloodHound collection for attack path analysis
+- CREDENTIAL_ACCESS performs Kerberoasting, AS-REP roasting
+- CRACKER cracks discovered hashes
+- Orchestrator queues vulnerabilities for exploitation
 
-### Priority 2: Administrator Hash
+### Phase 3: Privilege Escalation
 
-When Administrator hashes are found, immediately use domain_admin_checker on
-all targets and run secretsdump across the environment.
+- PRIVESC exploits ADCS vulnerabilities (ESC1-8), delegation attacks
+- ACL exploits WriteDACL, shadow credentials, targeted Kerberoast
+- Credential expansion loop continues
 
-### Priority 3: Credential Expansion
+### Phase 4: Lateral Movement
 
-For each new credential discovered:
+- LATERAL moves to new hosts with discovered credentials
+- CREDENTIAL_ACCESS runs secretsdump on each compromised host
+- CRACKER processes new hashes
 
-1. Check for privilege escalation paths (BloodHound ACL abuse, ADCS, delegation)
-2. Enumerate users and shares on all targets
-3. Pilfer accessible shares for embedded credentials
-4. Kerberoast and AS-REP roast with new credentials
-5. Crack discovered hashes and loop back
+### Phase 5: Domain Dominance
+
+- DCSync to extract all domain hashes
+- Golden ticket generation for persistence
+- Operation completion with full report
+
+### Running Multi-Agent Operations
+
+```bash
+# Run multi-agent operation (requires K8s cluster with agents deployed)
+task red:multi TARGET=dreadgoad DOMAIN=contoso.local
+
+# Monitor operation progress
+task red:multi:loot LATEST=true WATCH=10
+
+# View orchestrator logs
+task remote:logs ROLE=orchestrator FOLLOW=true
+```
 
 Example report location: `reports/redteam-<operation-id>_report.md`
+
+See [Red Team Architecture](docs/red.md) for detailed multi-agent documentation.
 
 ## Blue Team Evaluation
 

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -24,10 +24,11 @@ ares/
 │   ├── agents/                  # Agent orchestrators
 │   ├── integrations/            # Third-party integrations
 │   ├── reports/                 # Report generation
+│   ├── eval/                    # Evaluation framework
 │   ├── templates/               # Jinja2 templates for prompts
 │   ├── main.py                  # CLI entry point
 │   └── cli_ops.py               # CLI operations
-├── tests/                       # Test suite (60+ files)
+├── tests/                       # Test suite
 ├── docs/                        # Documentation
 ├── config/                      # Configuration files
 ├── scripts/                     # Utility scripts
@@ -46,17 +47,21 @@ The central framework for both blue and red team operations.
 | `dispatcher/` | Red team task dispatcher - orchestrates worker agents |
 | `worker/` | Worker agent implementation for executing specialized tasks |
 | `orchestrator/` | Multi-agent orchestration and coordination |
+| `replay/` | Deterministic replay for debugging and testing |
+| `factories/` | Agent and worker factory implementations |
 | `models.py` | Data models (Credential, Host, Evidence, Target, etc.) |
 | `task_queue.py` | Redis-based task queue for multi-agent coordination |
 | `persistence.py` | State persistence and serialization |
 | `recovery.py` | Operation checkpoint and recovery management |
+| `state_backend.py` | Redis state backend for persistent storage |
+| `workflows.py` | Credential expansion and exploitation workflows |
 
 ### Supporting Components
 
 | File | Purpose |
 | ---- | ------- |
 | `config.py` | Configuration loading and environment management |
-| `correlation.py` | Evidence correlation and timeline generation |
+| `correlation.py` | Red-Blue correlation and timeline generation |
 | `engines.py` | Question generation engines (MITRE, pyramid climb, attack chains) |
 | `evidence_validation.py` | Evidence validation and deduplication |
 | `k8s_executor.py` | Kubernetes pod execution interface |
@@ -65,35 +70,122 @@ The central framework for both blue and red team operations.
 | `orchestrator_client.py` | Client for communicating with orchestrator |
 | `orchestrator_service.py` | Orchestrator service pod implementation |
 | `query_resilience.py` | Query retry logic and resilience patterns |
-| `redis_client.py` | Redis client wrapper |
+| `redis_client.py` | Redis client wrapper with Sentinel support |
 | `remote.py` | Remote execution on Kubernetes pods |
 | `templates.py` | Jinja2 template loading and rendering |
-| `workflows.py` | Credential expansion and exploitation workflows |
+| `alert_correlation.py` | Alert clustering for blue team investigations |
+| `capability_registry.py` | Agent capability registration and lookup |
+| `context_manager.py` | Context window management and compaction |
+| `tool_retrieval.py` | Dynamic tool loading and retrieval |
+| `litellm_env.py` | LiteLLM environment configuration |
+| `rigging_patches.py` | Rigging framework patches and extensions |
+| `exceptions.py` | Custom exception definitions |
+| `logging_utils.py` | Logging utilities |
+
+### Dispatcher (`src/ares/core/dispatcher/`)
+
+| File | Purpose |
+| ---- | ------- |
+| `_dispatcher.py` | Core dispatcher implementation |
+| `routing.py` | Task routing and role-based dispatch |
+| `throttling.py` | Task throttling and rate limiting |
+| `persistence.py` | Dispatcher state persistence to Redis |
+| `result_processing.py` | Task result processing and state updates |
+| `publishing.py` | Credential/hash broadcasting to shared state |
+| `vulnerability.py` | Vulnerability queue management |
+| `deferred_queue.py` | Deferred task queue for delayed execution |
+| `monitoring.py` | Operation monitoring and health checks |
+| `announcements.py` | Domain admin and completion announcements |
+| `status.py` | Operation status tracking |
+| `extraction.py` | Result extraction from task outputs |
+| `acl_chains.py` | ACL attack chain processing |
+| `agents.py` | Agent registration and management |
+
+### Worker (`src/ares/core/worker/`)
+
+| File | Purpose |
+| ---- | ------- |
+| `_worker.py` | Core worker agent implementation |
+| `operations.py` | Worker operation handlers |
+| `prompts.py` | Worker prompt generation |
+| `dc_resolution.py` | Domain controller resolution logic |
+| `cleanup.py` | Worker cleanup and shutdown |
+
+### Orchestrator (`src/ares/core/orchestrator/`)
+
+| File | Purpose |
+| ---- | ------- |
+| `_orchestrator.py` | Core orchestrator implementation |
+
+### Replay (`src/ares/core/replay/`)
+
+| File | Purpose |
+| ---- | ------- |
+| `store.py` | Replay data storage |
+| `determinism.py` | Deterministic replay utilities |
+| `wrappers.py` | Tool wrappers for replay capture |
 
 ### Factories (`src/ares/core/factories/`)
 
 | File | Purpose |
 | ---- | ------- |
-| `red_agents.py` | Red team agent factory |
-| `red_factory.py` | Red team dispatcher and worker creation |
+| `red_agents.py` | Red team agent factory and toolset assignment |
 | `blue_factory.py` | Blue team agent factory |
 
 ## Tools (`src/ares/tools/`)
 
 ### Red Team Tools (`tools/red/`)
 
-| File | Purpose |
+| File/Directory | Purpose |
 | ---- | ------- |
-| `credential_discovery.py` | Kerberoasting, AS-REP roasting, password spray, hash extraction |
+| `credential_discovery/` | Credential discovery module (see below) |
 | `reconnaissance.py` | Network scanning, user enumeration, share discovery |
 | `orchestrator.py` | Orchestrator-specific tool dispatch and reporting |
-| `kerberos_attacks.py` | Kerberos delegation attacks, ticket generation |
+| `kerberos_attacks.py` | Kerberos delegation attacks, ticket generation, ADCS |
 | `lateral_movement.py` | PSExec, WMI, SMB execution, host compromise |
 | `acl_attacks.py` | ACL abuse, BloodHound integration, privilege escalation paths |
+| `privilege_escalation.py` | Local privilege escalation tools |
 | `coercion.py` | NTLM coercion, responder integration, relay attacks |
-| `cve_exploits.py` | ADCS exploitation (ESC1-15), direct CVE exploitation |
+| `cve_exploits.py` | CVE exploitation tools |
 | `common.py` | Shared utilities (parsing, error handling) |
 | `reporting.py` | Operation summary and result reporting |
+
+#### Credential Discovery (`tools/red/credential_discovery/`)
+
+| File | Purpose |
+| ---- | ------- |
+| `discovery.py` | Password spray, username=password, LDAP descriptions |
+| `harvesting.py` | secretsdump, kerberoast, AS-REP roast, credential extraction |
+| `cracking.py` | Hash cracking with hashcat and john |
+| `pilfering.py` | Share spidering, GPP passwords, SYSVOL scripts |
+
+#### Tool Classes (Exported from `tools/red/__init__.py`)
+
+| Class | Purpose |
+| ---- | ------- |
+| `NetworkEnumerationTools` | nmap, user/share enumeration, domain info |
+| `BloodHoundTools` | AD relationship mapping, attack path analysis |
+| `PostureValidationTools` | Access validation and reachability checks |
+| `CredentialDiscoveryTools` | Password spray, username=password, LDAP search |
+| `CredentialHarvestingTools` | secretsdump, kerberoast, AS-REP roast |
+| `SharePilferingTools` | GPP passwords, SYSVOL scripts, share spidering |
+| `CrackingTools` | hashcat, john |
+| `ACLExploitTools` | bloodyAD, pywhisker, dacledit, targeted kerberoast |
+| `CertipyTools` | ADCS exploitation (ESC1-ESC8) |
+| `DelegationTools` | Constrained/unconstrained delegation attacks |
+| `GMSATools` | gMSA password extraction |
+| `GoldenTicketTools` | Kerberos ticket forging |
+| `TrustAttackTools` | Domain/forest trust attacks |
+| `MSSQLTools` | SQL Server attacks, linked server pivoting |
+| `CVEExploitTools` | Known vulnerability exploits |
+| `LateralMovementTools` | psexec, evil-winrm, wmiexec, smbexec |
+| `PrivilegeEscalationTools` | Local privilege escalation |
+| `CoercionTools` | PetitPotam, Coercer, PrinterBug |
+| `CoercionNetworkTools` | Responder, ntlmrelayx, mitm6 |
+| `OrchestratorTools` | Dispatch functions for worker agents |
+| `CrackerCallbackTools` | Cracker callback functions |
+| `LateralCallbackTools` | Lateral movement callback functions |
+| `RedTeamReportingTools` | Status reporting, operation control |
 
 ### Blue Team Tools (`tools/blue/`)
 
@@ -122,9 +214,28 @@ The central framework for both blue and red team operations.
 
 ### Red Team (`agents/red/`)
 
-| File           | Purpose                            |
-| -------------- | ---------------------------------- |
-| `pentester.py` | Penetration testing orchestrator   |
+Red team agents are now created dynamically via `core/factories/red_agents.py`.
+The orchestrator runs in `core/orchestrator/` and workers run in `core/worker/`.
+
+## Evaluation Framework (`src/ares/eval/`)
+
+| File | Purpose |
+| ---- | ------- |
+| `workflow.py` | Evaluation runner and scenario execution |
+| `results.py` | Evaluation result models and aggregation |
+| `scorers.py` | IOC detection and technique coverage scoring |
+| `ground_truth.py` | Ground truth extraction from red team state |
+| `detection_playbook.py` | Detection playbook generation from red ops |
+| `gap_analysis.py` | Detection gap analysis between red and blue |
+
+## Reports (`src/ares/reports/`)
+
+| File | Purpose |
+| ---- | ------- |
+| `investigation.py` | Blue team investigation report generation |
+| `redteam.py` | Red team operation report generation |
+| `blueteam.py` | Blue team consolidated operation reports |
+| `user_summary.py` | User-facing summary generation |
 
 ## Data Models (`src/ares/core/models.py`)
 
@@ -160,9 +271,7 @@ The central framework for both blue and red team operations.
 
 ```text
 templates/
-├── agent/                   # Agent system prompts
-│   ├── initial_alert_prompt.md.jinja
-│   └── system_instructions.md.jinja
+├── blueteam/                # Blue team templates
 ├── engines/                 # Question generation engines
 │   ├── attack_chains.yaml
 │   ├── climb_strategies.yaml
@@ -182,22 +291,34 @@ templates/
 │   │   ├── acl.md.jinja
 │   │   ├── privesc.md.jinja
 │   │   ├── lateral.md.jinja
-│   │   └── coercion.md.jinja
+│   │   ├── coercion.md.jinja
+│   │   └── system_instructions.md.jinja
 │   └── reports/             # Operation reports
-└── tools/                   # Tool prompts
+├── tools/                   # Tool prompts
+└── README.md.j2             # Template documentation
 ```
 
 ## CLI Entry Points (`src/ares/main.py`)
 
 | Command | Purpose |
 | ------- | ------- |
-| `ares investigate-alert` | Investigate a Grafana alert |
-| `ares red-team` | Run single-agent red team operation |
-| `ares multi-agent-red` | Run multi-agent red team operation |
-| `ares worker` | Run worker agent |
-| `ares orchestrator` | Run orchestrator service |
-| `ares loot` | Extract operation state |
-| `ares config` | Show configuration |
+| `ares` (default) | Run blue team in poll mode (Grafana alerts) |
+| `ares investigate-alert` | Investigate a specific alert (JSON file or string) |
+| `ares multi-agent` | Run multi-agent red team operation |
+| `ares worker` | Run specialized worker agent |
+| `ares evaluate` | Evaluate blue team against red team state |
+| `ares evaluate-dataset` | Evaluate against a dataset of red team operations |
+| `ares version` | Print version information |
+
+Additional CLI commands are in `cli_ops.py`:
+
+| Function | Purpose |
+| -------- | ------- |
+| `loot` | Extract operation state from Redis |
+| `status` | Check operation status |
+| `list_operations` | List all operations |
+| `inject_credential` | Inject credential into running operation |
+| `inject_vulnerability` | Inject vulnerability into running operation |
 
 ## Configuration
 
@@ -228,14 +349,14 @@ Each agent defines: model selection, max_steps, pod_selector, capabilities.
 
 ```text
 Orchestrator Pod (ares-orchestrator)
-    ↓ Redis pub/sub
+    ↓ Redis task queues + pub/sub
 Worker Pods:
     ├── RECON (ares-recon-agent)
-    ├── CREDENTIAL_ACCESS (ares-credential-agent)
+    ├── CREDENTIAL_ACCESS (ares-credential-access-agent)
     ├── CRACKER (ares-cracker-agent)
     ├── ACL (ares-acl-agent)
     ├── PRIVESC (ares-privesc-agent)
-    ├── LATERAL (ares-lateral-agent)
+    ├── LATERAL (ares-lateral-movement-agent)
     └── COERCION (ares-coercion-agent)
 ```
 
@@ -243,16 +364,15 @@ Worker Pods:
 
 1. Orchestrator coordinates, workers execute
 2. Workers are specialists with domain-specific tools
-3. Shared state via Redis
+3. Shared state via Redis (write-through cache pattern)
 
 **For detailed agent configuration (max_steps, tool classes, model selection):**
 See [Agent Quick Reference](red.md#agent-quick-reference) in `docs/red.md`.
 
 **Pod Labels:**
 
-- All agents: `ares.dreadnode.io/component=red-team`
 - Orchestrator: `app.kubernetes.io/name=ares-orchestrator`
-- Workers: `ares.dreadnode.io/role={enum,cracker,acl,privesc,lateral,coercion}`
+- Workers: `ares.dreadnode.io/role={recon,credential_access,cracker,acl,privesc,lateral,coercion}`
 
 **Namespace:** `attack-simulation`
 
@@ -263,12 +383,13 @@ See [Agent Quick Reference](red.md#agent-quick-reference) in `docs/red.md`.
 | Category | Files |
 | -------- | ----- |
 | Core Framework | `test_dispatcher.py`, `test_worker.py`, `test_orchestrator.py`, `test_task_queue.py` |
-| Models & State | `test_models.py`, `test_persistence.py` |
-| Multi-Agent | `test_multi_agent_workflow.py`, `test_red_agents.py`, `test_red_factory.py` |
+| Models & State | `test_models.py`, `test_persistence.py`, `test_state_backend.py` |
+| Multi-Agent | `test_multi_agent_workflow.py`, `test_red_agents.py` |
 | Red Team Tools | `test_recon_toolset.py`, `test_lateral_movement.py`, `test_orchestrator_tools.py` |
 | Blue Team Tools | `test_actions.py`, `test_grafana.py`, `test_investigation_tools.py` |
 | Reports | `test_reports_investigation.py`, `test_reports_redteam.py` |
-| Integration | `tests/integration/test_multi_agent_workflow.py` |
+| Evaluation | `test_eval_workflow.py`, `test_scorers.py` |
+| Integration | `tests/integration/` |
 
 ### Test Fixtures (`tests/conftest.py`)
 
@@ -295,25 +416,30 @@ See [Agent Quick Reference](red.md#agent-quick-reference) in `docs/red.md`.
 ### Key Files to Understand the System
 
 1. `docs/red.md` - Multi-agent architecture principles (includes Agent Quick Reference)
-2. `src/ares/core/models.py` - Data model definitions
-3. `src/ares/core/dispatcher/` - Task coordination logic
-4. `src/ares/core/worker/` - Worker agent implementation
-5. `config/multi-agent-production.yaml` - Agent configurations
+2. `docs/blue.md` - Blue team investigation workflow
+3. `src/ares/core/models.py` - Data model definitions
+4. `src/ares/core/dispatcher/` - Task coordination logic
+5. `src/ares/core/worker/` - Worker agent implementation
+6. `src/ares/core/orchestrator/` - Orchestrator implementation
+7. `config/multi-agent-production.yaml` - Agent configurations
 
 ### Entry Points to Understand Flow
 
 1. `src/ares/main.py` - CLI commands
-2. `src/ares/agents/red/pentester.py` - Red team orchestrator
-3. `src/ares/agents/blue/soc_investigator.py` - Blue team orchestrator
-4. `src/ares/core/orchestrator/` - Multi-agent coordination
+2. `src/ares/agents/blue/soc_investigator.py` - Blue team orchestrator
+3. `src/ares/core/orchestrator/_orchestrator.py` - Red team orchestrator
+4. `src/ares/core/worker/_worker.py` - Worker agent task loop
 5. `src/ares/core/task_queue.py` - Message passing
+6. `src/ares/core/factories/red_agents.py` - Agent creation and toolsets
 
 ### Core Dependencies
 
 - **dreadnode** - Agent SDK
+- **rigging** - LLM interaction framework
 - **cyclopts** - CLI framework
 - **loguru** - Logging
 - **httpx** - HTTP client
 - **redis** - Multi-agent coordination
 - **kubernetes** - K8s integration
 - **boto3** - AWS integration
+- **litellm** - LLM provider abstraction

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -122,8 +122,15 @@ When adding new features, follow the project structure:
 
 ```bash
 .
+├── src/ares/          # Main package
+│   ├── core/          # Core framework
+│   ├── tools/         # Tool implementations
+│   ├── agents/        # Agent orchestrators
+│   ├── eval/          # Evaluation framework
+│   ├── reports/       # Report generators
+│   └── templates/     # Jinja2 templates
+├── config/            # Configuration files
 ├── docs/              # Documentation
-├── examples/          # Usage examples
 ├── tests/             # Test suite
 └── pyproject.toml     # Project configuration
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,18 +63,24 @@ ares/
 │   │   ├── blue/                # SOC investigation agent
 │   │   └── red/                 # Penetration testing agent
 │   ├── core/                    # Core models and engines
-│   │   └── factories/           # Agent factories
+│   │   ├── dispatcher/          # Task dispatch and routing
+│   │   ├── worker/              # Worker agent implementation
+│   │   ├── orchestrator/        # Orchestrator implementation
+│   │   ├── factories/           # Agent factories
+│   │   └── replay/              # Deterministic replay
+│   ├── eval/                    # Evaluation framework
 │   ├── integrations/            # External integrations (MITRE)
 │   ├── reports/                 # Report generators
+│   ├── templates/               # Jinja2 prompt templates
+│   │   ├── blueteam/            # Blue team templates
+│   │   ├── engines/             # Question engine templates
+│   │   ├── redteam/             # Red team agent templates
+│   │   └── reports/             # Report templates
 │   └── tools/                   # Agent toolsets
 │       ├── blue/                # Blue team tools
 │       ├── red/                 # Red team tools
 │       └── shared/              # Shared tools (MITRE)
-├── templates/                   # Jinja2 prompt templates
-│   ├── agent/                   # Blue team agent templates
-│   ├── engines/                 # Question engine templates
-│   ├── redteam/                 # Red team agent templates
-│   └── reports/                 # Report templates
+├── config/                      # Configuration files
 ├── tests/                       # Test suite
 ├── docs/                        # Documentation
 └── reports/                     # Generated reports

--- a/docs/prompt_templates.md
+++ b/docs/prompt_templates.md
@@ -36,10 +36,10 @@ result = loader.render(
 
 | Category | Purpose | Status |
 | -------- | ------- | ------ |
-| `agent/` | Blue team system instructions & alert prompts | ✅ Complete |
+| `blueteam/` | Blue team system instructions & prompts | ✅ Complete |
 | `engines/` | Question generation & attack chain templates | ✅ Complete |
 | `tools/` | Investigation query suggestions | ✅ Complete |
-| `reports/` | Report section templates | ⚠️ Partial |
+| `reports/` | Report section templates | ✅ Complete |
 | `redteam/` | Red team agent templates | ✅ Complete |
 
 ## API Reference
@@ -55,12 +55,25 @@ templates = loader.list_templates()
 
 ## Template Variables
 
-### Agent Templates
+### Blue Team Templates
 
 | Template | Required Variables | Purpose |
 | -------- | ------------------ | ------- |
-| `agent/system_instructions.md.jinja` | None | Agent system instructions |
-| `agent/initial_alert_prompt.md.jinja` | `alert_name`, `severity`, `instance`, `job`, `starts_at`, `summary`, `description`, `labels` | Alert investigation context |
+| `blueteam/*.md.jinja` | Varies | Blue team agent instructions |
+
+### Red Team Templates
+
+| Template | Required Variables | Purpose |
+| -------- | ------------------ | ------- |
+| `redteam/agents/orchestrator.md.jinja` | `state`, `credentials`, etc. | Orchestrator system prompt |
+| `redteam/agents/recon.md.jinja` | `task`, `state` | Recon agent instructions |
+| `redteam/agents/credential_access.md.jinja` | `task`, `state` | Credential access agent |
+| `redteam/agents/cracker.md.jinja` | `task`, `state` | Cracker agent instructions |
+| `redteam/agents/acl.md.jinja` | `task`, `state` | ACL agent instructions |
+| `redteam/agents/privesc.md.jinja` | `task`, `state` | PrivEsc agent instructions |
+| `redteam/agents/lateral.md.jinja` | `task`, `state` | Lateral movement agent |
+| `redteam/agents/coercion.md.jinja` | `task`, `state` | Coercion agent instructions |
+| `redteam/agents/system_instructions.md.jinja` | `state` | Shared system instructions |
 
 ### Engine Templates
 
@@ -137,13 +150,14 @@ except Exception as e:
 | File | Status | Notes |
 | ---- | ------ | ----- |
 | `src/ares/agents/blue/soc_investigator.py` | ✅ Complete | Uses template loader |
-| `src/ares/agents/red/pentester.py` | ✅ Complete | Uses template loader |
 | `src/ares/core/factories/blue_factory.py` | ✅ Complete | System instructions from template |
-| `src/ares/core/factories/red_factory.py` | ✅ Complete | System instructions from template |
+| `src/ares/core/factories/red_agents.py` | ✅ Complete | Red team agent templates |
+| `src/ares/core/worker/prompts.py` | ✅ Complete | Worker prompt generation |
 | `src/ares/core/engines.py` | ✅ Complete | All questions templated |
 | `src/ares/tools/blue/investigation.py` | ✅ Complete | Query suggestions templated |
 | `src/ares/reports/investigation.py` | ⚠️ Partial | Templates exist, integration incomplete |
 | `src/ares/reports/redteam.py` | ✅ Complete | Red team reports templated |
+| `src/ares/reports/blueteam.py` | ✅ Complete | Blue team reports templated |
 
 ## Troubleshooting
 


### PR DESCRIPTION

**Key Changes:**

- Refactored documentation to reflect new multi-agent red team framework
- Expanded codebase and directory structure explanations for clarity
- Updated CLI usage, workflow, and toolset documentation to match current system

**Added:**

- Detailed description of multi-agent red team architecture, agent roles,
  orchestration, and Redis-based coordination in the `README.md`
- Expanded explanation of codebase layout, including new submodules such as
  `dispatcher`, `worker`, `orchestrator`, `replay`, `factories`, and agent
  toolset classes in `docs/codemap.md`
- Descriptions for the evaluation framework and report modules in `docs/codemap.md`
- New sections in `README.md` documenting the multi-agent operation workflow,
  commands, and best practices for operation monitoring
- Extended CLI command and configuration documentation to support new agent types
- New breakdowns of prompt template structure and required variables in
  `docs/prompt_templates.md`

**Changed:**

- Updated `README.md` to clarify red team operation phases, agent specializations,
  and Redis-based shared state, replacing outdated single-agent terminology
- Revised task and command tables in `README.md` to document new multi-agent
  commands and workflows
- Improved and expanded codebase map in `docs/codemap.md` and `docs/index.md` to
  reflect new core modules and correct agent/worker/orchestrator placement
- Clarified directory structure in `docs/contributing.md` and `docs/index.md` to
  match current repository layout
- Updated prompt template documentation in `docs/prompt_templates.md` to reflect
  new template categories (`blueteam/`, `redteam/`) and their integration points
- Enhanced lists of key files, core dependencies, and testing structure to reflect
  latest codebase organization in `docs/codemap.md`
- Improved variable documentation and template API references in
  `docs/prompt_templates.md`

**Removed:**

- Outdated references to deprecated files and single-agent red team workflow
  (e.g., `pentester.py`, old agent directory structures)
- Legacy agent system prompt templates and instructions that have been replaced
  by new template organization