### PR TITLE
refactor: centralize api key and model selection vars in blue team Taskfile

### DIFF
--- a/.taskfiles/blue/Taskfile.yaml
+++ b/.taskfiles/blue/Taskfile.yaml
@@ -7,6 +7,26 @@ vars:
   PROFILE: '{{.PROFILE | default "infrastructure"}}'
   REGION: '{{.REGION | default "us-west-2"}}'
 
+  # 1Password API keys (shared across tasks)
+  ANTHROPIC_API_KEY:
+    sh: op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
+  DREADNODE_API_KEY:
+    sh: op item get "Dreadnode Dev Platform" --fields api-key --reveal 2>/dev/null || echo ""
+  GRAFANA_SERVICE_ACCOUNT_TOKEN:
+    sh: op item get "Ares Grafana MCP" --fields api-token --reveal 2>/dev/null || echo ""
+  OPENAI_API_KEY:
+    sh: op item get "Openai" --fields dreadnode-jayson-api-key --reveal 2>/dev/null || echo ""
+    # sh: op item get "Openai" --fields dreadnode-personal-api-key --reveal 2>/dev/null || echo ""
+
+  # Model selection (MODEL_ALL takes precedence over MODEL)
+  MODEL_ARG:
+    sh: |
+      if [ -n "{{.MODEL_ALL}}" ]; then
+        echo "{{.MODEL_ALL}}"
+      else
+        echo "{{.MODEL}}"
+      fi
+
 tasks:
   # ===========================================================================
   # Blue Team Agent Tasks
@@ -15,22 +35,6 @@ tasks:
   poll:
     desc: "Run blue team agent in poll mode (uses 1Password for API keys)"
     silent: true
-    vars:
-      ANTHROPIC_API_KEY:
-        sh: op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
-      DREADNODE_API_KEY:
-        sh: op item get "Dreadnode Dev Platform" --fields api-key --reveal 2>/dev/null || echo ""
-      GRAFANA_SERVICE_ACCOUNT_TOKEN:
-        sh: op item get "Ares Grafana MCP" --fields api-token --reveal 2>/dev/null || echo ""
-      OPENAI_API_KEY:
-        sh: op item get "Openai" --fields dreadnode-personal-api-key --reveal 2>/dev/null || echo ""
-      MODEL_ARG:
-        sh: |
-          if [ -n "{{.MODEL_ALL}}" ]; then
-            echo "{{.MODEL_ALL}}"
-          else
-            echo "{{.MODEL}}"
-          fi
     cmds:
       - |
         # Verify AWS auth
@@ -65,14 +69,6 @@ tasks:
   poll:local:
     desc: "Run blue team agent in poll mode using .env file"
     silent: true
-    vars:
-      MODEL_ARG:
-        sh: |
-          if [ -n "{{.MODEL_ALL}}" ]; then
-            echo "{{.MODEL_ALL}}"
-          else
-            echo "{{.MODEL}}"
-          fi
     preconditions:
       - sh: test -f .env
         msg: ".env file not found"
@@ -111,21 +107,6 @@ tasks:
     vars:
       OPERATION_ID: '{{.OPERATION_ID | default ""}}'
       LATEST: '{{.LATEST | default ""}}'
-      ANTHROPIC_API_KEY:
-        sh: op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
-      DREADNODE_API_KEY:
-        sh: op item get "Dreadnode Dev Platform" --fields api-key --reveal 2>/dev/null || echo ""
-      GRAFANA_SERVICE_ACCOUNT_TOKEN:
-        sh: op item get "Ares Grafana MCP" --fields api-token --reveal 2>/dev/null || echo ""
-      OPENAI_API_KEY:
-        sh: op item get "Openai" --fields dreadnode-personal-api-key --reveal 2>/dev/null || echo ""
-      MODEL_ARG:
-        sh: |
-          if [ -n "{{.MODEL_ALL}}" ]; then
-            echo "{{.MODEL_ALL}}"
-          else
-            echo "{{.MODEL}}"
-          fi
     cmds:
       - |
         # Verify AWS auth
@@ -173,13 +154,6 @@ tasks:
     vars:
       OPERATION_ID: '{{.OPERATION_ID | default ""}}'
       LATEST: '{{.LATEST | default ""}}'
-      MODEL_ARG:
-        sh: |
-          if [ -n "{{.MODEL_ALL}}" ]; then
-            echo "{{.MODEL_ALL}}"
-          else
-            echo "{{.MODEL}}"
-          fi
     preconditions:
       - sh: test -f .env
         msg: ".env file not found"
@@ -227,21 +201,6 @@ tasks:
     silent: true
     vars:
       ALERT: '{{.ALERT | default ""}}'
-      ANTHROPIC_API_KEY:
-        sh: op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
-      DREADNODE_API_KEY:
-        sh: op item get "Dreadnode Dev Platform" --fields api-key --reveal 2>/dev/null || echo ""
-      GRAFANA_SERVICE_ACCOUNT_TOKEN:
-        sh: op item get "Ares Grafana MCP" --fields grafana-token --reveal 2>/dev/null || echo ""
-      OPENAI_API_KEY:
-        sh: op item get "Openai" --fields dreadnode-personal-api-key --reveal 2>/dev/null || echo ""
-      MODEL_ARG:
-        sh: |
-          if [ -n "{{.MODEL_ALL}}" ]; then
-            echo "{{.MODEL_ALL}}"
-          else
-            echo "{{.MODEL}}"
-          fi
     preconditions:
       - sh: test -n "{{.ALERT}}"
         msg: "ALERT variable is required. Usage: task blue:investigate ALERT=alert.json"

--- a/.taskfiles/red/Taskfile.yaml
+++ b/.taskfiles/red/Taskfile.yaml
@@ -26,7 +26,8 @@ tasks:
       GRAFANA_SERVICE_ACCOUNT_TOKEN:
         sh: op item get "Ares Grafana MCP" --fields grafana-token --reveal 2>/dev/null || echo ""
       OPENAI_API_KEY:
-        sh: op item get "Openai" --fields dreadnode-personal-api-key --reveal 2>/dev/null || echo ""
+        sh: op item get "Openai" --fields dreadnode-ares-api-key --reveal 2>/dev/null || echo ""
+        # sh: op item get "Openai" --fields dreadnode-jayson-api-key --reveal 2>/dev/null || echo ""
       ARES_MODEL:
         sh: |
           if [ -n "{{.MODEL_ALL}}" ]; then


### PR DESCRIPTION

**Key Changes:**

- Centralized API key and model selection variable definitions for blue team tasks
- Removed redundant per-task variable declarations for improved maintainability
- Standardized OpenAI API key usage in red team Taskfile with clearer intent

**Added:**

- Centralized API key and model selection variables at the top of the blue team
  `Taskfile.yaml`, making them available to all tasks
- MODEL_ARG logic for model precedence is now globally defined and reused

**Changed:**

- All blue team tasks now inherit API key and model selection vars from the root
  level instead of defining them redundantly within each task
- Red team task for OpenAI API key updated to use
  `dreadnode-ares-api-key` by default, with a commented alternative for clarity

**Removed:**

- Per-task API key and model selection variable definitions from all blue team
  tasks, eliminating duplication and reducing risk of inconsistency