### PR TITLE
feat: add multi-agent blue team investigation and severity-based orchestrator routing

### DIFF
--- a/src/ares/agents/blue/__init__.py
+++ b/src/ares/agents/blue/__init__.py
@@ -3,6 +3,16 @@
 from ares.agents.blue.soc_investigator import InvestigationOrchestrator, build_initial_prompt
 
 __all__ = [
+    "BlueTeamOrchestrator",
     "InvestigationOrchestrator",
     "build_initial_prompt",
 ]
+
+
+def __getattr__(name: str):
+    if name == "BlueTeamOrchestrator":
+        from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
+
+        return BlueTeamOrchestrator
+
+    raise AttributeError(f"module 'ares.agents.blue' has no attribute {name!r}")

--- a/src/ares/agents/blue/multi_agent_orchestrator.py
+++ b/src/ares/agents/blue/multi_agent_orchestrator.py
@@ -12,13 +12,10 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import dreadnode as dn
-from dreadnode.agent import Agent, Thread
-from dreadnode.agent.stop import tool_use
+from dreadnode.agent import Thread
 from dreadnode.agent.tools.base import Toolset
 from loguru import logger
 
@@ -29,19 +26,16 @@ from ares.core.factories.blue_agents import (
     create_blue_agent,
     get_blue_stop_conditions,
     load_blue_instructions,
-    max_tool_calls_stop,
 )
 from ares.core.models import (
     BlueRole,
-    BlueTaskInfo,
-    BlueTaskType,
     InvestigationState,
-    SharedBlueTeamState,
 )
-from ares.core.templates import get_template_loader
 from ares.reports.investigation import MarkdownReportGenerator
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ares.integrations.mitre import MITREAttackClient
 
 
@@ -53,7 +47,10 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
     """
 
     _dispatcher: BlueTeamDispatcher | None = None
-    _workers: dict[BlueRole, BlueWorkerAgent] = {}
+    _workers: dict[BlueRole, BlueWorkerAgent]
+
+    def __init__(self) -> None:
+        self._workers = {}
 
     def set_dispatcher(self, dispatcher: BlueTeamDispatcher) -> None:
         self._dispatcher = dispatcher
@@ -96,9 +93,9 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
             worker.start_task(task)
             result = await self._dispatcher.wait_for_result(task.task_id, timeout=600)
             return _format_task_result("Triage", task.task_id, result)
-        else:
-            worker.start_task(task)
-            return f"[+] Triage dispatched: task_id={task.task_id}. Use get_task_result() to check."
+
+        worker.start_task(task)
+        return f"[+] Triage dispatched: task_id={task.task_id}. Use get_task_result() to check."
 
     @dn.tool_method  # type: ignore[untyped-decorator]
     async def dispatch_threat_hunt(
@@ -145,9 +142,9 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
             worker.start_task(task)
             result = await self._dispatcher.wait_for_result(task.task_id, timeout=600)
             return _format_task_result("Threat Hunt", task.task_id, result)
-        else:
-            worker.start_task(task)
-            return f"[+] Threat hunt dispatched: task_id={task.task_id}."
+
+        worker.start_task(task)
+        return f"[+] Threat hunt dispatched: task_id={task.task_id}."
 
     @dn.tool_method  # type: ignore[untyped-decorator]
     async def dispatch_lateral_analysis(
@@ -188,9 +185,9 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
             worker.start_task(task)
             result = await self._dispatcher.wait_for_result(task.task_id, timeout=600)
             return _format_task_result("Lateral Analysis", task.task_id, result)
-        else:
-            worker.start_task(task)
-            return f"[+] Lateral analysis dispatched: task_id={task.task_id}."
+
+        worker.start_task(task)
+        return f"[+] Lateral analysis dispatched: task_id={task.task_id}."
 
     @dn.tool_method  # type: ignore[untyped-decorator]
     async def get_investigation_status(self) -> str:
@@ -285,7 +282,7 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
                 await backend.add_recommendation(rec)
 
         logger.info(f"Investigation completed: {summary[:100]}...")
-        return f"[+] Investigation complete. Summary recorded. Report will be generated."
+        return "[+] Investigation complete. Summary recorded. Report will be generated."
 
     @dn.tool_method  # type: ignore[untyped-decorator]
     async def escalate_investigation(
@@ -313,7 +310,7 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
             return "ERROR: No dispatcher configured"
 
         backend = self._dispatcher.backend
-        await backend.set_meta("escalated", True)
+        await backend.set_meta("escalated", value=True)
         await backend.set_meta("escalation_reason", reason)
 
         if attack_synopsis:
@@ -332,16 +329,18 @@ def _format_task_result(task_type: str, task_id: str, result: dict[str, Any]) ->
     lines = [f"=== {task_type} Result (task_id={task_id}) ==="]
 
     if result.get("error"):
-        lines.append(f"Status: FAILED")
+        lines.append("Status: FAILED")
         lines.append(f"Error: {result['error']}")
     else:
-        lines.append(f"Status: SUCCESS")
+        lines.append("Status: SUCCESS")
 
     inner = result.get("result", {})
     if isinstance(inner, dict):
         # Format known result fields
         if inner.get("summary") or inner.get("findings_summary") or inner.get("scope_summary"):
-            summary = inner.get("summary") or inner.get("findings_summary") or inner.get("scope_summary")
+            summary = (
+                inner.get("summary") or inner.get("findings_summary") or inner.get("scope_summary")
+            )
             lines.append(f"Summary: {summary}")
 
         if inner.get("severity_assessment"):

--- a/src/ares/agents/blue/multi_agent_orchestrator.py
+++ b/src/ares/agents/blue/multi_agent_orchestrator.py
@@ -94,7 +94,7 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
 
         if wait_for_result:
             worker.start_task(task)
-            result = await self._dispatcher.wait_for_result(task.task_id, timeout=300)
+            result = await self._dispatcher.wait_for_result(task.task_id, timeout=600)
             return _format_task_result("Triage", task.task_id, result)
         else:
             worker.start_task(task)
@@ -143,7 +143,7 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
 
         if wait_for_result:
             worker.start_task(task)
-            result = await self._dispatcher.wait_for_result(task.task_id, timeout=300)
+            result = await self._dispatcher.wait_for_result(task.task_id, timeout=600)
             return _format_task_result("Threat Hunt", task.task_id, result)
         else:
             worker.start_task(task)
@@ -186,7 +186,7 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
 
         if wait_for_result:
             worker.start_task(task)
-            result = await self._dispatcher.wait_for_result(task.task_id, timeout=300)
+            result = await self._dispatcher.wait_for_result(task.task_id, timeout=600)
             return _format_task_result("Lateral Analysis", task.task_id, result)
         else:
             worker.start_task(task)
@@ -292,6 +292,8 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
         self,
         reason: str,
         severity: str,
+        attack_synopsis: str = "",
+        recommendations: list[str] | None = None,
     ) -> str:
         """Escalate the investigation for human analyst review.
 
@@ -301,6 +303,8 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
         Args:
             reason: Why escalation is needed.
             severity: Escalation severity: critical, high, medium.
+            attack_synopsis: Narrative of the attack chain discovered so far.
+            recommendations: List of recommended containment/remediation actions.
 
         Returns:
             Confirmation message.
@@ -311,6 +315,13 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
         backend = self._dispatcher.backend
         await backend.set_meta("escalated", True)
         await backend.set_meta("escalation_reason", reason)
+
+        if attack_synopsis:
+            await backend.set_meta("attack_synopsis", attack_synopsis)
+
+        if recommendations:
+            for rec in recommendations:
+                await backend.add_recommendation(rec)
 
         logger.warning(f"Investigation ESCALATED: {reason} (severity={severity})")
         return f"[!] Investigation ESCALATED. Reason: {reason}. Severity: {severity}."
@@ -477,7 +488,7 @@ class BlueTeamOrchestrator:
         # Connect to Redis
         from ares.core.redis_client import create_redis_client
 
-        redis_client = create_redis_client(self.redis_url)
+        redis_client = await create_redis_client(self.redis_url)
         await redis_client.ping()
 
         # Create dispatcher
@@ -491,9 +502,9 @@ class BlueTeamOrchestrator:
         workers: dict[BlueRole, BlueWorkerAgent] = {}
 
         for role, max_steps in [
-            (BlueRole.TRIAGE, 20),
-            (BlueRole.THREAT_HUNTER, 30),
-            (BlueRole.LATERAL_ANALYST, 25),
+            (BlueRole.TRIAGE, 8),
+            (BlueRole.THREAT_HUNTER, 20),
+            (BlueRole.LATERAL_ANALYST, 15),
         ]:
             agent, callback_tools = create_blue_agent(
                 role=role,
@@ -503,6 +514,8 @@ class BlueTeamOrchestrator:
                 mitre_client=self.mitre_client,
                 mcp_tools=self._mcp_tools,
                 max_steps=max_steps,
+                grafana_url=self.grafana_url,
+                alert=alert,
             )
             worker = BlueWorkerAgent(
                 role=role,

--- a/src/ares/agents/blue/multi_agent_orchestrator.py
+++ b/src/ares/agents/blue/multi_agent_orchestrator.py
@@ -1,0 +1,616 @@
+"""Blue team multi-agent orchestrator.
+
+Coordinates triage, threat hunter, and lateral analyst workers
+for investigating security alerts. Workers run in-process via
+asyncio.create_task() with shared state in Redis.
+
+The orchestrator LLM decides when to dispatch tasks and how to
+synthesize findings. Workers report back via the dispatcher.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import dreadnode as dn
+from dreadnode.agent import Agent, Thread
+from dreadnode.agent.stop import tool_use
+from dreadnode.agent.tools.base import Toolset
+from loguru import logger
+
+from ares.agents.blue.soc_investigator import WatchdogTimer, build_initial_prompt
+from ares.core.blue_dispatcher import BlueTeamDispatcher
+from ares.core.blue_worker import BlueWorkerAgent
+from ares.core.factories.blue_agents import (
+    create_blue_agent,
+    get_blue_stop_conditions,
+    load_blue_instructions,
+    max_tool_calls_stop,
+)
+from ares.core.models import (
+    BlueRole,
+    BlueTaskInfo,
+    BlueTaskType,
+    InvestigationState,
+    SharedBlueTeamState,
+)
+from ares.core.templates import get_template_loader
+from ares.reports.investigation import MarkdownReportGenerator
+
+if TYPE_CHECKING:
+    from ares.integrations.mitre import MITREAttackClient
+
+
+class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
+    """Tools available to the orchestrator LLM for dispatching work.
+
+    The orchestrator doesn't query logs directly - it dispatches
+    tasks to specialized workers and synthesizes their findings.
+    """
+
+    _dispatcher: BlueTeamDispatcher | None = None
+    _workers: dict[BlueRole, BlueWorkerAgent] = {}
+
+    def set_dispatcher(self, dispatcher: BlueTeamDispatcher) -> None:
+        self._dispatcher = dispatcher
+
+    def set_workers(self, workers: dict[BlueRole, BlueWorkerAgent]) -> None:
+        self._workers = workers
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def dispatch_triage(
+        self,
+        wait_for_result: bool = True,
+    ) -> str:
+        """Dispatch initial triage of the alert to the triage worker.
+
+        The triage worker will assess the alert severity, check for
+        correlated alerts, and record initial evidence.
+
+        This should be your FIRST action for any new alert.
+
+        Args:
+            wait_for_result: If True, wait for triage to complete and
+                return findings. If False, return task_id immediately.
+
+        Returns:
+            Triage findings (if wait_for_result) or task_id.
+        """
+        if not self._dispatcher:
+            return "ERROR: No dispatcher configured"
+
+        alert = self._dispatcher.shared_state.alert
+        correlation = self._dispatcher.shared_state.correlation_context
+
+        task = await self._dispatcher.dispatch_triage(alert, correlation)
+        worker = self._workers.get(BlueRole.TRIAGE)
+
+        if not worker:
+            return f"ERROR: No triage worker available. Task {task.task_id} queued."
+
+        if wait_for_result:
+            worker.start_task(task)
+            result = await self._dispatcher.wait_for_result(task.task_id, timeout=300)
+            return _format_task_result("Triage", task.task_id, result)
+        else:
+            worker.start_task(task)
+            return f"[+] Triage dispatched: task_id={task.task_id}. Use get_task_result() to check."
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def dispatch_threat_hunt(
+        self,
+        technique_id: str = "",
+        detection_method: str = "",
+        hostname: str = "",
+        username: str = "",
+        context: str = "",
+        wait_for_result: bool = True,
+    ) -> str:
+        """Dispatch a threat hunting task to the threat hunter worker.
+
+        The threat hunter will run detection queries, investigate
+        specific MITRE techniques, and record evidence.
+
+        Args:
+            technique_id: MITRE technique to hunt for (e.g., "T1558.003").
+            detection_method: Specific detection query to run (e.g., "detect_kerberoasting").
+            hostname: Host to focus investigation on.
+            username: User to focus investigation on.
+            context: Additional context from prior investigation steps.
+            wait_for_result: If True, wait for hunt to complete.
+
+        Returns:
+            Hunt findings (if wait_for_result) or task_id.
+        """
+        if not self._dispatcher:
+            return "ERROR: No dispatcher configured"
+
+        task = await self._dispatcher.dispatch_threat_hunt(
+            technique_id=technique_id,
+            detection_method=detection_method,
+            hostname=hostname,
+            username=username,
+            context=context,
+        )
+        worker = self._workers.get(BlueRole.THREAT_HUNTER)
+
+        if not worker:
+            return f"ERROR: No threat hunter worker available. Task {task.task_id} queued."
+
+        if wait_for_result:
+            worker.start_task(task)
+            result = await self._dispatcher.wait_for_result(task.task_id, timeout=300)
+            return _format_task_result("Threat Hunt", task.task_id, result)
+        else:
+            worker.start_task(task)
+            return f"[+] Threat hunt dispatched: task_id={task.task_id}."
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def dispatch_lateral_analysis(
+        self,
+        focus_host: str = "",
+        focus_user: str = "",
+        context: str = "",
+        wait_for_result: bool = True,
+    ) -> str:
+        """Dispatch lateral movement analysis to the lateral analyst.
+
+        The lateral analyst will investigate scope, map lateral paths,
+        and identify compromise boundaries.
+
+        Args:
+            focus_host: Primary host to analyze lateral movement from/to.
+            focus_user: Primary user to analyze activity for.
+            context: Additional context from prior investigation steps.
+            wait_for_result: If True, wait for analysis to complete.
+
+        Returns:
+            Analysis findings (if wait_for_result) or task_id.
+        """
+        if not self._dispatcher:
+            return "ERROR: No dispatcher configured"
+
+        task = await self._dispatcher.dispatch_lateral_analysis(
+            focus_host=focus_host,
+            focus_user=focus_user,
+            context=context,
+        )
+        worker = self._workers.get(BlueRole.LATERAL_ANALYST)
+
+        if not worker:
+            return f"ERROR: No lateral analyst worker available. Task {task.task_id} queued."
+
+        if wait_for_result:
+            worker.start_task(task)
+            result = await self._dispatcher.wait_for_result(task.task_id, timeout=300)
+            return _format_task_result("Lateral Analysis", task.task_id, result)
+        else:
+            worker.start_task(task)
+            return f"[+] Lateral analysis dispatched: task_id={task.task_id}."
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def get_investigation_status(self) -> str:
+        """Get current investigation status across all workers.
+
+        Returns summary of evidence collected, techniques found,
+        hosts/users investigated, and task status.
+
+        Returns:
+            Formatted investigation status.
+        """
+        if not self._dispatcher:
+            return "ERROR: No dispatcher configured"
+
+        summary = await self._dispatcher.get_investigation_summary()
+        evidence_summary = await self._dispatcher.get_evidence_summary()
+
+        lines = [
+            "=== Investigation Status ===",
+            f"Stage: {summary.get('stage', 'unknown')}",
+            f"Evidence: {summary.get('evidence_count', 0)} items",
+            f"Techniques: {summary.get('technique_count', 0)}",
+            f"  IDs: {', '.join(summary.get('techniques_identified', [])[:10])}",
+            f"Highest Pyramid Level: {summary.get('highest_pyramid_level', 0)}/6",
+            f"Hosts Investigated: {', '.join(summary.get('hosts_investigated', [])[:10])}",
+            f"Users Investigated: {', '.join(summary.get('users_investigated', [])[:10])}",
+            f"Pending Tasks: {summary.get('pending_tasks', 0)}",
+            f"Completed Tasks: {summary.get('completed_tasks', 0)}",
+        ]
+
+        if evidence_summary.get("by_type"):
+            lines.append(f"Evidence by type: {evidence_summary['by_type']}")
+        if evidence_summary.get("by_pyramid_level"):
+            lines.append(f"Evidence by pyramid: {evidence_summary['by_pyramid_level']}")
+        if summary.get("queued_pivots", 0) > 0 or summary.get("queued_chains", 0) > 0:
+            lines.append(
+                f"Queued follow-ups: {summary.get('queued_pivots', 0)} pivots, "
+                f"{summary.get('queued_chains', 0)} chains"
+            )
+
+        return "\n".join(lines)
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def get_task_result(self, task_id: str) -> str:
+        """Get the result of a previously dispatched task.
+
+        Use this when you dispatched with wait_for_result=False.
+
+        Args:
+            task_id: The task ID returned by a dispatch call.
+
+        Returns:
+            Task result or status.
+        """
+        if not self._dispatcher:
+            return "ERROR: No dispatcher configured"
+
+        result = await self._dispatcher.wait_for_result(task_id, timeout=10)
+        if result.get("error") and "timed out" in str(result.get("error", "")):
+            return f"[*] Task {task_id} still running..."
+        return _format_task_result("Task", task_id, result)
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def complete_investigation(
+        self,
+        summary: str,
+        attack_synopsis: str | None = None,
+        recommendations: list[str] | None = None,
+    ) -> str:
+        """Complete the investigation with final synthesis.
+
+        Call this when you have gathered enough evidence and are
+        ready to generate the final report.
+
+        Args:
+            summary: Executive summary of the investigation.
+            attack_synopsis: Narrative of the attack chain.
+            recommendations: List of recommended actions.
+
+        Returns:
+            Confirmation message.
+        """
+        if not self._dispatcher:
+            return "ERROR: No dispatcher configured"
+
+        backend = self._dispatcher.backend
+        await backend.set_meta("attack_synopsis", attack_synopsis or summary)
+        await backend.set_meta("stage", "synthesis")
+
+        if recommendations:
+            for rec in recommendations:
+                await backend.add_recommendation(rec)
+
+        logger.info(f"Investigation completed: {summary[:100]}...")
+        return f"[+] Investigation complete. Summary recorded. Report will be generated."
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def escalate_investigation(
+        self,
+        reason: str,
+        severity: str,
+    ) -> str:
+        """Escalate the investigation for human analyst review.
+
+        Call this when you identify an active attack, critical
+        infrastructure at risk, or scope exceeds capacity.
+
+        Args:
+            reason: Why escalation is needed.
+            severity: Escalation severity: critical, high, medium.
+
+        Returns:
+            Confirmation message.
+        """
+        if not self._dispatcher:
+            return "ERROR: No dispatcher configured"
+
+        backend = self._dispatcher.backend
+        await backend.set_meta("escalated", True)
+        await backend.set_meta("escalation_reason", reason)
+
+        logger.warning(f"Investigation ESCALATED: {reason} (severity={severity})")
+        return f"[!] Investigation ESCALATED. Reason: {reason}. Severity: {severity}."
+
+
+def _format_task_result(task_type: str, task_id: str, result: dict[str, Any]) -> str:
+    """Format a task result for display to the orchestrator."""
+    lines = [f"=== {task_type} Result (task_id={task_id}) ==="]
+
+    if result.get("error"):
+        lines.append(f"Status: FAILED")
+        lines.append(f"Error: {result['error']}")
+    else:
+        lines.append(f"Status: SUCCESS")
+
+    inner = result.get("result", {})
+    if isinstance(inner, dict):
+        # Format known result fields
+        if inner.get("summary") or inner.get("findings_summary") or inner.get("scope_summary"):
+            summary = inner.get("summary") or inner.get("findings_summary") or inner.get("scope_summary")
+            lines.append(f"Summary: {summary}")
+
+        if inner.get("severity_assessment"):
+            lines.append(f"Severity: {inner['severity_assessment']}")
+
+        if inner.get("needs_deep_investigation") is not None:
+            lines.append(f"Needs Deep Investigation: {inner['needs_deep_investigation']}")
+
+        if inner.get("techniques_found"):
+            lines.append(f"Techniques: {', '.join(inner['techniques_found'])}")
+
+        if inner.get("initial_techniques"):
+            lines.append(f"Initial Techniques: {', '.join(inner['initial_techniques'])}")
+
+        if inner.get("evidence_highlights"):
+            lines.append("Evidence Highlights:")
+            for h in inner["evidence_highlights"][:5]:
+                lines.append(f"  - {h}")
+
+        if inner.get("recommended_next_steps"):
+            lines.append("Recommended Next Steps:")
+            for s in inner["recommended_next_steps"][:5]:
+                lines.append(f"  - {s}")
+
+        if inner.get("recommended_pivots"):
+            lines.append("Recommended Pivots:")
+            for p in inner["recommended_pivots"][:5]:
+                lines.append(f"  - {p}")
+
+        if inner.get("hosts_investigated"):
+            lines.append(f"Hosts: {', '.join(inner['hosts_investigated'][:10])}")
+
+        if inner.get("users_investigated"):
+            lines.append(f"Users: {', '.join(inner['users_investigated'][:10])}")
+
+        if inner.get("lateral_paths"):
+            lines.append("Lateral Paths:")
+            for p in inner["lateral_paths"][:5]:
+                lines.append(f"  - {p}")
+
+        if inner.get("containment_recommendations"):
+            lines.append("Containment:")
+            for c in inner["containment_recommendations"][:5]:
+                lines.append(f"  - {c}")
+
+        if inner.get("detection_gaps"):
+            lines.append("Detection Gaps:")
+            for g in inner["detection_gaps"][:5]:
+                lines.append(f"  - {g}")
+
+    return "\n".join(lines)
+
+
+class BlueTeamOrchestrator:
+    """Multi-agent blue team investigation orchestrator.
+
+    Coordinates triage, threat hunter, and lateral analyst workers
+    to investigate security alerts. Uses an LLM-driven orchestrator
+    agent that dispatches work to specialized workers.
+
+    Attributes:
+        model: LLM model identifier.
+        grafana_url: Grafana URL for MCP connection.
+        grafana_api_key: Grafana API key.
+        mitre_client: MITRE ATT&CK client.
+        report_dir: Directory for generated reports.
+        max_steps: Max orchestrator steps.
+        redis_url: Redis URL for shared state.
+        attack_context: Optional red team operation context.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        grafana_url: str,
+        grafana_api_key: str,
+        mitre_client: MITREAttackClient,
+        report_dir: Path,
+        max_steps: int = 50,
+        redis_url: str = "redis://localhost:6379",
+        attack_context: dict | None = None,
+    ):
+        self.model = model
+        self.grafana_url = grafana_url
+        self.grafana_api_key = grafana_api_key
+        self.mitre_client = mitre_client
+        self.report_dir = report_dir
+        self.max_steps = max_steps
+        self.redis_url = redis_url
+        self.attack_context = attack_context
+        self._mcp_tools: list | None = None
+
+    async def _ensure_mcp_connection(self) -> None:
+        """Ensure MCP connection is ready (from pool)."""
+        if self._mcp_tools is not None:
+            return
+
+        try:
+            from ares.tools.blue.grafana import MCPConnectionPool, connect_grafana_mcp
+
+            timeout = 10.0 if MCPConnectionPool.is_connected() else 60.0
+            mcp_client = await asyncio.wait_for(
+                connect_grafana_mcp(
+                    grafana_url=self.grafana_url,
+                    grafana_api_key=self.grafana_api_key,
+                ),
+                timeout=timeout,
+            )
+            self._mcp_tools = mcp_client.tools
+            logger.success(f"Grafana MCP ready ({len(self._mcp_tools or [])} tools)")
+        except Exception as e:
+            logger.warning(f"Failed to connect to Grafana MCP: {e}")
+            self._mcp_tools = None
+
+    async def _shutdown_mcp(self) -> None:
+        """Clear local MCP references."""
+        self._mcp_tools = None
+
+    async def investigate(
+        self,
+        alert: dict,
+        correlation_context: dict | None = None,
+    ) -> dict:
+        """Run a multi-agent investigation on an alert.
+
+        1. Connects to Redis and creates dispatcher + shared state
+        2. Creates 3 worker agents (triage, hunter, lateral)
+        3. Creates orchestrator agent with dispatch tools
+        4. Runs orchestrator LLM which dispatches work to workers
+        5. Generates report from shared state
+
+        Args:
+            alert: The alert dictionary.
+            correlation_context: Optional alert correlation context.
+
+        Returns:
+            Result dict matching monolithic orchestrator output shape.
+        """
+        investigation_id = f"inv-{uuid.uuid4().hex[:8]}"
+        alert_name = alert.get("labels", {}).get("alertname", "unknown")
+
+        logger.info(f"Starting multi-agent investigation {investigation_id}: {alert_name}")
+
+        # Connect to Redis
+        from ares.core.redis_client import create_redis_client
+
+        redis_client = create_redis_client(self.redis_url)
+        await redis_client.ping()
+
+        # Create dispatcher
+        dispatcher = BlueTeamDispatcher(redis_client)
+        await dispatcher.start(investigation_id, alert, correlation_context)
+
+        # Ensure MCP connection
+        await self._ensure_mcp_connection()
+
+        # Create worker agents
+        workers: dict[BlueRole, BlueWorkerAgent] = {}
+
+        for role, max_steps in [
+            (BlueRole.TRIAGE, 20),
+            (BlueRole.THREAT_HUNTER, 30),
+            (BlueRole.LATERAL_ANALYST, 25),
+        ]:
+            agent, callback_tools = create_blue_agent(
+                role=role,
+                model=self.model,
+                backend=dispatcher.backend,
+                dispatcher=dispatcher,
+                mitre_client=self.mitre_client,
+                mcp_tools=self._mcp_tools,
+                max_steps=max_steps,
+            )
+            worker = BlueWorkerAgent(
+                role=role,
+                agent=agent,
+                agent_name=f"{role.value}-{investigation_id[:8]}",
+                investigation_id=investigation_id,
+                dispatcher=dispatcher,
+                callback_tools=callback_tools,
+            )
+            workers[role] = worker
+
+        # Create orchestrator agent
+        orchestrator_tools = BlueOrchestratorTools()
+        orchestrator_tools.set_dispatcher(dispatcher)
+        orchestrator_tools.set_workers(workers)
+
+        instructions = load_blue_instructions(BlueRole.ORCHESTRATOR)
+        stop_conditions = get_blue_stop_conditions(BlueRole.ORCHESTRATOR)
+
+        orchestrator_agent = dn.Agent(
+            name="Blue Team Orchestrator",
+            model=self.model,
+            instructions=instructions,
+            max_steps=self.max_steps,
+            tools=[orchestrator_tools],
+            stop_conditions=stop_conditions,
+            thread=Thread(),  # type: ignore[call-arg]
+        )
+
+        # Build initial prompt
+        initial_prompt = build_initial_prompt(alert, self.attack_context)
+
+        # Watchdog timer
+        hard_timeout = (self.max_steps * 60) + 120
+        state_for_watchdog = InvestigationState(
+            investigation_id=investigation_id,
+            alert=alert,
+        )
+        watchdog = WatchdogTimer(
+            hard_timeout, investigation_id, state_for_watchdog, self.report_dir
+        )
+        watchdog.start()
+
+        try:
+            with dn.run(tags=["multi-agent-investigation", alert_name]):
+                dn.log_params(
+                    model=self.model,
+                    investigation_id=investigation_id,
+                    alert_name=alert_name,
+                    mode="multi_agent",
+                    max_steps=self.max_steps,
+                )
+
+                # Run orchestrator
+                timeout_seconds = self.max_steps * 60
+                try:
+                    result = await asyncio.wait_for(
+                        orchestrator_agent.run(initial_prompt),
+                        timeout=timeout_seconds,
+                    )
+                    logger.success(
+                        f"Orchestrator completed: {result.steps} steps, {result.stop_reason}"
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(f"Orchestrator timed out after {timeout_seconds}s")
+                except Exception as e:
+                    logger.error(f"Orchestrator failed: {e}")
+
+            # Snapshot shared state and convert to InvestigationState
+            shared_state = await dispatcher.snapshot_to_shared_state()
+            investigation_state = shared_state.to_investigation_state()
+
+            # Determine status
+            status = "completed"
+            if shared_state.escalated:
+                status = "escalated"
+
+            # Generate report
+            try:
+                report_gen = MarkdownReportGenerator(self.report_dir)
+                report_path = report_gen.generate(investigation_state)
+                logger.success(f"Report generated: {report_path}")
+            except Exception as e:
+                logger.error(f"Report generation failed: {e}")
+
+            return {
+                "investigation_id": investigation_id,
+                "status": status,
+                "evidence_count": len(investigation_state.evidence),
+                "techniques_identified": list(investigation_state.identified_techniques),
+                "highest_pyramid_level": investigation_state.highest_pyramid_level,
+                "state": investigation_state,
+            }
+
+        finally:
+            watchdog.cancel()
+
+            # Stop workers
+            for worker in workers.values():
+                await worker.stop()
+
+            # Stop dispatcher
+            await dispatcher.stop()
+
+            # Close Redis
+            try:
+                await redis_client.aclose()
+            except Exception:
+                pass
+
+            logger.info(f"Multi-agent investigation {investigation_id} cleanup complete")

--- a/src/ares/core/blue_dispatcher/__init__.py
+++ b/src/ares/core/blue_dispatcher/__init__.py
@@ -1,0 +1,9 @@
+"""Blue team multi-agent dispatcher.
+
+Coordinates triage, threat hunting, and lateral analysis workers
+for blue team investigations. Manages shared state via Redis.
+"""
+
+from ares.core.blue_dispatcher._dispatcher import BlueTeamDispatcher
+
+__all__ = ["BlueTeamDispatcher"]

--- a/src/ares/core/blue_dispatcher/_dispatcher.py
+++ b/src/ares/core/blue_dispatcher/_dispatcher.py
@@ -1,0 +1,284 @@
+"""Blue team multi-agent dispatcher.
+
+Coordinates investigation work across triage, threat hunter, and
+lateral analyst workers. All workers run in-process via asyncio.
+
+Uses Redis (via BlueStateBackend) for shared state and task tracking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from ares.core.blue_dispatcher.publishing import BluePublishingMixin
+from ares.core.blue_dispatcher.result_processing import BlueResultProcessingMixin
+from ares.core.blue_dispatcher.routing import BlueRoutingMixin
+from ares.core.blue_dispatcher.status import BlueStatusMixin
+from ares.core.blue_state_backend import BlueStateBackend
+from ares.core.models import (
+    BlueTaskInfo,
+    InvestigationStage,
+    SharedBlueTeamState,
+    TaskStatus,
+)
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+
+class BlueTeamDispatcher(
+    BlueRoutingMixin,
+    BlueResultProcessingMixin,
+    BluePublishingMixin,
+    BlueStatusMixin,
+):
+    """Central coordinator for blue team multi-agent investigations.
+
+    Manages shared state via Redis, routes tasks to workers, processes
+    results, and auto-chains follow-up investigations.
+
+    All workers run in-process (asyncio.create_task), so no cross-pod
+    messaging is needed. Redis provides shared state persistence and
+    deduplication.
+
+    Attributes:
+        _redis: Async Redis client.
+        _backend: BlueStateBackend for Redis state operations.
+        _shared_state: SharedBlueTeamState in-memory state object.
+        _investigation_id: Current investigation ID.
+        _task_results: Maps task_id -> asyncio.Event for result notification.
+        _task_result_data: Maps task_id -> result data.
+    """
+
+    def __init__(self, redis_client: Redis) -> None:
+        """Initialize the dispatcher.
+
+        Args:
+            redis_client: Connected async Redis client.
+        """
+        self._redis = redis_client
+        self._backend: BlueStateBackend | None = None
+        self._shared_state: SharedBlueTeamState | None = None
+        self._investigation_id: str = ""
+        self._task_events: dict[str, asyncio.Event] = {}
+        self._task_result_data: dict[str, dict[str, Any]] = {}
+
+    @property
+    def backend(self) -> BlueStateBackend:
+        """Get the backend (raises if not started)."""
+        if not self._backend:
+            raise RuntimeError("Dispatcher not started. Call start() first.")
+        return self._backend
+
+    @property
+    def shared_state(self) -> SharedBlueTeamState:
+        """Get the shared state (raises if not started)."""
+        if not self._shared_state:
+            raise RuntimeError("Dispatcher not started. Call start() first.")
+        return self._shared_state
+
+    @property
+    def investigation_id(self) -> str:
+        return self._investigation_id
+
+    async def start(
+        self,
+        investigation_id: str,
+        alert: dict[str, Any],
+        correlation_context: dict[str, Any] | None = None,
+    ) -> None:
+        """Start the dispatcher for a new investigation.
+
+        Creates the backend and shared state, stores initial alert data.
+
+        Args:
+            investigation_id: Unique investigation identifier.
+            alert: The alert JSON that triggered the investigation.
+            correlation_context: Optional alert correlation context.
+        """
+        self._investigation_id = investigation_id
+        self._backend = BlueStateBackend(self._redis, investigation_id)
+        self._shared_state = SharedBlueTeamState(
+            investigation_id=investigation_id,
+            alert=alert,
+            correlation_context=correlation_context,
+        )
+        self._shared_state.set_backend(self._backend)
+
+        # Store alert and meta in Redis
+        await self._backend.set_meta("alert", alert)
+        await self._backend.set_meta("stage", InvestigationStage.TRIAGE.value)
+        await self._backend.set_meta("escalated", False)
+        if correlation_context:
+            await self._backend.set_meta("correlation_context", correlation_context)
+
+        logger.info(f"Blue dispatcher started for investigation {investigation_id}")
+
+    async def stop(self) -> None:
+        """Stop the dispatcher and clean up."""
+        self._task_events.clear()
+        self._task_result_data.clear()
+        logger.info(f"Blue dispatcher stopped for investigation {self._investigation_id}")
+
+    async def notify_task_result(
+        self,
+        task_id: str,
+        success: bool,
+        result: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Notify that a task has completed (called by workers).
+
+        This both persists the result and signals any waiters.
+
+        Args:
+            task_id: The completed task ID.
+            success: Whether the task succeeded.
+            result: Task result data.
+            error: Error message if failed.
+        """
+        await self.complete_task(task_id, success, result, error)
+
+        # Store result data and signal waiter
+        self._task_result_data[task_id] = {
+            "success": success,
+            "result": result or {},
+            "error": error,
+        }
+        event = self._task_events.get(task_id)
+        if event:
+            event.set()
+
+    async def wait_for_result(
+        self,
+        task_id: str,
+        timeout: float = 300.0,
+    ) -> dict[str, Any]:
+        """Wait for a task to complete and return its result.
+
+        Args:
+            task_id: Task ID to wait for.
+            timeout: Maximum seconds to wait.
+
+        Returns:
+            Result dict with success, result, error fields.
+
+        Raises:
+            asyncio.TimeoutError: If timeout exceeded.
+        """
+        # Check if already completed
+        if task_id in self._task_result_data:
+            return self._task_result_data[task_id]
+
+        # Create event and wait
+        event = asyncio.Event()
+        self._task_events[task_id] = event
+
+        try:
+            await asyncio.wait_for(event.wait(), timeout=timeout)
+            return self._task_result_data.get(task_id, {
+                "success": False,
+                "result": {},
+                "error": "Result not found after notification",
+            })
+        except asyncio.TimeoutError:
+            logger.warning(f"Task {task_id} timed out after {timeout}s")
+            return {
+                "success": False,
+                "result": {},
+                "error": f"Task timed out after {timeout}s",
+            }
+        finally:
+            self._task_events.pop(task_id, None)
+
+    async def snapshot_to_shared_state(self) -> SharedBlueTeamState:
+        """Refresh the shared state from Redis.
+
+        Returns:
+            Updated SharedBlueTeamState.
+        """
+        from ares.core.models import Evidence, PyramidLevel, TimelineEvent
+
+        snapshot = await self._backend.snapshot()
+        meta = snapshot.get("meta", {})
+
+        state = self._shared_state
+        if not state:
+            state = SharedBlueTeamState(investigation_id=self._investigation_id)
+
+        # Update fields from snapshot
+        state.alert = meta.get("alert", state.alert)
+        stage_val = meta.get("stage", "triage")
+        state.stage = InvestigationStage(stage_val)
+        state.escalated = meta.get("escalated", False)
+        state.escalation_reason = meta.get("escalation_reason")
+        state.attack_synopsis = meta.get("attack_synopsis")
+        state.correlation_context = meta.get("correlation_context")
+
+        # Rebuild evidence list from dicts
+        state.evidence = []
+        for ev_dict in snapshot.get("evidence", []):
+            try:
+                level_val = ev_dict.get("pyramid_level", 1)
+                ts = None
+                if ev_dict.get("timestamp"):
+                    from datetime import datetime
+
+                    ts = datetime.fromisoformat(str(ev_dict["timestamp"]))
+
+                ev = Evidence(
+                    id=ev_dict.get("id", ""),
+                    type=ev_dict.get("type", ""),
+                    value=ev_dict.get("value", ""),
+                    source=ev_dict.get("source", ""),
+                    timestamp=ts,
+                    pyramid_level=PyramidLevel(min(max(int(level_val), 1), 6)),
+                    mitre_techniques=ev_dict.get("mitre_techniques", []),
+                    confidence=ev_dict.get("confidence", 0.5),
+                    source_query_id=ev_dict.get("source_query_id"),
+                    validated=ev_dict.get("validated", False),
+                )
+                state.evidence.append(ev)
+            except Exception as e:
+                logger.warning(f"Failed to deserialize evidence: {e}")
+
+        # Rebuild timeline
+        state.timeline = []
+        for tl_dict in snapshot.get("timeline", []):
+            try:
+                from datetime import datetime, timezone as tz
+
+                ts = datetime.fromisoformat(str(tl_dict["timestamp"]))
+                event = TimelineEvent(
+                    id=tl_dict.get("id", ""),
+                    timestamp=ts,
+                    description=tl_dict.get("description", ""),
+                    evidence_ids=tl_dict.get("evidence_ids", []),
+                    mitre_techniques=tl_dict.get("mitre_techniques", []),
+                    confidence=tl_dict.get("confidence", 0.5),
+                )
+                state.timeline.append(event)
+            except Exception as e:
+                logger.warning(f"Failed to deserialize timeline event: {e}")
+
+        state.timeline.sort(key=lambda e: e.timestamp)
+
+        # Simple fields
+        state.identified_techniques = snapshot.get("techniques", set())
+        state.identified_tactics = snapshot.get("tactics", set())
+        state.technique_names = snapshot.get("technique_names", {})
+        state.queried_hosts = snapshot.get("hosts", set())
+        state.queried_users = snapshot.get("users", set())
+        state.executed_query_types = snapshot.get("query_types", set())
+        state.executed_queries = snapshot.get("queries", [])
+        state.lateral_connections = snapshot.get("lateral_connections", [])
+        state.queued_pivot_queries = snapshot.get("pivot_queue", [])
+        state.queued_chain_queries = snapshot.get("chain_queue", [])
+        state.recommendations = snapshot.get("recommendations", [])
+
+        self._shared_state = state
+        return state

--- a/src/ares/core/blue_dispatcher/_dispatcher.py
+++ b/src/ares/core/blue_dispatcher/_dispatcher.py
@@ -9,7 +9,6 @@ Uses Redis (via BlueStateBackend) for shared state and task tracking.
 from __future__ import annotations
 
 import asyncio
-import json
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -20,10 +19,8 @@ from ares.core.blue_dispatcher.routing import BlueRoutingMixin
 from ares.core.blue_dispatcher.status import BlueStatusMixin
 from ares.core.blue_state_backend import BlueStateBackend
 from ares.core.models import (
-    BlueTaskInfo,
     InvestigationStage,
     SharedBlueTeamState,
-    TaskStatus,
 )
 
 if TYPE_CHECKING:
@@ -61,7 +58,7 @@ class BlueTeamDispatcher(
             redis_client: Connected async Redis client.
         """
         self._redis = redis_client
-        self._backend: BlueStateBackend | None = None
+        self._backend: BlueStateBackend | None = None  # type: ignore[assignment]
         self._shared_state: SharedBlueTeamState | None = None
         self._investigation_id: str = ""
         self._task_events: dict[str, asyncio.Event] = {}
@@ -112,7 +109,7 @@ class BlueTeamDispatcher(
         # Store alert and meta in Redis
         await self._backend.set_meta("alert", alert)
         await self._backend.set_meta("stage", InvestigationStage.TRIAGE.value)
-        await self._backend.set_meta("escalated", False)
+        await self._backend.set_meta("escalated", value=False)
         if correlation_context:
             await self._backend.set_meta("correlation_context", correlation_context)
 
@@ -180,11 +177,14 @@ class BlueTeamDispatcher(
 
         try:
             await asyncio.wait_for(event.wait(), timeout=timeout)
-            return self._task_result_data.get(task_id, {
-                "success": False,
-                "result": {},
-                "error": "Result not found after notification",
-            })
+            return self._task_result_data.get(
+                task_id,
+                {
+                    "success": False,
+                    "result": {},
+                    "error": "Result not found after notification",
+                },
+            )
         except asyncio.TimeoutError:
             logger.warning(f"Task {task_id} timed out after {timeout}s")
             return {
@@ -203,7 +203,7 @@ class BlueTeamDispatcher(
         """
         from ares.core.models import Evidence, PyramidLevel, TimelineEvent
 
-        snapshot = await self._backend.snapshot()
+        snapshot = await self.backend.snapshot()
         meta = snapshot.get("meta", {})
 
         state = self._shared_state
@@ -250,7 +250,7 @@ class BlueTeamDispatcher(
         state.timeline = []
         for tl_dict in snapshot.get("timeline", []):
             try:
-                from datetime import datetime, timezone as tz
+                from datetime import datetime
 
                 ts = datetime.fromisoformat(str(tl_dict["timestamp"]))
                 event = TimelineEvent(

--- a/src/ares/core/blue_dispatcher/publishing.py
+++ b/src/ares/core/blue_dispatcher/publishing.py
@@ -35,7 +35,9 @@ class BluePublishingMixin:
             )
         return added
 
-    async def publish_timeline_event(self, event_dict: dict[str, Any], source_agent: str = "") -> None:
+    async def publish_timeline_event(
+        self, event_dict: dict[str, Any], source_agent: str = ""
+    ) -> None:
         """Publish a timeline event to shared state.
 
         Args:
@@ -47,9 +49,7 @@ class BluePublishingMixin:
         await self._backend.add_timeline_event(event_dict)
         logger.debug(f"Published timeline event: {str(event_dict.get('description', ''))[:50]}")
 
-    async def publish_technique(
-        self, technique_id: str, name: str = "", tactic: str = ""
-    ) -> None:
+    async def publish_technique(self, technique_id: str, name: str = "", tactic: str = "") -> None:
         """Publish a MITRE technique to shared state.
 
         Args:

--- a/src/ares/core/blue_dispatcher/publishing.py
+++ b/src/ares/core/blue_dispatcher/publishing.py
@@ -1,0 +1,92 @@
+"""Evidence and discovery publishing for blue team dispatcher."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from ares.core.blue_state_backend import BlueStateBackend
+
+
+class BluePublishingMixin:
+    """Publishes evidence, timeline events, and techniques to shared state."""
+
+    _backend: BlueStateBackend
+
+    async def publish_evidence(self, evidence_dict: dict[str, Any], source_agent: str = "") -> bool:
+        """Publish evidence to shared state with deduplication.
+
+        Args:
+            evidence_dict: Evidence data dict (from Evidence.to_dict()).
+            source_agent: Name of the agent that found this evidence.
+
+        Returns:
+            True if new evidence (not duplicate).
+        """
+        if source_agent:
+            evidence_dict["source_agent"] = source_agent
+        added = await self._backend.add_evidence(evidence_dict)
+        if added:
+            logger.debug(
+                f"Published evidence: {evidence_dict.get('type')}="
+                f"{str(evidence_dict.get('value', ''))[:50]}"
+            )
+        return added
+
+    async def publish_timeline_event(self, event_dict: dict[str, Any], source_agent: str = "") -> None:
+        """Publish a timeline event to shared state.
+
+        Args:
+            event_dict: Timeline event data dict.
+            source_agent: Name of the source agent.
+        """
+        if source_agent:
+            event_dict["source_agent"] = source_agent
+        await self._backend.add_timeline_event(event_dict)
+        logger.debug(f"Published timeline event: {str(event_dict.get('description', ''))[:50]}")
+
+    async def publish_technique(
+        self, technique_id: str, name: str = "", tactic: str = ""
+    ) -> None:
+        """Publish a MITRE technique to shared state.
+
+        Args:
+            technique_id: MITRE ATT&CK technique ID.
+            name: Human-readable technique name.
+            tactic: Associated tactic.
+        """
+        await self._backend.add_technique(technique_id, name)
+        if tactic:
+            await self._backend.add_tactic(tactic)
+        logger.debug(f"Published technique: {technique_id} ({name})")
+
+    async def publish_lateral_connection(
+        self,
+        source: str,
+        destination: str,
+        connection_type: str,
+        user: str = "",
+        mitre_technique: str = "",
+    ) -> None:
+        """Publish a lateral movement connection to shared state.
+
+        Args:
+            source: Source host.
+            destination: Destination host.
+            connection_type: Connection type (rdp, smb, wmi, etc.).
+            user: User account used.
+            mitre_technique: Associated MITRE technique.
+        """
+        connection = {
+            "source": source,
+            "destination": destination,
+            "connection_type": connection_type,
+            "user": user,
+            "mitre_technique": mitre_technique,
+        }
+        await self._backend.add_lateral_connection(connection)
+        await self._backend.track_host(source.strip().lower())
+        await self._backend.track_host(destination.strip().lower())
+        logger.debug(f"Published lateral: {source} -> {destination} ({connection_type})")

--- a/src/ares/core/blue_dispatcher/result_processing.py
+++ b/src/ares/core/blue_dispatcher/result_processing.py
@@ -6,13 +6,10 @@ auto-chaining follow-up tasks based on evidence.
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
-
-from ares.core.models import BlueTaskInfo, BlueTaskType, TaskStatus
 
 if TYPE_CHECKING:
     from ares.core.blue_state_backend import BlueStateBackend
@@ -83,8 +80,6 @@ class BlueResultProcessingMixin:
         Examines the result for evidence types that should trigger
         additional detection queries.
         """
-        result_type = result.get("type", "")
-
         # Check for techniques that should trigger chains
         techniques = result.get("techniques_found", [])
         for technique in techniques:

--- a/src/ares/core/blue_dispatcher/result_processing.py
+++ b/src/ares/core/blue_dispatcher/result_processing.py
@@ -1,0 +1,140 @@
+"""Result processing for blue team dispatcher.
+
+Handles merging worker discoveries into shared state and
+auto-chaining follow-up tasks based on evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from ares.core.models import BlueTaskInfo, BlueTaskType, TaskStatus
+
+if TYPE_CHECKING:
+    from ares.core.blue_state_backend import BlueStateBackend
+
+
+# Evidence type → detection methods to auto-chain
+EVIDENCE_CHAIN_MAP: dict[str, list[str]] = {
+    "kerberoast_hash": ["detect_pass_the_hash", "detect_lateral_movement"],
+    "dcsync": ["detect_golden_ticket", "detect_lateral_movement"],
+    "t1003": [
+        "detect_dcsync",
+        "detect_secretsdump",
+        "detect_golden_ticket",
+        "detect_pass_the_hash",
+        "detect_credential_access",
+    ],
+    "golden_ticket": ["detect_lateral_movement", "detect_persistence"],
+    "pass_the_hash": ["detect_lateral_movement", "detect_credential_access"],
+    "lateral_movement": ["detect_pass_the_hash", "detect_credential_access"],
+    "credential_access": ["detect_dcsync", "detect_kerberoasting"],
+    "persistence": ["detect_scheduled_tasks", "detect_registry_modification"],
+    "privilege_escalation": ["detect_token_manipulation", "detect_credential_access"],
+}
+
+# Users that require immediate escalation
+CRITICAL_USERS: set[str] = {"krbtgt", "administrator", "domain admins", "enterprise admins"}
+
+
+class BlueResultProcessingMixin:
+    """Processes task results and auto-chains follow-up investigations."""
+
+    _backend: BlueStateBackend
+    _investigation_id: str
+
+    async def complete_task(
+        self,
+        task_id: str,
+        success: bool,
+        result: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Mark a task as completed and merge results.
+
+        Args:
+            task_id: The task ID to complete.
+            success: Whether the task succeeded.
+            result: Task result data.
+            error: Error message if failed.
+        """
+        result_dict = {
+            "task_id": task_id,
+            "success": success,
+            "result": result or {},
+            "error": error,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        await self._backend.complete_task(task_id, result_dict)
+
+        if success and result:
+            await self._process_result_chains(result)
+
+        status = "completed" if success else "failed"
+        logger.info(f"Task {task_id} {status}")
+
+    async def _process_result_chains(self, result: dict[str, Any]) -> None:
+        """Auto-chain follow-up queries based on task results.
+
+        Examines the result for evidence types that should trigger
+        additional detection queries.
+        """
+        result_type = result.get("type", "")
+
+        # Check for techniques that should trigger chains
+        techniques = result.get("techniques_found", [])
+        for technique in techniques:
+            technique_lower = technique.lower()
+            # Map technique IDs to evidence types for chaining
+            if "t1558" in technique_lower:
+                await self._queue_chains_for("kerberoast_hash")
+            elif "t1003" in technique_lower:
+                await self._queue_chains_for("t1003")
+            elif "t1550" in technique_lower:
+                await self._queue_chains_for("pass_the_hash")
+
+        # Check for critical users in results
+        await self._check_critical_users(result)
+
+    async def _queue_chains_for(self, evidence_type: str) -> None:
+        """Queue chained detection methods for an evidence type."""
+        chain_methods = EVIDENCE_CHAIN_MAP.get(evidence_type, [])
+        for method in chain_methods:
+            already_executed = await self._backend.is_query_type_executed(method)
+            if not already_executed:
+                await self._backend.queue_chain(method)
+                logger.debug(f"Auto-chained: {evidence_type} -> {method}")
+
+    async def _check_critical_users(self, result: dict[str, Any]) -> None:
+        """Check if any critical users were found in results.
+
+        If krbtgt, administrator, etc. appear, queue critical detections.
+        """
+        # Check users investigated
+        users = result.get("users_investigated", [])
+        for user in users:
+            user_lower = user.lower().strip()
+            if user_lower in CRITICAL_USERS:
+                logger.warning(f"CRITICAL USER detected in results: {user}")
+                # Queue golden ticket and DCSync detection
+                for method in ["detect_golden_ticket", "detect_dcsync"]:
+                    already_executed = await self._backend.is_query_type_executed(method)
+                    if not already_executed:
+                        await self._backend.queue_chain(method)
+
+        # Also check evidence highlights for critical user mentions
+        highlights = result.get("evidence_highlights", [])
+        for highlight in highlights:
+            highlight_lower = highlight.lower()
+            for user in CRITICAL_USERS:
+                if user in highlight_lower:
+                    logger.warning(f"CRITICAL USER mentioned in evidence: {user}")
+                    for method in ["detect_golden_ticket", "detect_dcsync"]:
+                        already_executed = await self._backend.is_query_type_executed(method)
+                        if not already_executed:
+                            await self._backend.queue_chain(method)
+                    break

--- a/src/ares/core/blue_dispatcher/routing.py
+++ b/src/ares/core/blue_dispatcher/routing.py
@@ -26,7 +26,7 @@ class BlueRoutingMixin:
         params: dict[str, Any],
     ) -> BlueTaskInfo:
         """Create a task and register it as pending."""
-        task = BlueTaskInfo(
+        return BlueTaskInfo(
             task_id=str(uuid.uuid4())[:8],
             task_type=task_type,
             investigation_id=self._investigation_id,
@@ -34,7 +34,6 @@ class BlueRoutingMixin:
             assigned_role=role,
             params=params,
         )
-        return task
 
     async def dispatch_triage(
         self,
@@ -126,7 +125,9 @@ class BlueRoutingMixin:
             },
         )
         await self._register_pending_task(task)
-        logger.info(f"Dispatched lateral analysis task {task.task_id}: host={focus_host}, user={focus_user}")
+        logger.info(
+            f"Dispatched lateral analysis task {task.task_id}: host={focus_host}, user={focus_user}"
+        )
         return task
 
     async def dispatch_host_investigation(self, hostname: str, context: str = "") -> BlueTaskInfo:
@@ -169,7 +170,6 @@ class BlueRoutingMixin:
 
     async def _register_pending_task(self, task: BlueTaskInfo) -> None:
         """Register a task as pending in the backend."""
-        import json
         from datetime import datetime, timezone
 
         task_dict = {

--- a/src/ares/core/blue_dispatcher/routing.py
+++ b/src/ares/core/blue_dispatcher/routing.py
@@ -1,0 +1,184 @@
+"""Task routing for blue team dispatcher."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from ares.core.models import BlueRole, BlueTaskInfo, BlueTaskType, TaskStatus
+
+if TYPE_CHECKING:
+    from ares.core.blue_state_backend import BlueStateBackend
+
+
+class BlueRoutingMixin:
+    """Routes investigation tasks to appropriate worker roles."""
+
+    _backend: BlueStateBackend
+    _investigation_id: str
+
+    def _create_task(
+        self,
+        task_type: BlueTaskType,
+        role: BlueRole,
+        params: dict[str, Any],
+    ) -> BlueTaskInfo:
+        """Create a task and register it as pending."""
+        task = BlueTaskInfo(
+            task_id=str(uuid.uuid4())[:8],
+            task_type=task_type,
+            investigation_id=self._investigation_id,
+            status=TaskStatus.PENDING,
+            assigned_role=role,
+            params=params,
+        )
+        return task
+
+    async def dispatch_triage(
+        self,
+        alert: dict[str, Any],
+        correlation_context: dict[str, Any] | None = None,
+    ) -> BlueTaskInfo:
+        """Dispatch a triage task to the triage worker.
+
+        Args:
+            alert: The alert JSON to triage.
+            correlation_context: Optional correlation context.
+
+        Returns:
+            BlueTaskInfo for the created task.
+        """
+        task = self._create_task(
+            BlueTaskType.TRIAGE_ALERT,
+            BlueRole.TRIAGE,
+            {
+                "alert": alert,
+                "correlation_context": correlation_context or {},
+            },
+        )
+        await self._register_pending_task(task)
+        logger.info(f"Dispatched triage task {task.task_id}")
+        return task
+
+    async def dispatch_threat_hunt(
+        self,
+        technique_id: str = "",
+        detection_method: str = "",
+        hostname: str = "",
+        username: str = "",
+        context: str = "",
+    ) -> BlueTaskInfo:
+        """Dispatch a threat hunting task.
+
+        Args:
+            technique_id: MITRE technique to hunt for.
+            detection_method: Specific detection query to run.
+            hostname: Host to focus on.
+            username: User to focus on.
+            context: Additional context from prior investigation.
+
+        Returns:
+            BlueTaskInfo for the created task.
+        """
+        task = self._create_task(
+            BlueTaskType.THREAT_HUNT,
+            BlueRole.THREAT_HUNTER,
+            {
+                "technique_id": technique_id,
+                "detection_method": detection_method,
+                "hostname": hostname,
+                "username": username,
+                "context": context,
+            },
+        )
+        await self._register_pending_task(task)
+        logger.info(
+            f"Dispatched threat hunt task {task.task_id}: "
+            f"technique={technique_id}, method={detection_method}"
+        )
+        return task
+
+    async def dispatch_lateral_analysis(
+        self,
+        focus_host: str = "",
+        focus_user: str = "",
+        context: str = "",
+    ) -> BlueTaskInfo:
+        """Dispatch a lateral movement analysis task.
+
+        Args:
+            focus_host: Primary host to analyze.
+            focus_user: Primary user to analyze.
+            context: Additional context from prior investigation.
+
+        Returns:
+            BlueTaskInfo for the created task.
+        """
+        task = self._create_task(
+            BlueTaskType.LATERAL_ANALYSIS,
+            BlueRole.LATERAL_ANALYST,
+            {
+                "focus_host": focus_host,
+                "focus_user": focus_user,
+                "context": context,
+            },
+        )
+        await self._register_pending_task(task)
+        logger.info(f"Dispatched lateral analysis task {task.task_id}: host={focus_host}, user={focus_user}")
+        return task
+
+    async def dispatch_host_investigation(self, hostname: str, context: str = "") -> BlueTaskInfo:
+        """Dispatch a host-focused investigation task.
+
+        Args:
+            hostname: Host to investigate.
+            context: Additional context.
+
+        Returns:
+            BlueTaskInfo for the created task.
+        """
+        task = self._create_task(
+            BlueTaskType.HOST_INVESTIGATION,
+            BlueRole.LATERAL_ANALYST,
+            {"hostname": hostname, "context": context},
+        )
+        await self._register_pending_task(task)
+        logger.info(f"Dispatched host investigation task {task.task_id}: {hostname}")
+        return task
+
+    async def dispatch_user_investigation(self, username: str, context: str = "") -> BlueTaskInfo:
+        """Dispatch a user-focused investigation task.
+
+        Args:
+            username: User to investigate.
+            context: Additional context.
+
+        Returns:
+            BlueTaskInfo for the created task.
+        """
+        task = self._create_task(
+            BlueTaskType.USER_INVESTIGATION,
+            BlueRole.THREAT_HUNTER,
+            {"username": username, "context": context},
+        )
+        await self._register_pending_task(task)
+        logger.info(f"Dispatched user investigation task {task.task_id}: {username}")
+        return task
+
+    async def _register_pending_task(self, task: BlueTaskInfo) -> None:
+        """Register a task as pending in the backend."""
+        import json
+        from datetime import datetime, timezone
+
+        task_dict = {
+            "task_id": task.task_id,
+            "task_type": task.task_type.value,
+            "investigation_id": task.investigation_id,
+            "status": task.status.value,
+            "assigned_role": task.assigned_role.value,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "params": task.params,
+        }
+        await self._backend.add_pending_task(task.task_id, task_dict)

--- a/src/ares/core/blue_dispatcher/status.py
+++ b/src/ares/core/blue_dispatcher/status.py
@@ -99,8 +99,7 @@ class BlueStatusMixin:
             "by_type": by_type,
             "by_pyramid_level": by_level,
             "techniques": {
-                tid: technique_names.get(tid, tid)
-                for tid in snapshot.get("techniques", set())
+                tid: technique_names.get(tid, tid) for tid in snapshot.get("techniques", set())
             },
             "lateral_connections": len(snapshot.get("lateral_connections", [])),
         }

--- a/src/ares/core/blue_dispatcher/status.py
+++ b/src/ares/core/blue_dispatcher/status.py
@@ -1,0 +1,106 @@
+"""Investigation status queries for blue team dispatcher."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ares.core.blue_state_backend import BlueStateBackend
+
+
+class BlueStatusMixin:
+    """Provides investigation status and summary queries."""
+
+    _backend: BlueStateBackend
+    _investigation_id: str
+
+    async def get_investigation_summary(self) -> dict[str, Any]:
+        """Get a summary of the current investigation state.
+
+        Returns:
+            Dict with evidence counts, techniques, tasks, etc.
+        """
+        snapshot = await self._backend.snapshot()
+        meta = snapshot.get("meta", {})
+
+        evidence_list = snapshot.get("evidence", [])
+        pyramid_levels = [e.get("pyramid_level", 0) for e in evidence_list]
+
+        return {
+            "investigation_id": self._investigation_id,
+            "stage": meta.get("stage", "triage"),
+            "evidence_count": len(evidence_list),
+            "timeline_events": len(snapshot.get("timeline", [])),
+            "techniques_identified": list(snapshot.get("techniques", set())),
+            "technique_count": len(snapshot.get("techniques", set())),
+            "tactics_identified": list(snapshot.get("tactics", set())),
+            "highest_pyramid_level": max(pyramid_levels, default=0),
+            "hosts_investigated": list(snapshot.get("hosts", set())),
+            "users_investigated": list(snapshot.get("users", set())),
+            "pending_tasks": len(snapshot.get("pending_tasks", {})),
+            "completed_tasks": len(snapshot.get("completed_tasks", {})),
+            "queued_pivots": len(snapshot.get("pivot_queue", [])),
+            "queued_chains": len(snapshot.get("chain_queue", [])),
+            "escalated": meta.get("escalated", False),
+            "recommendations": snapshot.get("recommendations", []),
+        }
+
+    async def get_task_status(self) -> dict[str, Any]:
+        """Get status of all tasks.
+
+        Returns:
+            Dict with pending and completed task summaries.
+        """
+        snapshot = await self._backend.snapshot()
+        pending = snapshot.get("pending_tasks", {})
+        completed = snapshot.get("completed_tasks", {})
+
+        return {
+            "pending_count": len(pending),
+            "completed_count": len(completed),
+            "pending_tasks": [
+                {
+                    "task_id": t.get("task_id"),
+                    "task_type": t.get("task_type"),
+                    "assigned_role": t.get("assigned_role"),
+                }
+                for t in pending.values()
+            ],
+            "completed_tasks": [
+                {
+                    "task_id": t.get("task_id"),
+                    "success": t.get("success"),
+                }
+                for t in completed.values()
+            ],
+        }
+
+    async def get_evidence_summary(self) -> dict[str, Any]:
+        """Get a summary of collected evidence.
+
+        Returns:
+            Dict with evidence organized by type and pyramid level.
+        """
+        snapshot = await self._backend.snapshot()
+        evidence_list = snapshot.get("evidence", [])
+
+        by_type: dict[str, int] = {}
+        by_level: dict[int, int] = {}
+        for ev in evidence_list:
+            ev_type = ev.get("type", "unknown")
+            by_type[ev_type] = by_type.get(ev_type, 0) + 1
+            level = ev.get("pyramid_level", 0)
+            by_level[level] = by_level.get(level, 0) + 1
+
+        technique_names = snapshot.get("technique_names", {})
+
+        return {
+            "total_evidence": len(evidence_list),
+            "by_type": by_type,
+            "by_pyramid_level": by_level,
+            "techniques": {
+                tid: technique_names.get(tid, tid)
+                for tid in snapshot.get("techniques", set())
+            },
+            "lateral_connections": len(snapshot.get("lateral_connections", [])),
+        }

--- a/src/ares/core/blue_state_backend.py
+++ b/src/ares/core/blue_state_backend.py
@@ -1,0 +1,824 @@
+"""Redis-native state backend for blue team investigations.
+
+This module provides Redis-native storage for blue team investigation state,
+mirroring the pattern established in state_backend.py (RedisStateBackend) for
+red team operations.
+
+Key design decisions:
+- Evidence uses Redis HASH (dedup_key -> JSON) for O(1) deduplication via HSETNX
+- Timeline and lateral connections use Redis LIST (ordered, append-only)
+- Techniques, tactics, hosts, users, and query_types use Redis SET (auto-dedup)
+- Technique names use Redis HASH (technique_id -> name)
+- Meta scalars use Redis HASH (field -> JSON value)
+- Queues (pivot, chain) use Redis LIST consumed via drain-all reads
+- Tasks use Redis HASH (task_id -> JSON) split into pending/completed
+- Recommendations use Redis LIST (ordered, append-only)
+
+Redis key structure:
+    ares:blue:inv:{id}:evidence          HASH (dedup_key -> JSON)
+    ares:blue:inv:{id}:timeline          LIST (JSON events, ordered)
+    ares:blue:inv:{id}:techniques        SET
+    ares:blue:inv:{id}:tactics           SET
+    ares:blue:inv:{id}:hosts             SET (queried hosts)
+    ares:blue:inv:{id}:users             SET (queried users)
+    ares:blue:inv:{id}:query_types       SET (executed detection method names)
+    ares:blue:inv:{id}:queries           LIST (executed query records)
+    ares:blue:inv:{id}:lateral           LIST (JSON connections)
+    ares:blue:inv:{id}:pivot_queue       LIST
+    ares:blue:inv:{id}:chain_queue       LIST
+    ares:blue:inv:{id}:dedup:evidence    SET (evidence dedup keys)
+    ares:blue:inv:{id}:meta              HASH (stage, escalated, synopsis, alert JSON, etc.)
+    ares:blue:inv:{id}:tasks:pending     HASH (task_id -> JSON)
+    ares:blue:inv:{id}:tasks:completed   HASH (task_id -> JSON)
+    ares:blue:inv:{id}:technique_names   HASH (tech_id -> name)
+    ares:blue:inv:{id}:recommendations   LIST
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+
+class BlueStateBackend:
+    """Redis-native state storage for blue team investigations.
+
+    This backend stores investigation state directly in Redis using native data
+    structures, eliminating the need for full JSON checkpoint serialization on
+    every mutation.
+
+    Thread Safety:
+        This class is designed to be used from async contexts. All methods are
+        async and use the provided Redis client.
+
+    Key Prefix:
+        All keys are prefixed with ``ares:blue:inv:{investigation_id}:`` to
+        namespace state per investigation and allow multiple concurrent
+        investigations.
+
+    TTL:
+        All keys are set with a 24-hour TTL to auto-cleanup completed
+        investigations.
+    """
+
+    # Key prefix
+    KEY_PREFIX = "ares:blue:inv"
+
+    # Collection keys
+    KEY_EVIDENCE = "evidence"
+    KEY_TIMELINE = "timeline"
+    KEY_TECHNIQUES = "techniques"
+    KEY_TACTICS = "tactics"
+    KEY_HOSTS = "hosts"
+    KEY_USERS = "users"
+    KEY_QUERY_TYPES = "query_types"
+    KEY_QUERIES = "queries"
+    KEY_LATERAL = "lateral"
+    KEY_PIVOT_QUEUE = "pivot_queue"
+    KEY_CHAIN_QUEUE = "chain_queue"
+    KEY_META = "meta"
+    KEY_PENDING_TASKS = "tasks:pending"
+    KEY_COMPLETED_TASKS = "tasks:completed"
+    KEY_TECHNIQUE_NAMES = "technique_names"
+    KEY_RECOMMENDATIONS = "recommendations"
+
+    # Dedup set prefix
+    KEY_DEDUP_PREFIX = "dedup"
+
+    # TTL for all keys (24 hours)
+    DEFAULT_TTL = 86400
+
+    def __init__(self, redis_client: Redis, investigation_id: str) -> None:
+        """Initialize the backend.
+
+        Args:
+            redis_client: Async Redis client (from create_redis_client).
+            investigation_id: Unique investigation identifier.
+        """
+        self._redis = redis_client
+        self._investigation_id = investigation_id
+        self._key_prefix = f"{self.KEY_PREFIX}:{investigation_id}"
+
+    def _key(self, suffix: str) -> str:
+        """Build full Redis key."""
+        return f"{self._key_prefix}:{suffix}"
+
+    async def _set_ttl(self, key: str) -> None:
+        """Set TTL on a key."""
+        await self._redis.expire(key, self.DEFAULT_TTL)
+
+    # =========================================================================
+    # Evidence (Redis HASH with HSETNX for O(1) deduplication)
+    # =========================================================================
+
+    async def add_evidence(self, evidence_dict: dict) -> bool:
+        """Add evidence to Redis HASH with O(1) deduplication via HSETNX.
+
+        Deduplication key: ``{type}:{value_lower}`` derived from the evidence
+        dict's ``type`` and ``value`` fields (case-insensitive).
+
+        Args:
+            evidence_dict: JSON-serializable evidence data. Expected to contain
+                at least ``type`` and ``value`` fields for dedup key generation.
+
+        Returns:
+            True if added (new), False if duplicate.
+        """
+        key = self._key(self.KEY_EVIDENCE)
+        try:
+            ev_type = str(evidence_dict.get("type", "unknown")).strip().lower()
+            ev_value = str(evidence_dict.get("value", "")).strip().lower()
+            dedup_field = f"{ev_type}:{ev_value}"
+
+            data = json.dumps(evidence_dict, separators=(",", ":"), default=str)
+            # HSETNX returns 1 if field was set (new), 0 if already existed
+            added = await self._redis.hsetnx(key, dedup_field, data)
+            if not added:
+                logger.debug(f"Evidence rejected (duplicate): {dedup_field}")
+                return False
+            await self._set_ttl(key)
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to add evidence to Redis: {e}")
+            return False
+
+    # =========================================================================
+    # Timeline (Redis LIST)
+    # =========================================================================
+
+    async def add_timeline_event(self, event_dict: dict) -> None:
+        """Append a timeline event to the ordered list.
+
+        Args:
+            event_dict: JSON-serializable event data.
+        """
+        key = self._key(self.KEY_TIMELINE)
+        try:
+            data = json.dumps(event_dict, separators=(",", ":"), default=str)
+            await self._redis.rpush(key, data)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to add timeline event to Redis: {e}")
+
+    # =========================================================================
+    # Techniques (Redis SET + HASH for names)
+    # =========================================================================
+
+    async def add_technique(self, technique_id: str, name: str = "") -> None:
+        """Add a MITRE ATT&CK technique.
+
+        Adds the technique ID to the techniques SET and, if a name is provided,
+        stores the mapping in the technique_names HASH.
+
+        Args:
+            technique_id: MITRE technique ID (e.g., ``T1078``).
+            name: Optional human-readable name for the technique.
+        """
+        tech_key = self._key(self.KEY_TECHNIQUES)
+        try:
+            await self._redis.sadd(tech_key, technique_id)
+            await self._set_ttl(tech_key)
+        except Exception as e:
+            logger.warning(f"Failed to add technique {technique_id} to Redis: {e}")
+            return
+
+        if name:
+            names_key = self._key(self.KEY_TECHNIQUE_NAMES)
+            try:
+                await self._redis.hset(names_key, technique_id, name)
+                await self._set_ttl(names_key)
+            except Exception as e:
+                logger.warning(f"Failed to set technique name for {technique_id}: {e}")
+
+    async def get_techniques(self) -> set[str]:
+        """Get all technique IDs.
+
+        Returns:
+            Set of technique ID strings.
+        """
+        key = self._key(self.KEY_TECHNIQUES)
+        try:
+            items = await self._redis.smembers(key)
+            return {item if isinstance(item, str) else item.decode() for item in items}
+        except Exception as e:
+            logger.warning(f"Failed to get techniques from Redis: {e}")
+            return set()
+
+    # =========================================================================
+    # Tactics (Redis SET)
+    # =========================================================================
+
+    async def add_tactic(self, tactic_id: str) -> None:
+        """Add a MITRE ATT&CK tactic.
+
+        Args:
+            tactic_id: MITRE tactic ID (e.g., ``TA0001``).
+        """
+        key = self._key(self.KEY_TACTICS)
+        try:
+            await self._redis.sadd(key, tactic_id)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to add tactic {tactic_id} to Redis: {e}")
+
+    async def get_tactics(self) -> set[str]:
+        """Get all tactic IDs.
+
+        Returns:
+            Set of tactic ID strings.
+        """
+        key = self._key(self.KEY_TACTICS)
+        try:
+            items = await self._redis.smembers(key)
+            return {item if isinstance(item, str) else item.decode() for item in items}
+        except Exception as e:
+            logger.warning(f"Failed to get tactics from Redis: {e}")
+            return set()
+
+    # =========================================================================
+    # Hosts (Redis SET)
+    # =========================================================================
+
+    async def track_host(self, name: str) -> None:
+        """Track a queried host.
+
+        Args:
+            name: Hostname or IP address.
+        """
+        key = self._key(self.KEY_HOSTS)
+        try:
+            await self._redis.sadd(key, name)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to track host {name} in Redis: {e}")
+
+    async def get_hosts(self) -> set[str]:
+        """Get all tracked hosts.
+
+        Returns:
+            Set of host name strings.
+        """
+        key = self._key(self.KEY_HOSTS)
+        try:
+            items = await self._redis.smembers(key)
+            return {item if isinstance(item, str) else item.decode() for item in items}
+        except Exception as e:
+            logger.warning(f"Failed to get hosts from Redis: {e}")
+            return set()
+
+    # =========================================================================
+    # Users (Redis SET)
+    # =========================================================================
+
+    async def track_user(self, name: str) -> None:
+        """Track a queried user.
+
+        Args:
+            name: Username or user principal name.
+        """
+        key = self._key(self.KEY_USERS)
+        try:
+            await self._redis.sadd(key, name)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to track user {name} in Redis: {e}")
+
+    async def get_users(self) -> set[str]:
+        """Get all tracked users.
+
+        Returns:
+            Set of user name strings.
+        """
+        key = self._key(self.KEY_USERS)
+        try:
+            items = await self._redis.smembers(key)
+            return {item if isinstance(item, str) else item.decode() for item in items}
+        except Exception as e:
+            logger.warning(f"Failed to get users from Redis: {e}")
+            return set()
+
+    # =========================================================================
+    # Meta (Scalars) — Redis HASH
+    # =========================================================================
+
+    async def set_meta(self, k: str, v: Any) -> None:
+        """Set a scalar meta field.
+
+        Values are JSON-serialized before storage.
+
+        Args:
+            k: Field name.
+            v: Value (will be JSON serialized).
+        """
+        key = self._key(self.KEY_META)
+        try:
+            await self._redis.hset(
+                key, k, json.dumps(v, separators=(",", ":"), default=str)
+            )
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to set meta field {k}: {e}")
+
+    async def get_meta(self, k: str) -> Any:
+        """Get a scalar meta field.
+
+        Args:
+            k: Field name.
+
+        Returns:
+            Deserialized value, or None if not found.
+        """
+        key = self._key(self.KEY_META)
+        try:
+            value = await self._redis.hget(key, k)
+            if value is None:
+                return None
+            return json.loads(value if isinstance(value, str) else value.decode())
+        except Exception as e:
+            logger.warning(f"Failed to get meta field {k}: {e}")
+            return None
+
+    # =========================================================================
+    # Queues — Pivot & Chain (Redis LIST)
+    # =========================================================================
+
+    async def queue_pivot(self, data: dict) -> None:
+        """Enqueue a pivot investigation target.
+
+        Args:
+            data: JSON-serializable pivot data.
+        """
+        key = self._key(self.KEY_PIVOT_QUEUE)
+        try:
+            await self._redis.rpush(
+                key, json.dumps(data, separators=(",", ":"), default=str)
+            )
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to queue pivot in Redis: {e}")
+
+    async def queue_chain(self, method_name: str) -> None:
+        """Enqueue a detection method for chain execution.
+
+        Args:
+            method_name: Name of the detection method to run.
+        """
+        key = self._key(self.KEY_CHAIN_QUEUE)
+        try:
+            await self._redis.rpush(key, method_name)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to queue chain method {method_name} in Redis: {e}")
+
+    async def pop_pivot(self) -> list[dict]:
+        """Drain the pivot queue and return all entries.
+
+        Returns:
+            List of pivot data dicts.
+        """
+        key = self._key(self.KEY_PIVOT_QUEUE)
+        try:
+            items = await self._redis.lrange(key, 0, -1)
+            if items:
+                await self._redis.delete(key)
+            return [
+                json.loads(item if isinstance(item, str) else item.decode())
+                for item in items
+            ]
+        except Exception as e:
+            logger.warning(f"Failed to pop pivot queue from Redis: {e}")
+            return []
+
+    async def pop_chain(self) -> list[str]:
+        """Drain the chain queue and return all entries.
+
+        Returns:
+            List of detection method name strings.
+        """
+        key = self._key(self.KEY_CHAIN_QUEUE)
+        try:
+            items = await self._redis.lrange(key, 0, -1)
+            if items:
+                await self._redis.delete(key)
+            return [
+                item if isinstance(item, str) else item.decode() for item in items
+            ]
+        except Exception as e:
+            logger.warning(f"Failed to pop chain queue from Redis: {e}")
+            return []
+
+    # =========================================================================
+    # Query Tracking (Redis LIST + SET)
+    # =========================================================================
+
+    async def record_query(self, query_dict: dict) -> None:
+        """Record an executed query.
+
+        Args:
+            query_dict: JSON-serializable query record.
+        """
+        key = self._key(self.KEY_QUERIES)
+        try:
+            data = json.dumps(query_dict, separators=(",", ":"), default=str)
+            await self._redis.rpush(key, data)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to record query in Redis: {e}")
+
+    async def mark_query_type(self, method_name: str) -> None:
+        """Mark a detection method as executed.
+
+        Args:
+            method_name: Detection method name (e.g., ``detect_brute_force``).
+        """
+        key = self._key(self.KEY_QUERY_TYPES)
+        try:
+            await self._redis.sadd(key, method_name)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to mark query type {method_name} in Redis: {e}")
+
+    async def is_query_type_executed(self, method_name: str) -> bool:
+        """Check if a detection method has been executed.
+
+        Args:
+            method_name: Detection method name.
+
+        Returns:
+            True if the method has already been executed.
+        """
+        key = self._key(self.KEY_QUERY_TYPES)
+        try:
+            return await self._redis.sismember(key, method_name) == 1
+        except Exception as e:
+            logger.warning(f"Failed to check query type {method_name} in Redis: {e}")
+            return False
+
+    # =========================================================================
+    # Lateral Connections (Redis LIST)
+    # =========================================================================
+
+    async def add_lateral_connection(self, connection_dict: dict) -> None:
+        """Record a lateral movement connection.
+
+        Args:
+            connection_dict: JSON-serializable connection data.
+        """
+        key = self._key(self.KEY_LATERAL)
+        try:
+            data = json.dumps(connection_dict, separators=(",", ":"), default=str)
+            await self._redis.rpush(key, data)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to add lateral connection to Redis: {e}")
+
+    async def get_lateral_connections(self) -> list[dict]:
+        """Get all recorded lateral movement connections.
+
+        Returns:
+            List of connection dicts.
+        """
+        key = self._key(self.KEY_LATERAL)
+        try:
+            items = await self._redis.lrange(key, 0, -1)
+            return [
+                json.loads(item if isinstance(item, str) else item.decode())
+                for item in items
+            ]
+        except Exception as e:
+            logger.warning(f"Failed to get lateral connections from Redis: {e}")
+            return []
+
+    # =========================================================================
+    # Recommendations (Redis LIST)
+    # =========================================================================
+
+    async def add_recommendation(self, text: str) -> None:
+        """Add a recommendation to the investigation.
+
+        Args:
+            text: Recommendation text.
+        """
+        key = self._key(self.KEY_RECOMMENDATIONS)
+        try:
+            await self._redis.rpush(key, text)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to add recommendation to Redis: {e}")
+
+    async def get_recommendations(self) -> list[str]:
+        """Get all recommendations.
+
+        Returns:
+            List of recommendation strings.
+        """
+        key = self._key(self.KEY_RECOMMENDATIONS)
+        try:
+            items = await self._redis.lrange(key, 0, -1)
+            return [
+                item if isinstance(item, str) else item.decode() for item in items
+            ]
+        except Exception as e:
+            logger.warning(f"Failed to get recommendations from Redis: {e}")
+            return []
+
+    # =========================================================================
+    # Tasks (Redis HASH — pending & completed)
+    # =========================================================================
+
+    async def add_pending_task(self, task_id: str, task_dict: dict) -> None:
+        """Add a pending task.
+
+        Args:
+            task_id: Unique task identifier.
+            task_dict: JSON-serializable task data.
+        """
+        key = self._key(self.KEY_PENDING_TASKS)
+        try:
+            data = json.dumps(task_dict, separators=(",", ":"), default=str)
+            await self._redis.hset(key, task_id, data)
+            await self._set_ttl(key)
+        except Exception as e:
+            logger.warning(f"Failed to add pending task {task_id} to Redis: {e}")
+
+    async def complete_task(self, task_id: str, result_dict: dict) -> None:
+        """Move a task from pending to completed.
+
+        Removes the task from the pending HASH and adds the result to the
+        completed HASH in a single pipeline.
+
+        Args:
+            task_id: Task identifier to complete.
+            result_dict: JSON-serializable result data.
+        """
+        pending_key = self._key(self.KEY_PENDING_TASKS)
+        completed_key = self._key(self.KEY_COMPLETED_TASKS)
+        try:
+            data = json.dumps(result_dict, separators=(",", ":"), default=str)
+            pipe = self._redis.pipeline()
+            pipe.hdel(pending_key, task_id)
+            pipe.hset(completed_key, task_id, data)
+            pipe.expire(pending_key, self.DEFAULT_TTL)
+            pipe.expire(completed_key, self.DEFAULT_TTL)
+            await pipe.execute()
+        except Exception as e:
+            logger.warning(f"Failed to complete task {task_id} in Redis: {e}")
+
+    async def get_pending_tasks(self) -> dict[str, dict]:
+        """Get all pending tasks.
+
+        Returns:
+            Dict mapping task_id to task data dict.
+        """
+        key = self._key(self.KEY_PENDING_TASKS)
+        try:
+            raw = await self._redis.hgetall(key)
+            result: dict[str, dict] = {}
+            for k, v in raw.items():
+                task_id = k if isinstance(k, str) else k.decode()
+                try:
+                    result[task_id] = json.loads(v)
+                except json.JSONDecodeError:
+                    logger.warning(f"Invalid JSON for pending task {task_id}")
+            return result
+        except Exception as e:
+            logger.warning(f"Failed to get pending tasks from Redis: {e}")
+            return {}
+
+    async def get_completed_tasks(self) -> dict[str, dict]:
+        """Get all completed tasks.
+
+        Returns:
+            Dict mapping task_id to result data dict.
+        """
+        key = self._key(self.KEY_COMPLETED_TASKS)
+        try:
+            raw = await self._redis.hgetall(key)
+            result: dict[str, dict] = {}
+            for k, v in raw.items():
+                task_id = k if isinstance(k, str) else k.decode()
+                try:
+                    result[task_id] = json.loads(v)
+                except json.JSONDecodeError:
+                    logger.warning(f"Invalid JSON for completed task {task_id}")
+            return result
+        except Exception as e:
+            logger.warning(f"Failed to get completed tasks from Redis: {e}")
+            return {}
+
+    # =========================================================================
+    # Snapshot — read ALL keys into a single dict
+    # =========================================================================
+
+    async def snapshot(self) -> dict:
+        """Read all investigation state from Redis and return as a raw dict.
+
+        This method reconstitutes all Redis keys into a single dictionary that
+        can be used to populate a ``SharedBlueTeamState`` object.
+
+        Returns:
+            Dict with all investigation state fields::
+
+                {
+                    "investigation_id": str,
+                    "evidence": list[dict],
+                    "timeline": list[dict],
+                    "techniques": set[str],
+                    "tactics": set[str],
+                    "technique_names": dict[str, str],
+                    "hosts": set[str],
+                    "users": set[str],
+                    "query_types": set[str],
+                    "queries": list[dict],
+                    "lateral_connections": list[dict],
+                    "pivot_queue": list[dict],
+                    "chain_queue": list[str],
+                    "meta": dict[str, Any],
+                    "pending_tasks": dict[str, dict],
+                    "completed_tasks": dict[str, dict],
+                    "recommendations": list[str],
+                }
+        """
+        result: dict[str, Any] = {
+            "investigation_id": self._investigation_id,
+            "evidence": [],
+            "timeline": [],
+            "techniques": set(),
+            "tactics": set(),
+            "technique_names": {},
+            "hosts": set(),
+            "users": set(),
+            "query_types": set(),
+            "queries": [],
+            "lateral_connections": [],
+            "pivot_queue": [],
+            "chain_queue": [],
+            "meta": {},
+            "pending_tasks": {},
+            "completed_tasks": {},
+            "recommendations": [],
+        }
+
+        # Evidence (HASH values -> list[dict])
+        try:
+            ev_key = self._key(self.KEY_EVIDENCE)
+            ev_raw = await self._redis.hgetall(ev_key)
+            for v in ev_raw.values():
+                try:
+                    result["evidence"].append(
+                        json.loads(v if isinstance(v, str) else v.decode())
+                    )
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON in evidence hash value")
+        except Exception as e:
+            logger.warning(f"Failed to snapshot evidence: {e}")
+
+        # Timeline (LIST -> list[dict])
+        try:
+            tl_key = self._key(self.KEY_TIMELINE)
+            tl_items = await self._redis.lrange(tl_key, 0, -1)
+            for item in tl_items:
+                try:
+                    result["timeline"].append(
+                        json.loads(item if isinstance(item, str) else item.decode())
+                    )
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON in timeline list")
+        except Exception as e:
+            logger.warning(f"Failed to snapshot timeline: {e}")
+
+        # Techniques (SET)
+        try:
+            result["techniques"] = await self.get_techniques()
+        except Exception as e:
+            logger.warning(f"Failed to snapshot techniques: {e}")
+
+        # Tactics (SET)
+        try:
+            result["tactics"] = await self.get_tactics()
+        except Exception as e:
+            logger.warning(f"Failed to snapshot tactics: {e}")
+
+        # Technique names (HASH -> dict[str, str])
+        try:
+            tn_key = self._key(self.KEY_TECHNIQUE_NAMES)
+            tn_raw = await self._redis.hgetall(tn_key)
+            result["technique_names"] = {
+                (k if isinstance(k, str) else k.decode()): (
+                    v if isinstance(v, str) else v.decode()
+                )
+                for k, v in tn_raw.items()
+            }
+        except Exception as e:
+            logger.warning(f"Failed to snapshot technique names: {e}")
+
+        # Hosts (SET)
+        try:
+            result["hosts"] = await self.get_hosts()
+        except Exception as e:
+            logger.warning(f"Failed to snapshot hosts: {e}")
+
+        # Users (SET)
+        try:
+            result["users"] = await self.get_users()
+        except Exception as e:
+            logger.warning(f"Failed to snapshot users: {e}")
+
+        # Query types (SET)
+        try:
+            qt_key = self._key(self.KEY_QUERY_TYPES)
+            qt_items = await self._redis.smembers(qt_key)
+            result["query_types"] = {
+                item if isinstance(item, str) else item.decode() for item in qt_items
+            }
+        except Exception as e:
+            logger.warning(f"Failed to snapshot query types: {e}")
+
+        # Queries (LIST -> list[dict])
+        try:
+            q_key = self._key(self.KEY_QUERIES)
+            q_items = await self._redis.lrange(q_key, 0, -1)
+            for item in q_items:
+                try:
+                    result["queries"].append(
+                        json.loads(item if isinstance(item, str) else item.decode())
+                    )
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON in queries list")
+        except Exception as e:
+            logger.warning(f"Failed to snapshot queries: {e}")
+
+        # Lateral connections (LIST -> list[dict])
+        try:
+            result["lateral_connections"] = await self.get_lateral_connections()
+        except Exception as e:
+            logger.warning(f"Failed to snapshot lateral connections: {e}")
+
+        # Pivot queue (LIST -> list[dict]) — non-destructive read
+        try:
+            pq_key = self._key(self.KEY_PIVOT_QUEUE)
+            pq_items = await self._redis.lrange(pq_key, 0, -1)
+            for item in pq_items:
+                try:
+                    result["pivot_queue"].append(
+                        json.loads(item if isinstance(item, str) else item.decode())
+                    )
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON in pivot queue")
+        except Exception as e:
+            logger.warning(f"Failed to snapshot pivot queue: {e}")
+
+        # Chain queue (LIST -> list[str]) — non-destructive read
+        try:
+            cq_key = self._key(self.KEY_CHAIN_QUEUE)
+            cq_items = await self._redis.lrange(cq_key, 0, -1)
+            result["chain_queue"] = [
+                item if isinstance(item, str) else item.decode() for item in cq_items
+            ]
+        except Exception as e:
+            logger.warning(f"Failed to snapshot chain queue: {e}")
+
+        # Meta (HASH -> dict[str, Any])
+        try:
+            meta_key = self._key(self.KEY_META)
+            meta_raw = await self._redis.hgetall(meta_key)
+            for k, v in meta_raw.items():
+                field = k if isinstance(k, str) else k.decode()
+                try:
+                    result["meta"][field] = json.loads(
+                        v if isinstance(v, str) else v.decode()
+                    )
+                except json.JSONDecodeError:
+                    logger.warning(f"Invalid JSON in meta field {field}")
+        except Exception as e:
+            logger.warning(f"Failed to snapshot meta: {e}")
+
+        # Pending tasks (HASH -> dict[str, dict])
+        try:
+            result["pending_tasks"] = await self.get_pending_tasks()
+        except Exception as e:
+            logger.warning(f"Failed to snapshot pending tasks: {e}")
+
+        # Completed tasks (HASH -> dict[str, dict])
+        try:
+            result["completed_tasks"] = await self.get_completed_tasks()
+        except Exception as e:
+            logger.warning(f"Failed to snapshot completed tasks: {e}")
+
+        # Recommendations (LIST -> list[str])
+        try:
+            result["recommendations"] = await self.get_recommendations()
+        except Exception as e:
+            logger.warning(f"Failed to snapshot recommendations: {e}")
+
+        return result
+
+
+__all__ = [
+    "BlueStateBackend",
+]

--- a/src/ares/core/blue_state_backend.py
+++ b/src/ares/core/blue_state_backend.py
@@ -317,9 +317,7 @@ class BlueStateBackend:
         """
         key = self._key(self.KEY_META)
         try:
-            await self._redis.hset(
-                key, k, json.dumps(v, separators=(",", ":"), default=str)
-            )
+            await self._redis.hset(key, k, json.dumps(v, separators=(",", ":"), default=str))
             await self._set_ttl(key)
         except Exception as e:
             logger.warning(f"Failed to set meta field {k}: {e}")
@@ -355,9 +353,7 @@ class BlueStateBackend:
         """
         key = self._key(self.KEY_PIVOT_QUEUE)
         try:
-            await self._redis.rpush(
-                key, json.dumps(data, separators=(",", ":"), default=str)
-            )
+            await self._redis.rpush(key, json.dumps(data, separators=(",", ":"), default=str))
             await self._set_ttl(key)
         except Exception as e:
             logger.warning(f"Failed to queue pivot in Redis: {e}")
@@ -386,10 +382,7 @@ class BlueStateBackend:
             items = await self._redis.lrange(key, 0, -1)
             if items:
                 await self._redis.delete(key)
-            return [
-                json.loads(item if isinstance(item, str) else item.decode())
-                for item in items
-            ]
+            return [json.loads(item if isinstance(item, str) else item.decode()) for item in items]
         except Exception as e:
             logger.warning(f"Failed to pop pivot queue from Redis: {e}")
             return []
@@ -405,9 +398,7 @@ class BlueStateBackend:
             items = await self._redis.lrange(key, 0, -1)
             if items:
                 await self._redis.delete(key)
-            return [
-                item if isinstance(item, str) else item.decode() for item in items
-            ]
+            return [item if isinstance(item, str) else item.decode() for item in items]
         except Exception as e:
             logger.warning(f"Failed to pop chain queue from Redis: {e}")
             return []
@@ -486,10 +477,7 @@ class BlueStateBackend:
         key = self._key(self.KEY_LATERAL)
         try:
             items = await self._redis.lrange(key, 0, -1)
-            return [
-                json.loads(item if isinstance(item, str) else item.decode())
-                for item in items
-            ]
+            return [json.loads(item if isinstance(item, str) else item.decode()) for item in items]
         except Exception as e:
             logger.warning(f"Failed to get lateral connections from Redis: {e}")
             return []
@@ -520,9 +508,7 @@ class BlueStateBackend:
         key = self._key(self.KEY_RECOMMENDATIONS)
         try:
             items = await self._redis.lrange(key, 0, -1)
-            return [
-                item if isinstance(item, str) else item.decode() for item in items
-            ]
+            return [item if isinstance(item, str) else item.decode() for item in items]
         except Exception as e:
             logger.warning(f"Failed to get recommendations from Redis: {e}")
             return []
@@ -670,9 +656,7 @@ class BlueStateBackend:
             ev_raw = await self._redis.hgetall(ev_key)
             for v in ev_raw.values():
                 try:
-                    result["evidence"].append(
-                        json.loads(v if isinstance(v, str) else v.decode())
-                    )
+                    result["evidence"].append(json.loads(v if isinstance(v, str) else v.decode()))
                 except json.JSONDecodeError:
                     logger.warning("Invalid JSON in evidence hash value")
         except Exception as e:
@@ -709,9 +693,7 @@ class BlueStateBackend:
             tn_key = self._key(self.KEY_TECHNIQUE_NAMES)
             tn_raw = await self._redis.hgetall(tn_key)
             result["technique_names"] = {
-                (k if isinstance(k, str) else k.decode()): (
-                    v if isinstance(v, str) else v.decode()
-                )
+                (k if isinstance(k, str) else k.decode()): (v if isinstance(v, str) else v.decode())
                 for k, v in tn_raw.items()
             }
         except Exception as e:
@@ -790,9 +772,7 @@ class BlueStateBackend:
             for k, v in meta_raw.items():
                 field = k if isinstance(k, str) else k.decode()
                 try:
-                    result["meta"][field] = json.loads(
-                        v if isinstance(v, str) else v.decode()
-                    )
+                    result["meta"][field] = json.loads(v if isinstance(v, str) else v.decode())
                 except json.JSONDecodeError:
                     logger.warning(f"Invalid JSON in meta field {field}")
         except Exception as e:

--- a/src/ares/core/blue_worker/__init__.py
+++ b/src/ares/core/blue_worker/__init__.py
@@ -1,0 +1,5 @@
+"""Blue team worker agent for multi-agent investigations."""
+
+from ares.core.blue_worker._worker import BlueWorkerAgent
+
+__all__ = ["BlueWorkerAgent"]

--- a/src/ares/core/blue_worker/_worker.py
+++ b/src/ares/core/blue_worker/_worker.py
@@ -13,12 +13,12 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from ares.core.blue_worker.prompts import generate_blue_task_prompt
-from ares.core.models import BlueRole, BlueTaskInfo, BlueTaskType, TaskStatus
 
 if TYPE_CHECKING:
     from dreadnode.agent import Agent
 
     from ares.core.blue_dispatcher import BlueTeamDispatcher
+    from ares.core.models import BlueRole, BlueTaskInfo
     from ares.tools.blue.callbacks import BlueWorkerCallbackTools
 
 
@@ -74,10 +74,7 @@ class BlueWorkerAgent:
         Returns:
             Result dict from the worker's completion callback.
         """
-        logger.info(
-            f"[{self.agent_name}] Processing task {task.task_id}: "
-            f"{task.task_type.value}"
-        )
+        logger.info(f"[{self.agent_name}] Processing task {task.task_id}: {task.task_type.value}")
 
         # Get current state summary for context
         state_summary = None
@@ -105,20 +102,18 @@ class BlueWorkerAgent:
             # Check if the agent called a completion callback
             if completion_event.is_set():
                 result = self.callback_tools.result_data
-                logger.info(
-                    f"[{self.agent_name}] Task {task.task_id} completed via callback"
-                )
+                logger.info(f"[{self.agent_name}] Task {task.task_id} completed via callback")
                 return result
-            else:
-                # Agent finished without calling callback (hit max_steps or stop condition)
-                logger.warning(
-                    f"[{self.agent_name}] Task {task.task_id} ended without completion callback"
-                )
-                return {
-                    "type": self.role.value,
-                    "summary": "Agent completed without explicit completion signal",
-                    "partial": True,
-                }
+
+            # Agent finished without calling callback (hit max_steps or stop condition)
+            logger.warning(
+                f"[{self.agent_name}] Task {task.task_id} ended without completion callback"
+            )
+            return {
+                "type": self.role.value,
+                "summary": "Agent completed without explicit completion signal",
+                "partial": True,
+            }
 
         except asyncio.CancelledError:
             logger.info(f"[{self.agent_name}] Task {task.task_id} cancelled")

--- a/src/ares/core/blue_worker/_worker.py
+++ b/src/ares/core/blue_worker/_worker.py
@@ -1,0 +1,189 @@
+"""Blue team worker agent for multi-agent investigations.
+
+Each worker runs in-process via asyncio.create_task(). It receives
+a pre-configured dreadnode Agent and processes tasks dispatched by
+the BlueTeamDispatcher.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from ares.core.blue_worker.prompts import generate_blue_task_prompt
+from ares.core.models import BlueRole, BlueTaskInfo, BlueTaskType, TaskStatus
+
+if TYPE_CHECKING:
+    from dreadnode.agent import Agent
+
+    from ares.core.blue_dispatcher import BlueTeamDispatcher
+    from ares.tools.blue.callbacks import BlueWorkerCallbackTools
+
+
+class BlueWorkerAgent:
+    """In-process worker that processes blue team investigation tasks.
+
+    Each worker:
+    1. Receives a task from the dispatcher
+    2. Generates a task prompt
+    3. Runs the dreadnode agent with that prompt
+    4. Reports results back to the dispatcher
+
+    Workers are started via start() which creates an asyncio task.
+    They process a single task at a time (synchronous from the
+    orchestrator's perspective when using wait_for_result=True).
+
+    Attributes:
+        role: The worker's specialized role.
+        agent: Pre-configured dreadnode Agent with role-specific tools.
+        agent_name: Human-readable agent name for logging.
+        investigation_id: Current investigation ID.
+        dispatcher: Reference to the dispatcher for result reporting.
+        callback_tools: Worker callback tools (for completion event).
+    """
+
+    def __init__(
+        self,
+        role: BlueRole,
+        agent: Agent,
+        agent_name: str,
+        investigation_id: str,
+        dispatcher: BlueTeamDispatcher,
+        callback_tools: BlueWorkerCallbackTools,
+    ) -> None:
+        self.role = role
+        self.agent = agent
+        self.agent_name = agent_name
+        self.investigation_id = investigation_id
+        self.dispatcher = dispatcher
+        self.callback_tools = callback_tools
+        self._task: asyncio.Task | None = None
+        self._should_stop = False
+
+    async def process_task(self, task: BlueTaskInfo) -> dict[str, Any]:
+        """Process a single task.
+
+        Generates the task prompt, runs the agent, and returns the
+        result from the callback tools.
+
+        Args:
+            task: The task to process.
+
+        Returns:
+            Result dict from the worker's completion callback.
+        """
+        logger.info(
+            f"[{self.agent_name}] Processing task {task.task_id}: "
+            f"{task.task_type.value}"
+        )
+
+        # Get current state summary for context
+        state_summary = None
+        try:
+            state_summary = await self.dispatcher.get_investigation_summary()
+        except Exception as e:
+            logger.warning(f"[{self.agent_name}] Failed to get state summary: {e}")
+
+        # Generate task prompt
+        prompt = generate_blue_task_prompt(
+            task_type=task.task_type,
+            params=task.params,
+            shared_state_summary=state_summary,
+        )
+
+        # Set up completion event
+        completion_event = asyncio.Event()
+        self.callback_tools.set_completion_event(completion_event)
+
+        # Run the agent
+        try:
+            logger.info(f"[{self.agent_name}] Starting agent.run() for task {task.task_id}")
+            await self.agent.run(prompt)
+
+            # Check if the agent called a completion callback
+            if completion_event.is_set():
+                result = self.callback_tools.result_data
+                logger.info(
+                    f"[{self.agent_name}] Task {task.task_id} completed via callback"
+                )
+                return result
+            else:
+                # Agent finished without calling callback (hit max_steps or stop condition)
+                logger.warning(
+                    f"[{self.agent_name}] Task {task.task_id} ended without completion callback"
+                )
+                return {
+                    "type": self.role.value,
+                    "summary": "Agent completed without explicit completion signal",
+                    "partial": True,
+                }
+
+        except asyncio.CancelledError:
+            logger.info(f"[{self.agent_name}] Task {task.task_id} cancelled")
+            return {
+                "type": self.role.value,
+                "error": "Task cancelled",
+                "partial": True,
+            }
+        except Exception as e:
+            logger.error(f"[{self.agent_name}] Task {task.task_id} failed: {e}")
+            return {
+                "type": self.role.value,
+                "error": str(e),
+                "partial": True,
+            }
+
+    async def execute_and_report(self, task: BlueTaskInfo) -> None:
+        """Execute a task and report results to the dispatcher.
+
+        This is the method called by the orchestrator's dispatch tools.
+        It processes the task and notifies the dispatcher of the result.
+
+        Args:
+            task: The task to process.
+        """
+        try:
+            result = await self.process_task(task)
+            await self.dispatcher.notify_task_result(
+                task_id=task.task_id,
+                success=not result.get("error"),
+                result=result,
+                error=result.get("error"),
+            )
+        except Exception as e:
+            logger.error(f"[{self.agent_name}] Failed to report task {task.task_id}: {e}")
+            await self.dispatcher.notify_task_result(
+                task_id=task.task_id,
+                success=False,
+                error=str(e),
+            )
+
+    def start_task(self, task: BlueTaskInfo) -> asyncio.Task:
+        """Start processing a task in the background.
+
+        Creates an asyncio task that processes and reports the result.
+
+        Args:
+            task: The task to process.
+
+        Returns:
+            The asyncio.Task for the running work.
+        """
+        self._task = asyncio.create_task(
+            self.execute_and_report(task),
+            name=f"{self.agent_name}:{task.task_id}",
+        )
+        return self._task
+
+    async def stop(self) -> None:
+        """Stop the worker and cancel any running task."""
+        self._should_stop = True
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await asyncio.wait_for(asyncio.shield(self._task), timeout=5.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                pass
+        logger.info(f"[{self.agent_name}] Stopped")

--- a/src/ares/core/blue_worker/prompts.py
+++ b/src/ares/core/blue_worker/prompts.py
@@ -46,8 +46,8 @@ def generate_blue_task_prompt(
         return _generate_fallback_prompt(task_type, params)
 
     try:
-        template = loader.get_template(template_name)
-        rendered = template.render(
+        rendered = loader.render(
+            template_name,
             current_time=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             state_summary=shared_state_summary or {},
             **params,

--- a/src/ares/core/blue_worker/prompts.py
+++ b/src/ares/core/blue_worker/prompts.py
@@ -1,0 +1,111 @@
+"""Task prompt generation for blue team workers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from ares.core.models import BlueTaskType
+
+
+def generate_blue_task_prompt(
+    task_type: BlueTaskType,
+    params: dict[str, Any],
+    shared_state_summary: dict[str, Any] | None = None,
+) -> str:
+    """Generate a task prompt for a blue team worker.
+
+    Renders the appropriate Jinja template with the task parameters
+    and current shared state summary.
+
+    Args:
+        task_type: Type of task to generate prompt for.
+        params: Task-specific parameters.
+        shared_state_summary: Current investigation state summary.
+
+    Returns:
+        Rendered prompt string.
+    """
+    from ares.core.templates import get_template_loader
+
+    loader = get_template_loader()
+
+    template_map = {
+        BlueTaskType.TRIAGE_ALERT: "blueteam/agents/triage_task.md.jinja",
+        BlueTaskType.THREAT_HUNT: "blueteam/agents/threat_hunt_task.md.jinja",
+        BlueTaskType.LATERAL_ANALYSIS: "blueteam/agents/lateral_task.md.jinja",
+        BlueTaskType.USER_INVESTIGATION: "blueteam/agents/user_investigation_task.md.jinja",
+        BlueTaskType.HOST_INVESTIGATION: "blueteam/agents/host_investigation_task.md.jinja",
+    }
+
+    template_name = template_map.get(task_type)
+    if not template_name:
+        # Fallback to a simple prompt
+        return _generate_fallback_prompt(task_type, params)
+
+    try:
+        template = loader.get_template(template_name)
+        rendered = template.render(
+            current_time=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            state_summary=shared_state_summary or {},
+            **params,
+        )
+        return rendered
+    except Exception as e:
+        logger.warning(f"Failed to render template {template_name}: {e}")
+        return _generate_fallback_prompt(task_type, params)
+
+
+def _generate_fallback_prompt(task_type: BlueTaskType, params: dict[str, Any]) -> str:
+    """Generate a simple fallback prompt when template rendering fails."""
+    import json
+
+    lines = [f"# Task: {task_type.value}", ""]
+
+    if task_type == BlueTaskType.TRIAGE_ALERT:
+        alert = params.get("alert", {})
+        alert_name = alert.get("labels", {}).get("alertname", "unknown")
+        lines.append(f"Triage alert: {alert_name}")
+        lines.append(f"Alert data: {json.dumps(alert, indent=2, default=str)[:2000]}")
+        lines.append("")
+        lines.append("Assess severity and record initial evidence. Call triage_complete() when done.")
+
+    elif task_type == BlueTaskType.THREAT_HUNT:
+        lines.append(f"Hunt for technique: {params.get('technique_id', 'N/A')}")
+        lines.append(f"Detection method: {params.get('detection_method', 'N/A')}")
+        if params.get("hostname"):
+            lines.append(f"Focus host: {params['hostname']}")
+        if params.get("username"):
+            lines.append(f"Focus user: {params['username']}")
+        lines.append("")
+        lines.append("Run detection queries, record evidence, call hunt_complete() when done.")
+
+    elif task_type == BlueTaskType.LATERAL_ANALYSIS:
+        lines.append(f"Analyze lateral movement scope")
+        if params.get("focus_host"):
+            lines.append(f"Focus host: {params['focus_host']}")
+        if params.get("focus_user"):
+            lines.append(f"Focus user: {params['focus_user']}")
+        lines.append("")
+        lines.append(
+            "Investigate host/user activity, record lateral connections, "
+            "call lateral_complete() when done."
+        )
+
+    elif task_type == BlueTaskType.USER_INVESTIGATION:
+        lines.append(f"Investigate user: {params.get('username', 'unknown')}")
+        lines.append("")
+        lines.append("Analyze user activity, record evidence, call hunt_complete() when done.")
+
+    elif task_type == BlueTaskType.HOST_INVESTIGATION:
+        lines.append(f"Investigate host: {params.get('hostname', 'unknown')}")
+        lines.append("")
+        lines.append("Analyze host activity, record evidence, call lateral_complete() when done.")
+
+    if params.get("context"):
+        lines.append("")
+        lines.append(f"Context: {params['context']}")
+
+    return "\n".join(lines)

--- a/src/ares/core/blue_worker/prompts.py
+++ b/src/ares/core/blue_worker/prompts.py
@@ -46,13 +46,12 @@ def generate_blue_task_prompt(
         return _generate_fallback_prompt(task_type, params)
 
     try:
-        rendered = loader.render(
+        return loader.render(
             template_name,
             current_time=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             state_summary=shared_state_summary or {},
             **params,
         )
-        return rendered
     except Exception as e:
         logger.warning(f"Failed to render template {template_name}: {e}")
         return _generate_fallback_prompt(task_type, params)
@@ -70,7 +69,9 @@ def _generate_fallback_prompt(task_type: BlueTaskType, params: dict[str, Any]) -
         lines.append(f"Triage alert: {alert_name}")
         lines.append(f"Alert data: {json.dumps(alert, indent=2, default=str)[:2000]}")
         lines.append("")
-        lines.append("Assess severity and record initial evidence. Call triage_complete() when done.")
+        lines.append(
+            "Assess severity and record initial evidence. Call triage_complete() when done."
+        )
 
     elif task_type == BlueTaskType.THREAT_HUNT:
         lines.append(f"Hunt for technique: {params.get('technique_id', 'N/A')}")
@@ -83,7 +84,7 @@ def _generate_fallback_prompt(task_type: BlueTaskType, params: dict[str, Any]) -
         lines.append("Run detection queries, record evidence, call hunt_complete() when done.")
 
     elif task_type == BlueTaskType.LATERAL_ANALYSIS:
-        lines.append(f"Analyze lateral movement scope")
+        lines.append("Analyze lateral movement scope")
         if params.get("focus_host"):
             lines.append(f"Focus host: {params['focus_host']}")
         if params.get("focus_user"):

--- a/src/ares/core/factories/blue_agents.py
+++ b/src/ares/core/factories/blue_agents.py
@@ -56,6 +56,8 @@ def create_blue_agent(
     mitre_client: MITREAttackClient,
     mcp_tools: list | None = None,
     max_steps: int = 20,
+    grafana_url: str = "",
+    alert: dict | None = None,
 ) -> tuple[Agent, BlueWorkerCallbackTools]:
     """Create a role-specific blue team agent.
 
@@ -67,12 +69,17 @@ def create_blue_agent(
         mitre_client: MITRE ATT&CK client.
         mcp_tools: Optional list of MCP tools from Grafana.
         max_steps: Maximum agent steps.
+        grafana_url: Grafana/Loki URL for QueryTemplateTools.
+        alert: Alert dict for deriving label selectors.
 
     Returns:
         Tuple of (Agent, BlueWorkerCallbackTools).
     """
     instructions = load_blue_instructions(role)
-    tools = _build_tools_for_role(role, backend, dispatcher, mitre_client, mcp_tools)
+    tools = _build_tools_for_role(
+        role, backend, dispatcher, mitre_client, mcp_tools,
+        grafana_url=grafana_url, alert=alert,
+    )
     callback_tools = tools[-1]  # Last tool is always the callback
     stop_conditions = get_blue_stop_conditions(role)
     hooks = create_blue_hooks(role)
@@ -127,6 +134,8 @@ def _build_tools_for_role(
     dispatcher: BlueTeamDispatcher,
     mitre_client: MITREAttackClient,
     mcp_tools: list | None = None,
+    grafana_url: str = "",
+    alert: dict | None = None,
 ) -> list:
     """Build the tool list for a specific role.
 
@@ -141,12 +150,28 @@ def _build_tools_for_role(
     shared_tools.set_shared_state(dispatcher.shared_state)
     shared_tools.set_mitre_client(mitre_client)
 
+    # Extract MCP query function and build QueryTemplateTools config
+    loki_url = grafana_url.rstrip("/") if grafana_url else "http://localhost:3100"
+    mcp_query_fn = _extract_mcp_query_fn(mcp_tools)
+    deployment = (alert or {}).get("labels", {}).get("deployment", "")
+    default_selector = (
+        f'{{deployment="{deployment}"}}' if deployment else '{job="windows-security"}'
+    )
+
     if role == BlueRole.TRIAGE:
         tools = _build_triage_tools(shared_tools, mitre_client, mcp_tools)
     elif role == BlueRole.THREAT_HUNTER:
-        tools = _build_hunter_tools(shared_tools, mitre_client, mcp_tools)
+        tools = _build_hunter_tools(
+            shared_tools, mitre_client, mcp_tools,
+            loki_url=loki_url, mcp_query_fn=mcp_query_fn,
+            default_selector=default_selector,
+        )
     elif role == BlueRole.LATERAL_ANALYST:
-        tools = _build_lateral_tools(shared_tools, mitre_client, mcp_tools)
+        tools = _build_lateral_tools(
+            shared_tools, mitre_client, mcp_tools,
+            loki_url=loki_url, mcp_query_fn=mcp_query_fn,
+            default_selector=default_selector,
+        )
     else:
         tools = [shared_tools]
 
@@ -186,6 +211,9 @@ def _build_hunter_tools(
     shared_tools: SharedInvestigationTools,
     mitre_client: MITREAttackClient,
     mcp_tools: list | None,
+    loki_url: str = "http://localhost:3100",
+    mcp_query_fn: Any = None,
+    default_selector: str = '{job="windows-security"}',
 ) -> list:
     """Build tools for threat hunter: detection queries + MCP + MITRE."""
     from ares.tools.blue import QueryTemplateTools
@@ -193,9 +221,17 @@ def _build_hunter_tools(
 
     tools: list = [shared_tools]
 
-    # QueryTemplateTools for detection queries
-    query_tools = QueryTemplateTools()
-    tools.append(query_tools)
+    # Pass specific QueryTemplateTools methods instead of whole toolset
+    # (39 detect_* methods → 4 selective methods = massive context reduction)
+    query_tools = QueryTemplateTools(
+        loki_url=loki_url,
+        default_label_selector=default_selector,
+        mcp_query_fn=mcp_query_fn,
+    )
+    tools.append(query_tools.run_detection_query)
+    tools.append(query_tools.list_query_templates)
+    tools.append(query_tools.get_host_activity)
+    tools.append(query_tools.get_user_activity)
 
     # MITRE lookup tools
     mitre_tools = MITRELookupTools()
@@ -214,15 +250,24 @@ def _build_lateral_tools(
     shared_tools: SharedInvestigationTools,
     mitre_client: MITREAttackClient,
     mcp_tools: list | None,
+    loki_url: str = "http://localhost:3100",
+    mcp_query_fn: Any = None,
+    default_selector: str = '{job="windows-security"}',
 ) -> list:
     """Build tools for lateral analyst: host/user activity + MCP."""
     from ares.tools.blue import QueryTemplateTools
 
     tools: list = [shared_tools]
 
-    # QueryTemplateTools for host/user activity queries
-    query_tools = QueryTemplateTools()
-    tools.append(query_tools)
+    # Pass specific QueryTemplateTools methods for lateral analysis
+    query_tools = QueryTemplateTools(
+        loki_url=loki_url,
+        default_label_selector=default_selector,
+        mcp_query_fn=mcp_query_fn,
+    )
+    tools.append(query_tools.run_detection_query)
+    tools.append(query_tools.get_host_activity)
+    tools.append(query_tools.get_user_activity)
 
     # Add filtered MCP tools
     if mcp_tools:
@@ -230,6 +275,47 @@ def _build_lateral_tools(
         tools.extend(filtered)
 
     return tools
+
+
+def _extract_mcp_query_fn(mcp_tools: list | None) -> Any:
+    """Extract MCP query_loki_logs function from MCP tools.
+
+    Returns a wrapper function compatible with QueryTemplateTools.mcp_query_fn,
+    or None if no query_loki_logs tool found.
+    """
+    if not mcp_tools:
+        return None
+
+    for tool in mcp_tools:
+        tool_name = getattr(tool, "name", "") or getattr(tool, "__name__", "")
+        if "query_loki_logs" in tool_name:
+            tool_fn = getattr(tool, "fn", None)
+            if tool_fn is None and callable(tool):
+                tool_fn = tool
+
+            if tool_fn:
+
+                async def mcp_loki_wrapper(
+                    datasource_uid: str,
+                    logql: str,
+                    start_time: str,
+                    end_time: str,
+                    limit: int,
+                    _fn=tool_fn,
+                ):
+                    return await _fn(
+                        datasourceUid=datasource_uid,
+                        logql=logql,
+                        startRfc3339=start_time,
+                        endRfc3339=end_time,
+                        limit=limit,
+                    )
+
+                logger.info(
+                    "QueryTemplateTools will use MCP query_loki_logs for authenticated queries"
+                )
+                return mcp_loki_wrapper
+    return None
 
 
 def _filter_mcp_for_role(mcp_tools: list, allowed_names: set[str]) -> list:
@@ -287,14 +373,18 @@ def create_blue_hooks(role: BlueRole) -> list:
 
     async def log_tool_usage(event: ToolStart):
         """Log tool calls for observability."""
-        tool_name = event.tool_call.name if event.tool_call else "unknown"
+        if not hasattr(event, "tool_call") or not event.tool_call:
+            return
+        tool_name = event.tool_call.name
         dn.log_metric(f"blue_{role.value}_tool_calls", 1, mode="count")
         logger.debug(f"[{role.value}] Tool call: {tool_name}")
 
     async def log_tool_result(event: ToolEnd):
         """Log tool results for observability."""
-        tool_name = event.tool_call.name if event.tool_call else "unknown"
-        result_len = len(str(event.tool_result)) if event.tool_result else 0
+        if not hasattr(event, "tool_call") or not event.tool_call:
+            return
+        tool_name = event.tool_call.name
+        result_len = len(str(event.tool_result)) if hasattr(event, "tool_result") and event.tool_result else 0
         logger.debug(f"[{role.value}] Tool result: {tool_name} ({result_len} chars)")
 
     return [log_tool_usage, log_tool_result]

--- a/src/ares/core/factories/blue_agents.py
+++ b/src/ares/core/factories/blue_agents.py
@@ -10,21 +10,18 @@ from typing import TYPE_CHECKING, Any
 
 import dreadnode as dn
 from dreadnode.agent import Agent, Thread
-from dreadnode.agent.events import ToolEnd, ToolStart
 from dreadnode.agent.stop import StopCondition, tool_use
 from loguru import logger
 
-from ares.core.factories.blue_factory import (
-    filter_essential_mcp_tools,
-    max_tool_calls_stop,
-    wrap_mcp_query_tools,
-)
+from ares.core.factories.blue_factory import max_tool_calls_stop
 from ares.core.models import BlueRole
 from ares.core.templates import get_template_loader
 from ares.tools.blue.callbacks import BlueWorkerCallbackTools
 from ares.tools.blue.shared_wrappers import SharedInvestigationTools
 
 if TYPE_CHECKING:
+    from dreadnode.agent.events import ToolEnd, ToolStart
+
     from ares.core.blue_dispatcher import BlueTeamDispatcher
     from ares.core.blue_state_backend import BlueStateBackend
     from ares.integrations.mitre import MITREAttackClient
@@ -77,8 +74,13 @@ def create_blue_agent(
     """
     instructions = load_blue_instructions(role)
     tools = _build_tools_for_role(
-        role, backend, dispatcher, mitre_client, mcp_tools,
-        grafana_url=grafana_url, alert=alert,
+        role,
+        backend,
+        dispatcher,
+        mitre_client,
+        mcp_tools,
+        grafana_url=grafana_url,
+        alert=alert,
     )
     callback_tools = tools[-1]  # Last tool is always the callback
     stop_conditions = get_blue_stop_conditions(role)
@@ -162,14 +164,20 @@ def _build_tools_for_role(
         tools = _build_triage_tools(shared_tools, mitre_client, mcp_tools)
     elif role == BlueRole.THREAT_HUNTER:
         tools = _build_hunter_tools(
-            shared_tools, mitre_client, mcp_tools,
-            loki_url=loki_url, mcp_query_fn=mcp_query_fn,
+            shared_tools,
+            mitre_client,
+            mcp_tools,
+            loki_url=loki_url,
+            mcp_query_fn=mcp_query_fn,
             default_selector=default_selector,
         )
     elif role == BlueRole.LATERAL_ANALYST:
         tools = _build_lateral_tools(
-            shared_tools, mitre_client, mcp_tools,
-            loki_url=loki_url, mcp_query_fn=mcp_query_fn,
+            shared_tools,
+            mitre_client,
+            mcp_tools,
+            loki_url=loki_url,
+            mcp_query_fn=mcp_query_fn,
             default_selector=default_selector,
         )
     else:
@@ -342,17 +350,17 @@ def get_blue_stop_conditions(role: BlueRole) -> list[StopCondition]:
             tool_use("triage_complete"),
             max_tool_calls_stop(max_calls=30),
         ]
-    elif role == BlueRole.THREAT_HUNTER:
+    if role == BlueRole.THREAT_HUNTER:
         return [
             tool_use("hunt_complete"),
             max_tool_calls_stop(max_calls=40),
         ]
-    elif role == BlueRole.LATERAL_ANALYST:
+    if role == BlueRole.LATERAL_ANALYST:
         return [
             tool_use("lateral_complete"),
             max_tool_calls_stop(max_calls=35),
         ]
-    elif role == BlueRole.ORCHESTRATOR:
+    if role == BlueRole.ORCHESTRATOR:
         return [
             tool_use("complete_investigation"),
             tool_use("escalate_investigation"),
@@ -384,7 +392,11 @@ def create_blue_hooks(role: BlueRole) -> list:
         if not hasattr(event, "tool_call") or not event.tool_call:
             return
         tool_name = event.tool_call.name
-        result_len = len(str(event.tool_result)) if hasattr(event, "tool_result") and event.tool_result else 0
+        result_len = (
+            len(str(event.tool_result))
+            if hasattr(event, "tool_result") and event.tool_result
+            else 0
+        )
         logger.debug(f"[{role.value}] Tool result: {tool_name} ({result_len} chars)")
 
     return [log_tool_usage, log_tool_result]

--- a/src/ares/core/factories/blue_agents.py
+++ b/src/ares/core/factories/blue_agents.py
@@ -1,0 +1,311 @@
+"""Factory for creating blue team multi-agent workers.
+
+Creates role-specific dreadnode Agents with appropriate tools,
+instructions, and stop conditions for each BlueRole.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import dreadnode as dn
+from dreadnode.agent import Agent, Thread
+from dreadnode.agent.events import ToolEnd, ToolStart
+from dreadnode.agent.stop import StopCondition, tool_use
+from loguru import logger
+
+from ares.core.factories.blue_factory import (
+    filter_essential_mcp_tools,
+    max_tool_calls_stop,
+    wrap_mcp_query_tools,
+)
+from ares.core.models import BlueRole
+from ares.core.templates import get_template_loader
+from ares.tools.blue.callbacks import BlueWorkerCallbackTools
+from ares.tools.blue.shared_wrappers import SharedInvestigationTools
+
+if TYPE_CHECKING:
+    from ares.core.blue_dispatcher import BlueTeamDispatcher
+    from ares.core.blue_state_backend import BlueStateBackend
+    from ares.integrations.mitre import MITREAttackClient
+
+
+# MCP tools needed by each worker role
+_TRIAGE_MCP_TOOLS = {
+    "query_loki_logs",
+    "list_loki_label_names",
+    "list_loki_label_values",
+}
+
+_HUNTER_MCP_TOOLS = {
+    "query_loki_logs",
+    "query_loki_patterns",
+    "query_loki_stats",
+}
+
+_LATERAL_MCP_TOOLS = {
+    "query_loki_logs",
+}
+
+
+def create_blue_agent(
+    role: BlueRole,
+    model: str,
+    backend: BlueStateBackend,
+    dispatcher: BlueTeamDispatcher,
+    mitre_client: MITREAttackClient,
+    mcp_tools: list | None = None,
+    max_steps: int = 20,
+) -> tuple[Agent, BlueWorkerCallbackTools]:
+    """Create a role-specific blue team agent.
+
+    Args:
+        role: The agent's specialized role.
+        model: LLM model identifier.
+        backend: BlueStateBackend for shared state.
+        dispatcher: BlueTeamDispatcher for coordination.
+        mitre_client: MITRE ATT&CK client.
+        mcp_tools: Optional list of MCP tools from Grafana.
+        max_steps: Maximum agent steps.
+
+    Returns:
+        Tuple of (Agent, BlueWorkerCallbackTools).
+    """
+    instructions = load_blue_instructions(role)
+    tools = _build_tools_for_role(role, backend, dispatcher, mitre_client, mcp_tools)
+    callback_tools = tools[-1]  # Last tool is always the callback
+    stop_conditions = get_blue_stop_conditions(role)
+    hooks = create_blue_hooks(role)
+
+    agent_name = _role_to_name(role)
+
+    agent = dn.Agent(
+        name=agent_name,
+        model=model,
+        instructions=instructions,
+        max_steps=max_steps,
+        tools=tools,
+        hooks=hooks,
+        stop_conditions=stop_conditions,
+        thread=Thread(),  # type: ignore[call-arg]
+    )
+
+    return agent, callback_tools
+
+
+def load_blue_instructions(role: BlueRole) -> str:
+    """Load role-specific system instructions from Jinja template.
+
+    Args:
+        role: The agent role.
+
+    Returns:
+        Rendered system instructions string.
+    """
+    template_map = {
+        BlueRole.ORCHESTRATOR: "blueteam/agents/orchestrator.md.jinja",
+        BlueRole.TRIAGE: "blueteam/agents/triage.md.jinja",
+        BlueRole.THREAT_HUNTER: "blueteam/agents/threat_hunter.md.jinja",
+        BlueRole.LATERAL_ANALYST: "blueteam/agents/lateral_analyst.md.jinja",
+    }
+
+    template_name = template_map.get(role)
+    if not template_name:
+        return f"You are a blue team {role.value} agent."
+
+    try:
+        loader = get_template_loader()
+        return loader.render(template_name)
+    except Exception as e:
+        logger.warning(f"Failed to load template for {role.value}: {e}")
+        return f"You are a blue team {role.value} agent. Investigate security alerts and record evidence."
+
+
+def _build_tools_for_role(
+    role: BlueRole,
+    backend: BlueStateBackend,
+    dispatcher: BlueTeamDispatcher,
+    mitre_client: MITREAttackClient,
+    mcp_tools: list | None = None,
+) -> list:
+    """Build the tool list for a specific role.
+
+    Returns:
+        List of tool instances. The last element is always BlueWorkerCallbackTools.
+    """
+    tools: list = []
+
+    # Shared investigation tools for all worker roles
+    shared_tools = SharedInvestigationTools()
+    shared_tools.set_backend(backend)
+    shared_tools.set_shared_state(dispatcher.shared_state)
+    shared_tools.set_mitre_client(mitre_client)
+
+    if role == BlueRole.TRIAGE:
+        tools = _build_triage_tools(shared_tools, mitre_client, mcp_tools)
+    elif role == BlueRole.THREAT_HUNTER:
+        tools = _build_hunter_tools(shared_tools, mitre_client, mcp_tools)
+    elif role == BlueRole.LATERAL_ANALYST:
+        tools = _build_lateral_tools(shared_tools, mitre_client, mcp_tools)
+    else:
+        tools = [shared_tools]
+
+    # Callback tools always last
+    callback = BlueWorkerCallbackTools()
+    tools.append(callback)
+
+    # Log tool count
+    tool_count = 0
+    for t in tools:
+        if hasattr(t, "get_tools"):
+            tool_count += len(t.get_tools())
+        else:
+            tool_count += 1
+    logger.info(f"[{role.value}] Built {tool_count} tools from {len(tools)} entries")
+
+    return tools
+
+
+def _build_triage_tools(
+    shared_tools: SharedInvestigationTools,
+    mitre_client: MITREAttackClient,
+    mcp_tools: list | None,
+) -> list:
+    """Build tools for triage worker: MCP query + investigation tools."""
+    tools: list = [shared_tools]
+
+    # Add filtered MCP tools (just Loki query + label discovery)
+    if mcp_tools:
+        filtered = _filter_mcp_for_role(mcp_tools, _TRIAGE_MCP_TOOLS)
+        tools.extend(filtered)
+
+    return tools
+
+
+def _build_hunter_tools(
+    shared_tools: SharedInvestigationTools,
+    mitre_client: MITREAttackClient,
+    mcp_tools: list | None,
+) -> list:
+    """Build tools for threat hunter: detection queries + MCP + MITRE."""
+    from ares.tools.blue import QueryTemplateTools
+    from ares.tools.shared import MITRELookupTools
+
+    tools: list = [shared_tools]
+
+    # QueryTemplateTools for detection queries
+    query_tools = QueryTemplateTools()
+    tools.append(query_tools)
+
+    # MITRE lookup tools
+    mitre_tools = MITRELookupTools()
+    mitre_tools.set_client(mitre_client)
+    tools.append(mitre_tools)
+
+    # Add filtered MCP tools
+    if mcp_tools:
+        filtered = _filter_mcp_for_role(mcp_tools, _HUNTER_MCP_TOOLS)
+        tools.extend(filtered)
+
+    return tools
+
+
+def _build_lateral_tools(
+    shared_tools: SharedInvestigationTools,
+    mitre_client: MITREAttackClient,
+    mcp_tools: list | None,
+) -> list:
+    """Build tools for lateral analyst: host/user activity + MCP."""
+    from ares.tools.blue import QueryTemplateTools
+
+    tools: list = [shared_tools]
+
+    # QueryTemplateTools for host/user activity queries
+    query_tools = QueryTemplateTools()
+    tools.append(query_tools)
+
+    # Add filtered MCP tools
+    if mcp_tools:
+        filtered = _filter_mcp_for_role(mcp_tools, _LATERAL_MCP_TOOLS)
+        tools.extend(filtered)
+
+    return tools
+
+
+def _filter_mcp_for_role(mcp_tools: list, allowed_names: set[str]) -> list:
+    """Filter MCP tools to only those needed by a specific role."""
+    filtered = []
+    for tool in mcp_tools:
+        tool_name = getattr(tool, "name", "") or getattr(tool, "__name__", str(tool))
+        if tool_name in allowed_names:
+            filtered.append(tool)
+    return filtered
+
+
+def get_blue_stop_conditions(role: BlueRole) -> list[StopCondition]:
+    """Get stop conditions for a specific role.
+
+    Args:
+        role: The agent role.
+
+    Returns:
+        List of stop conditions.
+    """
+    if role == BlueRole.TRIAGE:
+        return [
+            tool_use("triage_complete"),
+            max_tool_calls_stop(max_calls=30),
+        ]
+    elif role == BlueRole.THREAT_HUNTER:
+        return [
+            tool_use("hunt_complete"),
+            max_tool_calls_stop(max_calls=40),
+        ]
+    elif role == BlueRole.LATERAL_ANALYST:
+        return [
+            tool_use("lateral_complete"),
+            max_tool_calls_stop(max_calls=35),
+        ]
+    elif role == BlueRole.ORCHESTRATOR:
+        return [
+            tool_use("complete_investigation"),
+            tool_use("escalate_investigation"),
+            max_tool_calls_stop(max_calls=60),
+        ]
+    return [max_tool_calls_stop(max_calls=30)]
+
+
+def create_blue_hooks(role: BlueRole) -> list:
+    """Create hooks for a blue team agent.
+
+    Args:
+        role: The agent role.
+
+    Returns:
+        List of hook functions.
+    """
+
+    async def log_tool_usage(event: ToolStart):
+        """Log tool calls for observability."""
+        tool_name = event.tool_call.name if event.tool_call else "unknown"
+        dn.log_metric(f"blue_{role.value}_tool_calls", 1, mode="count")
+        logger.debug(f"[{role.value}] Tool call: {tool_name}")
+
+    async def log_tool_result(event: ToolEnd):
+        """Log tool results for observability."""
+        tool_name = event.tool_call.name if event.tool_call else "unknown"
+        result_len = len(str(event.tool_result)) if event.tool_result else 0
+        logger.debug(f"[{role.value}] Tool result: {tool_name} ({result_len} chars)")
+
+    return [log_tool_usage, log_tool_result]
+
+
+def _role_to_name(role: BlueRole) -> str:
+    """Convert role to human-readable agent name."""
+    names = {
+        BlueRole.ORCHESTRATOR: "Blue Team Orchestrator",
+        BlueRole.TRIAGE: "Triage Analyst",
+        BlueRole.THREAT_HUNTER: "Threat Hunter",
+        BlueRole.LATERAL_ANALYST: "Lateral Analyst",
+    }
+    return names.get(role, f"Blue Agent ({role.value})")

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -55,10 +55,15 @@ DEFAULT_MAX_RETRIES = 3
 __all__ = [
     # Constants
     "DEFAULT_MAX_RETRIES",
-    # Multi-Agent Models
+    # Multi-Agent Models (Red Team)
     "AgentInfo",
     "AgentLocalState",
     "AgentRole",
+    # Multi-Agent Models (Blue Team)
+    "BlueRole",
+    "BlueTaskInfo",
+    "BlueTaskType",
+    "SharedBlueTeamState",
     # Core Models
     "Credential",
     "Evidence",
@@ -3127,3 +3132,206 @@ class AgentLocalState:
     def record_error(self, error: str) -> None:
         """Record an error."""
         self.errors_encountered.append(error)
+
+
+# =============================================================================
+# Blue Team Multi-Agent Models
+# =============================================================================
+
+
+class BlueRole(Enum):
+    """Specialized roles for multi-agent blue team operations."""
+
+    ORCHESTRATOR = "orchestrator"
+    TRIAGE = "triage"
+    THREAT_HUNTER = "threat_hunter"
+    LATERAL_ANALYST = "lateral_analyst"
+
+
+class BlueTaskType(Enum):
+    """Types of tasks dispatched to blue team workers."""
+
+    TRIAGE_ALERT = "triage_alert"
+    THREAT_HUNT = "threat_hunt"
+    LATERAL_ANALYSIS = "lateral_analysis"
+    USER_INVESTIGATION = "user_investigation"
+    HOST_INVESTIGATION = "host_investigation"
+
+
+@dataclass
+class BlueTaskInfo:
+    """Information about a dispatched blue team task."""
+
+    task_id: str
+    task_type: BlueTaskType
+    investigation_id: str
+    status: TaskStatus = TaskStatus.PENDING
+    assigned_role: BlueRole = BlueRole.TRIAGE
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+    result: Any = None
+    error: str | None = None
+    retry_count: int = 0
+
+
+@dataclass
+class SharedBlueTeamState:
+    """Cluster-wide state shared across all blue team agents.
+
+    Stored in Redis for multi-agent coordination. Each field maps to
+    a Redis key under ares:blue:inv:{investigation_id}:*.
+
+    Attributes:
+        investigation_id: Unique identifier for this investigation.
+        alert: The original alert that triggered investigation.
+        stage: Current investigation stage.
+        started_at: When the investigation began.
+        evidence: List of all evidence collected across agents.
+        timeline: Timeline events in chronological order.
+        identified_techniques: MITRE ATT&CK technique IDs found.
+        identified_tactics: MITRE ATT&CK tactic IDs found.
+        queried_hosts: Hosts that have been investigated.
+        queried_users: Users that have been investigated.
+        executed_query_types: Query method names already executed.
+        executed_queries: Log of all queries executed.
+        technique_names: Mapping of technique IDs to names.
+        lateral_connections: Lateral movement connections discovered.
+        queued_pivot_queries: Auto-generated pivot queries.
+        queued_chain_queries: Auto-generated follow-up detection methods.
+        escalated: Whether investigation was escalated.
+        escalation_reason: Reason for escalation.
+        attack_synopsis: Summary of the attack.
+        recommendations: Recommended actions.
+        correlation_context: Alert correlation context.
+        pending_tasks: Tasks dispatched but not completed.
+        completed_tasks: Results of completed tasks.
+    """
+
+    investigation_id: str
+    alert: dict[str, Any] = field(default_factory=dict)
+    stage: InvestigationStage = InvestigationStage.TRIAGE
+    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    # Evidence and timeline (aggregated from all agents)
+    evidence: list[Evidence] = field(default_factory=list)
+    timeline: list[TimelineEvent] = field(default_factory=list)
+
+    # MITRE tracking
+    identified_techniques: set[str] = field(default_factory=set)
+    identified_tactics: set[str] = field(default_factory=set)
+    technique_names: dict[str, str] = field(default_factory=dict)
+
+    # Investigation scope
+    queried_hosts: set[str] = field(default_factory=set)
+    queried_users: set[str] = field(default_factory=set)
+    executed_query_types: set[str] = field(default_factory=set)
+    executed_queries: list[dict] = field(default_factory=list)
+
+    # Lateral movement
+    lateral_connections: list[dict] = field(default_factory=list)
+
+    # Auto-pivot and detection chaining
+    queued_pivot_queries: list[dict] = field(default_factory=list)
+    queued_chain_queries: list[str] = field(default_factory=list)
+
+    # Completion
+    escalated: bool = False
+    escalation_reason: str | None = None
+    attack_synopsis: str | None = None
+    recommendations: list[str] = field(default_factory=list)
+
+    # Alert correlation
+    correlation_context: dict[str, Any] | None = None
+
+    # Task tracking
+    pending_tasks: dict[str, BlueTaskInfo] = field(default_factory=dict)
+    completed_tasks: dict[str, BlueTaskInfo] = field(default_factory=dict)
+
+    # Evidence dedup keys (in-memory for fast checking)
+    _evidence_dedup_keys: set[str] = field(
+        default_factory=set, init=False, repr=False, compare=False
+    )
+
+    # Backend reference (NOT serialized)
+    _backend: Any = field(default=None, init=False, repr=False, compare=False)
+
+    @property
+    def evidence_count(self) -> int:
+        return len(self.evidence)
+
+    @property
+    def highest_pyramid_level(self) -> int:
+        if not self.evidence:
+            return 0
+        return max(e.pyramid_level.value for e in self.evidence)
+
+    @property
+    def ttp_count(self) -> int:
+        return len([e for e in self.evidence if e.pyramid_level == PyramidLevel.TTPS])
+
+    def set_backend(self, backend) -> None:
+        """Set Redis state backend."""
+        object.__setattr__(self, "_backend", backend)
+
+    def to_investigation_state(self) -> InvestigationState:
+        """Convert to InvestigationState for report generation and eval scoring.
+
+        This is the backward-compatibility bridge: MarkdownReportGenerator.generate()
+        and eval scorers operate on InvestigationState regardless of source.
+        """
+        from ares.core.lateral_analyzer import LateralGraph
+
+        state = InvestigationState(
+            investigation_id=self.investigation_id,
+            alert=self.alert,
+            stage=self.stage,
+            started_at=self.started_at,
+            evidence=list(self.evidence),
+            timeline=sorted(self.timeline, key=lambda e: e.timestamp),
+            executed_queries=list(self.executed_queries),
+            identified_techniques=set(self.identified_techniques),
+            identified_tactics=set(self.identified_tactics),
+            queried_hosts=set(self.queried_hosts),
+            queried_users=set(self.queried_users),
+            technique_names=dict(self.technique_names),
+            escalated=self.escalated,
+            escalation_reason=self.escalation_reason,
+            attack_synopsis=self.attack_synopsis,
+            recommendations=list(self.recommendations),
+            correlation_context=self.correlation_context,
+            queued_pivot_queries=list(self.queued_pivot_queries),
+            queued_chain_queries=list(self.queued_chain_queries),
+            executed_query_types=set(self.executed_query_types),
+        )
+
+        # Rebuild lateral graph from connections
+        graph = LateralGraph()
+        for conn in self.lateral_connections:
+            graph.add_connection(
+                source=conn.get("source", ""),
+                destination=conn.get("destination", ""),
+                connection_type=conn.get("connection_type", ""),
+                user=conn.get("user", ""),
+                mitre_technique=conn.get("mitre_technique", ""),
+            )
+        state.lateral_graph = graph
+
+        return state
+
+    def to_summary(self) -> dict:
+        """Return a summary dict of the investigation state."""
+        return {
+            "investigation_id": self.investigation_id,
+            "stage": self.stage.value,
+            "evidence_count": self.evidence_count,
+            "timeline_events": len(self.timeline),
+            "techniques_identified": list(self.identified_techniques),
+            "highest_pyramid_level": self.highest_pyramid_level,
+            "ttp_count": self.ttp_count,
+            "hosts_investigated": list(self.queried_hosts),
+            "users_investigated": list(self.queried_users),
+            "pending_tasks": len(self.pending_tasks),
+            "completed_tasks": len(self.completed_tasks),
+        }

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -53,18 +53,13 @@ def _get_uuid() -> str:
 DEFAULT_MAX_RETRIES = 3
 
 __all__ = [
-    # Constants
     "DEFAULT_MAX_RETRIES",
-    # Multi-Agent Models (Red Team)
     "AgentInfo",
     "AgentLocalState",
     "AgentRole",
-    # Multi-Agent Models (Blue Team)
     "BlueRole",
     "BlueTaskInfo",
     "BlueTaskType",
-    "SharedBlueTeamState",
-    # Core Models
     "Credential",
     "Evidence",
     "Hash",
@@ -77,6 +72,7 @@ __all__ = [
     "QuestionSource",
     "QuestionState",
     "Share",
+    "SharedBlueTeamState",
     "SharedRedTeamState",
     "Target",
     "TaskInfo",
@@ -85,7 +81,6 @@ __all__ = [
     "TimelineEvent",
     "User",
     "VulnerabilityInfo",
-    # Parsing utilities
     "parse",
     "parse_many",
     "parse_set",

--- a/src/ares/eval/workflow.py
+++ b/src/ares/eval/workflow.py
@@ -409,7 +409,13 @@ class EvaluationRunner:
         output_dir: Directory for evaluation results.
         inject_synthetic_alerts: If True, create synthetic alerts instead of polling.
         default_matching_rules: Default alert matching rules.
+        multi_agent: If True, force multi-agent for ALL alerts.
+        auto_route: If True, use multi-agent for HIGH/CRITICAL severity.
+        redis_url: Redis URL for multi-agent state (required if multi_agent or auto_route).
     """
+
+    # Severity levels that trigger multi-agent routing
+    HIGH_SEVERITY_LEVELS = frozenset({"critical", "high"})
 
     def __init__(
         self,
@@ -420,6 +426,9 @@ class EvaluationRunner:
         output_dir: Path | str = "./eval_results",
         inject_synthetic_alerts: bool = False,
         default_matching_rules: AlertMatchingRules | None = None,
+        multi_agent: bool = False,
+        auto_route: bool = True,
+        redis_url: str = "",
     ):
         self.model = model
         self.grafana_url = grafana_url
@@ -429,6 +438,9 @@ class EvaluationRunner:
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.inject_synthetic_alerts = inject_synthetic_alerts
         self.default_matching_rules = default_matching_rules or AlertMatchingRules()
+        self.multi_agent = multi_agent
+        self.auto_route = auto_route
+        self.redis_url = redis_url
 
         # Cached MITRE client
         self._mitre_client: MITREAttackClient | None = None
@@ -911,6 +923,21 @@ class EvaluationRunner:
 
         return False
 
+    def _should_use_multi_agent(self, severity: str) -> bool:
+        """Determine if an alert should use multi-agent based on severity.
+
+        Args:
+            severity: Alert severity level.
+
+        Returns:
+            True if multi-agent should be used for this alert.
+        """
+        if self.multi_agent:
+            return True
+        if self.auto_route and severity.lower() in self.HIGH_SEVERITY_LEVELS:
+            return bool(self.redis_url)
+        return False
+
     async def _run_investigation(self, alert: dict[str, Any]) -> tuple[InvestigationState, Any]:
         """Run a blue team investigation for an alert.
 
@@ -920,20 +947,48 @@ class EvaluationRunner:
         Returns:
             Tuple of (InvestigationState, orchestrator) for cleanup.
         """
-        from ares.agents.blue import InvestigationOrchestrator
-
         # Use cached MITRE client
         mitre_client = await self._get_mitre_client()
 
-        # Create orchestrator
-        orchestrator = InvestigationOrchestrator(
-            model=self.model,
-            grafana_url=self.grafana_url,
-            grafana_api_key=self.grafana_api_key,
-            mitre_client=mitre_client,
-            report_dir=self.output_dir / "reports",
-            max_steps=self.max_steps,
-        )
+        # Extract severity for routing
+        severity = alert.get("labels", {}).get("severity", "unknown")
+        use_multi = self._should_use_multi_agent(severity)
+
+        # Create orchestrator (multi-agent or monolithic) based on routing
+        # Use Any type to handle both orchestrator types uniformly
+        orchestrator: Any
+        if use_multi:
+            from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
+
+            if not self.redis_url:
+                raise RuntimeError(
+                    "Multi-agent mode requires redis_url - "
+                    "set redis_url parameter or use multi_agent=False"
+                )
+
+            mode = "multi-agent" if self.multi_agent else "multi-agent (auto-routed)"
+            logger.info(f"Investigation mode: {mode} (severity: {severity})")
+            orchestrator = BlueTeamOrchestrator(
+                model=self.model,
+                grafana_url=self.grafana_url,
+                grafana_api_key=self.grafana_api_key,
+                mitre_client=mitre_client,
+                report_dir=self.output_dir / "reports",
+                max_steps=self.max_steps,
+                redis_url=self.redis_url,
+            )
+        else:
+            from ares.agents.blue import InvestigationOrchestrator
+
+            logger.info(f"Investigation mode: single-agent (severity: {severity})")
+            orchestrator = InvestigationOrchestrator(
+                model=self.model,
+                grafana_url=self.grafana_url,
+                grafana_api_key=self.grafana_api_key,
+                mitre_client=mitre_client,
+                report_dir=self.output_dir / "reports",
+                max_steps=self.max_steps,
+            )
 
         # Run investigation
         result = await orchestrator.investigate(alert)

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -9,7 +9,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import cyclopts
 import dreadnode as dn
@@ -17,6 +17,38 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from ares.core.models import InvestigationState
+
+
+# Severity levels that trigger multi-agent routing
+HIGH_SEVERITY_LEVELS = frozenset({"critical", "high"})
+
+
+class InvestigationOrchestratorProtocol(Protocol):
+    """Protocol for investigation orchestrators (single and multi-agent)."""
+
+    async def investigate(self, alert: dict, *, correlation_context: dict | None = None) -> dict:
+        """Run an investigation on an alert."""
+        ...
+
+    async def _shutdown_mcp(self) -> None:
+        """Shutdown MCP connections."""
+        ...
+
+
+def should_use_multi_agent(severity: str, *, force_multi_agent: bool = False) -> bool:
+    """Determine if an alert should use multi-agent based on severity.
+
+    Args:
+        severity: Alert severity level (critical, high, medium, low, etc.)
+        force_multi_agent: If True, always use multi-agent regardless of severity.
+
+    Returns:
+        True if multi-agent should be used for this alert.
+    """
+    if force_multi_agent:
+        return True
+    return severity.lower() in HIGH_SEVERITY_LEVELS
+
 
 app = cyclopts.App(
     name="ares",
@@ -46,7 +78,8 @@ class Args:
         operation_id: Red team operation ID to focus investigation on.
         latest: Use the latest red team operation (prefer running).
         redis_url: Redis URL for loading red team operation state.
-        multi_agent: Use multi-agent orchestrator (requires Redis).
+        multi_agent: Force multi-agent for ALL alerts (requires Redis).
+        auto_route: Enable severity-based routing (multi-agent for HIGH/CRITICAL).
     """
 
     model: str = ""
@@ -59,7 +92,8 @@ class Args:
     operation_id: str = ""  # Red team operation to focus on
     latest: bool = False  # Use latest red team operation
     redis_url: str = ""  # Redis URL for red team state
-    multi_agent: bool = False  # Use multi-agent blue team orchestrator
+    multi_agent: bool = False  # Force multi-agent for ALL alerts
+    auto_route: bool = True  # Enable severity-based auto-routing
 
 
 @dataclass
@@ -262,11 +296,17 @@ async def main(
     report_dir.mkdir(parents=True, exist_ok=True)
     logger.info(f"Reports: {report_dir}")
 
-    if args.multi_agent:
-        from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
-        from ares.core.config import get_redis_url
+    # Determine Redis availability for multi-agent support
+    from ares.core.config import get_redis_url
 
-        blue_redis_url = args.redis_url or os.getenv("ARES_REDIS_URL", "") or get_redis_url()
+    blue_redis_url = args.redis_url or os.getenv("ARES_REDIS_URL", "") or get_redis_url()
+
+    # Create orchestrators based on configuration
+    single_agent_orchestrator: InvestigationOrchestratorProtocol | None = None
+    multi_agent_orchestrator: InvestigationOrchestratorProtocol | None = None
+
+    if args.multi_agent:
+        # Force multi-agent mode for ALL alerts
         if not blue_redis_url:
             logger.error(
                 "Multi-agent mode requires Redis. "
@@ -274,8 +314,37 @@ async def main(
             )
             return
 
+        from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
+
         logger.info(f"Mode: MULTI-AGENT (Redis: {blue_redis_url})")
-        orchestrator = BlueTeamOrchestrator(
+        multi_agent_orchestrator = BlueTeamOrchestrator(
+            model=model,
+            grafana_url=args.grafana_url,
+            grafana_api_key=grafana_api_key,
+            mitre_client=mitre_client,
+            report_dir=report_dir,
+            max_steps=args.max_steps,
+            redis_url=blue_redis_url,
+            attack_context=attack_context,
+        )
+    elif args.auto_route and blue_redis_url:
+        # Auto-routing mode: create both orchestrators
+        from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
+
+        logger.info(f"Mode: AUTO-ROUTE (Redis: {blue_redis_url})")
+        logger.info("  HIGH/CRITICAL alerts -> multi-agent")
+        logger.info("  Other alerts -> single-agent")
+
+        single_agent_orchestrator = InvestigationOrchestrator(
+            model=model,
+            grafana_url=args.grafana_url,
+            grafana_api_key=grafana_api_key,
+            mitre_client=mitre_client,
+            report_dir=report_dir,
+            max_steps=args.max_steps,
+            attack_context=attack_context,
+        )
+        multi_agent_orchestrator = BlueTeamOrchestrator(
             model=model,
             grafana_url=args.grafana_url,
             grafana_api_key=grafana_api_key,
@@ -286,7 +355,15 @@ async def main(
             attack_context=attack_context,
         )
     else:
-        orchestrator = InvestigationOrchestrator(
+        # Single-agent mode only
+        if args.auto_route and not blue_redis_url:
+            logger.warning(
+                "Auto-routing enabled but Redis unavailable. "
+                "Using single-agent for all alerts. "
+                "Set ARES_REDIS_URL to enable multi-agent for HIGH/CRITICAL alerts."
+            )
+        logger.info("Mode: SINGLE-AGENT")
+        single_agent_orchestrator = InvestigationOrchestrator(
             model=model,
             grafana_url=args.grafana_url,
             grafana_api_key=grafana_api_key,
@@ -295,6 +372,33 @@ async def main(
             max_steps=args.max_steps,
             attack_context=attack_context,
         )
+
+    # Helper to get the appropriate orchestrator for an alert
+    def get_orchestrator_for_alert(
+        alert_severity: str,
+    ) -> tuple[InvestigationOrchestratorProtocol, str]:
+        """Get the appropriate orchestrator based on alert severity.
+
+        Returns:
+            Tuple of (orchestrator, mode_name) for logging.
+        """
+        if args.multi_agent and multi_agent_orchestrator is not None:
+            # Force multi-agent mode
+            return multi_agent_orchestrator, "multi-agent"
+
+        if (
+            args.auto_route
+            and should_use_multi_agent(alert_severity)
+            and multi_agent_orchestrator is not None
+        ):
+            return multi_agent_orchestrator, "multi-agent (auto-routed)"
+
+        # Fallback to single-agent
+        if single_agent_orchestrator is not None:
+            return single_agent_orchestrator, "single-agent"
+
+        # This should never happen - at least one orchestrator should exist
+        raise RuntimeError("No orchestrator available")
 
     grafana = GrafanaTools(
         base_url=args.grafana_url,
@@ -353,6 +457,10 @@ async def main(
                             f"Alert correlation: {related_count} related alerts in cluster "
                             f"{cluster.cluster_id}"
                         )
+
+                    # Route alert to appropriate orchestrator based on severity
+                    orchestrator, orchestrator_mode = get_orchestrator_for_alert(severity)
+                    logger.info(f"Investigation mode: {orchestrator_mode}")
 
                     # Run investigation with correlation context
                     try:
@@ -434,9 +542,12 @@ async def main(
             except Exception as e:
                 logger.error(f"Failed to generate consolidated report: {e}")
 
-        # Clean up MCP connection on shutdown
+        # Clean up MCP connections on shutdown
         logger.info("Cleaning up connections...")
-        await orchestrator._shutdown_mcp()
+        if single_agent_orchestrator is not None:
+            await single_agent_orchestrator._shutdown_mcp()
+        if multi_agent_orchestrator is not None:
+            await multi_agent_orchestrator._shutdown_mcp()
         logger.success("Shutdown complete")
 
 
@@ -497,15 +608,32 @@ async def investigate_alert(
     report_dir = Path(args.report_dir).resolve()
     report_dir.mkdir(parents=True, exist_ok=True)
 
-    if args.multi_agent:
-        from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
-        from ares.core.config import get_redis_url
+    # Determine Redis availability and routing mode
+    from ares.core.config import get_redis_url
 
-        blue_redis_url = args.redis_url or os.getenv("ARES_REDIS_URL", "") or get_redis_url()
+    blue_redis_url = args.redis_url or os.getenv("ARES_REDIS_URL", "") or get_redis_url()
+
+    # Extract severity for routing
+    severity = alert.get("labels", {}).get("severity", "unknown")
+    alert_name = alert.get("labels", {}).get("alertname", "unknown")
+
+    # Determine which orchestrator to use
+    use_multi = args.multi_agent or (
+        args.auto_route and should_use_multi_agent(severity) and blue_redis_url
+    )
+
+    # Create orchestrator based on routing decision
+    # Use InvestigationOrchestratorProtocol type to handle both orchestrator types
+    orchestrator: InvestigationOrchestratorProtocol
+    if use_multi:
         if not blue_redis_url:
             logger.error("Multi-agent mode requires Redis. Set --args.redis-url or ARES_REDIS_URL.")
             return
 
+        from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
+
+        orchestrator_mode = "multi-agent" if args.multi_agent else "multi-agent (auto-routed)"
+        logger.info(f"Mode: {orchestrator_mode} (severity: {severity})")
         orchestrator = BlueTeamOrchestrator(
             model=model,
             grafana_url=args.grafana_url,
@@ -518,6 +646,7 @@ async def investigate_alert(
     else:
         from ares.agents.blue import InvestigationOrchestrator
 
+        logger.info(f"Mode: single-agent (severity: {severity})")
         orchestrator = InvestigationOrchestrator(
             model=model,
             grafana_url=args.grafana_url,
@@ -528,7 +657,7 @@ async def investigate_alert(
         )
 
     # Run investigation
-    logger.info(f"Investigating alert: {alert.get('labels', {}).get('alertname', 'unknown')}")
+    logger.info(f"Investigating alert: {alert_name}")
 
     result = await orchestrator.investigate(alert)
 
@@ -892,6 +1021,9 @@ class EvalArgs:
         min_ioc_rate: Minimum IOC detection rate to pass (0.0-1.0, CI mode only).
         min_technique_rate: Minimum technique coverage to pass (0.0-1.0, CI mode only).
         parallel: Number of scenarios to run in parallel (dataset only).
+        multi_agent: Force multi-agent for ALL alerts.
+        auto_route: Enable severity-based routing (multi-agent for HIGH/CRITICAL).
+        redis_url: Redis URL for multi-agent state (required for multi_agent/auto_route).
     """
 
     output_dir: str = "./eval_results"
@@ -902,6 +1034,9 @@ class EvalArgs:
     min_ioc_rate: float = 0.5
     min_technique_rate: float = 0.5
     parallel: int = 1
+    multi_agent: bool = False
+    auto_route: bool = True
+    redis_url: str = ""
 
 
 # Cyclopts decorator typing not yet fully supported by type checkers
@@ -964,6 +1099,31 @@ async def evaluate(
         logger.error(f"Red team state file not found: {state_path}")
         return
 
+    from ares.eval import EvaluationRunner, EvaluationScenario
+
+    # Resolve redis_url for multi-agent/auto-route mode
+    eval_redis_url = eval_args.redis_url
+    if (eval_args.multi_agent or eval_args.auto_route) and not eval_redis_url:
+        from ares.core.config import get_redis_url
+
+        eval_redis_url = os.getenv("ARES_REDIS_URL", "") or get_redis_url()
+
+    # Only fail if multi_agent is explicitly set and no Redis
+    if eval_args.multi_agent and not eval_redis_url:
+        logger.error(
+            "Multi-agent mode requires Redis. "
+            "Set --eval-args.redis-url or ARES_REDIS_URL environment variable."
+        )
+        return
+
+    # Determine routing mode for logging
+    if eval_args.multi_agent:
+        mode_str = "multi-agent (forced)"
+    elif eval_args.auto_route and eval_redis_url:
+        mode_str = "auto-route (HIGH/CRITICAL -> multi-agent)"
+    else:
+        mode_str = "single-agent"
+
     # Log startup
     logger.info("=" * 60)
     logger.info("ARES BLUE TEAM EVALUATION")
@@ -973,9 +1133,8 @@ async def evaluate(
     logger.info(f"Grafana: {args.grafana_url}")
     logger.info(f"Poll Timeout: {eval_args.poll_timeout}s")
     logger.info(f"Output Dir: {eval_args.output_dir}")
+    logger.info(f"Mode: {mode_str}")
     logger.info("=" * 60)
-
-    from ares.eval import EvaluationRunner, EvaluationScenario
 
     runner = EvaluationRunner(
         model=model,
@@ -983,6 +1142,9 @@ async def evaluate(
         grafana_api_key=grafana_api_key,
         max_steps=args.max_steps,
         output_dir=eval_args.output_dir,
+        multi_agent=eval_args.multi_agent,
+        auto_route=eval_args.auto_route,
+        redis_url=eval_redis_url,
     )
 
     scenario = EvaluationScenario(
@@ -1102,6 +1264,29 @@ async def evaluate_dataset(
         logger.error("No scenarios found in dataset")
         return
 
+    # Resolve redis_url for multi-agent/auto-route mode
+    eval_redis_url = eval_args.redis_url
+    if (eval_args.multi_agent or eval_args.auto_route) and not eval_redis_url:
+        from ares.core.config import get_redis_url
+
+        eval_redis_url = os.getenv("ARES_REDIS_URL", "") or get_redis_url()
+
+    # Only fail if multi_agent is explicitly set and no Redis
+    if eval_args.multi_agent and not eval_redis_url:
+        logger.error(
+            "Multi-agent mode requires Redis. "
+            "Set --eval-args.redis-url or ARES_REDIS_URL environment variable."
+        )
+        return
+
+    # Determine routing mode for logging
+    if eval_args.multi_agent:
+        mode_str = "multi-agent (forced)"
+    elif eval_args.auto_route and eval_redis_url:
+        mode_str = "auto-route (HIGH/CRITICAL -> multi-agent)"
+    else:
+        mode_str = "single-agent"
+
     # Log startup
     logger.info("=" * 60)
     logger.info("ARES BLUE TEAM DATASET EVALUATION")
@@ -1112,6 +1297,7 @@ async def evaluate_dataset(
     logger.info(f"Grafana: {args.grafana_url}")
     logger.info(f"Poll Timeout: {eval_args.poll_timeout}s")
     logger.info(f"Output Dir: {eval_args.output_dir}")
+    logger.info(f"Mode: {mode_str}")
     logger.info("=" * 60)
 
     runner = EvaluationRunner(
@@ -1121,6 +1307,9 @@ async def evaluate_dataset(
         max_steps=args.max_steps,
         output_dir=eval_args.output_dir,
         inject_synthetic_alerts=eval_args.synthetic,
+        multi_agent=eval_args.multi_agent,
+        auto_route=eval_args.auto_route,
+        redis_url=eval_redis_url,
     )
 
     result = await runner.evaluate_dataset(

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -46,6 +46,7 @@ class Args:
         operation_id: Red team operation ID to focus investigation on.
         latest: Use the latest red team operation (prefer running).
         redis_url: Redis URL for loading red team operation state.
+        multi_agent: Use multi-agent orchestrator (requires Redis).
     """
 
     model: str = ""
@@ -58,6 +59,7 @@ class Args:
     operation_id: str = ""  # Red team operation to focus on
     latest: bool = False  # Use latest red team operation
     redis_url: str = ""  # Redis URL for red team state
+    multi_agent: bool = False  # Use multi-agent blue team orchestrator
 
 
 @dataclass
@@ -260,15 +262,39 @@ async def main(
     report_dir.mkdir(parents=True, exist_ok=True)
     logger.info(f"Reports: {report_dir}")
 
-    orchestrator = InvestigationOrchestrator(
-        model=model,
-        grafana_url=args.grafana_url,
-        grafana_api_key=grafana_api_key,
-        mitre_client=mitre_client,
-        report_dir=report_dir,
-        max_steps=args.max_steps,
-        attack_context=attack_context,
-    )
+    if args.multi_agent:
+        from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
+        from ares.core.config import get_redis_url
+
+        blue_redis_url = args.redis_url or os.getenv("ARES_REDIS_URL", "") or get_redis_url()
+        if not blue_redis_url:
+            logger.error(
+                "Multi-agent mode requires Redis. "
+                "Set --args.redis-url or ARES_REDIS_URL environment variable."
+            )
+            return
+
+        logger.info(f"Mode: MULTI-AGENT (Redis: {blue_redis_url})")
+        orchestrator = BlueTeamOrchestrator(
+            model=model,
+            grafana_url=args.grafana_url,
+            grafana_api_key=grafana_api_key,
+            mitre_client=mitre_client,
+            report_dir=report_dir,
+            max_steps=args.max_steps,
+            redis_url=blue_redis_url,
+            attack_context=attack_context,
+        )
+    else:
+        orchestrator = InvestigationOrchestrator(
+            model=model,
+            grafana_url=args.grafana_url,
+            grafana_api_key=grafana_api_key,
+            mitre_client=mitre_client,
+            report_dir=report_dir,
+            max_steps=args.max_steps,
+            attack_context=attack_context,
+        )
 
     grafana = GrafanaTools(
         base_url=args.grafana_url,
@@ -462,7 +488,6 @@ async def investigate_alert(
         console=dn_args.console,
     )
 
-    from ares.agents.blue import InvestigationOrchestrator
     from ares.integrations.mitre import MITREAttackClient
 
     logger.info("Loading MITRE ATT&CK data...")
@@ -472,14 +497,35 @@ async def investigate_alert(
     report_dir = Path(args.report_dir).resolve()
     report_dir.mkdir(parents=True, exist_ok=True)
 
-    orchestrator = InvestigationOrchestrator(
-        model=model,
-        grafana_url=args.grafana_url,
-        grafana_api_key=grafana_api_key,
-        mitre_client=mitre_client,
-        report_dir=report_dir,
-        max_steps=args.max_steps,
-    )
+    if args.multi_agent:
+        from ares.agents.blue.multi_agent_orchestrator import BlueTeamOrchestrator
+        from ares.core.config import get_redis_url
+
+        blue_redis_url = args.redis_url or os.getenv("ARES_REDIS_URL", "") or get_redis_url()
+        if not blue_redis_url:
+            logger.error("Multi-agent mode requires Redis. Set --args.redis-url or ARES_REDIS_URL.")
+            return
+
+        orchestrator = BlueTeamOrchestrator(
+            model=model,
+            grafana_url=args.grafana_url,
+            grafana_api_key=grafana_api_key,
+            mitre_client=mitre_client,
+            report_dir=report_dir,
+            max_steps=args.max_steps,
+            redis_url=blue_redis_url,
+        )
+    else:
+        from ares.agents.blue import InvestigationOrchestrator
+
+        orchestrator = InvestigationOrchestrator(
+            model=model,
+            grafana_url=args.grafana_url,
+            grafana_api_key=grafana_api_key,
+            mitre_client=mitre_client,
+            report_dir=report_dir,
+            max_steps=args.max_steps,
+        )
 
     # Run investigation
     logger.info(f"Investigating alert: {alert.get('labels', {}).get('alertname', 'unknown')}")

--- a/src/ares/templates/blueteam/agents/host_investigation_task.md.jinja
+++ b/src/ares/templates/blueteam/agents/host_investigation_task.md.jinja
@@ -1,0 +1,52 @@
+# Host Investigation Task: {{ hostname }}
+
+## Target Host
+
+- **Hostname**: {{ hostname }}
+
+## Known Activity
+
+{{ known_activity }}
+
+## Context
+
+{{ context }}
+
+## Your Task
+
+1. **Get full host activity**: Call `get_host_activity("{{ hostname }}")` to retrieve all logon events, process creation, share access, and service creation for this host
+
+2. **Identify all users**: Extract every user who authenticated to `{{ hostname }}`. For each user:
+   - What logon type was used?
+   - What was the source IP/workstation?
+   - Was this a legitimate admin logon or potential lateral movement?
+   - Call `track_user_investigation()` for each user
+
+3. **Check for compromise indicators**:
+   - Service creation (Event 7045): PsExec, remote execution frameworks
+   - Admin share access (Event 5140 for ADMIN$, C$): Remote admin activity
+   - Multiple authentication sources: Different IPs/workstations authenticating as the same user
+   - Unusual process execution (Event 4688): Suspicious binaries, PowerShell, cmd.exe chains
+   - Scheduled task creation (Event 4698): Persistence mechanisms
+
+4. **Identify inbound connections**: For every authentication TO this host:
+   - Record the source with `record_lateral_connection(source_host=<source>, destination_host="{{ hostname }}", ...)`
+   - Investigate the source host if not already investigated
+
+5. **Identify outbound connections**: For every authentication FROM this host:
+   - Record the destination with `record_lateral_connection(source_host="{{ hostname }}", destination_host=<dest>, ...)`
+   - Investigate the destination host if not already investigated
+
+6. **Record all evidence**: Every finding must be recorded with `record_evidence()`:
+   - Users seen: evidence_type="user", pyramid_level=4
+   - Source IPs: evidence_type="ip", pyramid_level=2
+   - Processes: evidence_type="process", pyramid_level=4
+   - Services created: evidence_type="artifact", pyramid_level=4
+   - Techniques observed: evidence_type="technique", pyramid_level=6
+
+7. **Report results**: Call `lateral_complete()` with:
+   - All users who accessed this host
+   - All hosts connected to/from this host
+   - Containment recommendation (isolate host, block network segment, forensic image)
+
+**Start by calling `get_host_activity("{{ hostname }}")`.**

--- a/src/ares/templates/blueteam/agents/lateral_analyst.md.jinja
+++ b/src/ares/templates/blueteam/agents/lateral_analyst.md.jinja
@@ -1,0 +1,182 @@
+# Ares Lateral Movement Analyst Worker Agent
+
+You determine the scope of a security incident by analyzing lateral movement patterns. Your role is to identify all affected hosts and users, map movement paths, and recommend containment boundaries.
+
+## Your Responsibilities
+
+1. **Analyze host activity** for signs of compromise or attacker presence
+2. **Analyze user activity** for credential abuse or unauthorized access
+3. **Map lateral movement paths** between hosts
+4. **Record lateral connections** with source, destination, and method
+5. **Track all hosts and users** in the movement chain
+6. **Recommend containment** based on scope findings
+7. **Report analysis results** to the orchestrator
+
+## Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `get_host_activity` | Retrieve all activity for a specific host |
+| `get_user_activity` | Retrieve all activity for a specific user |
+| `query_loki_logs` | Run custom LogQL queries for lateral movement evidence |
+| `record_evidence` | Record findings with type, value, source, pyramid level |
+| `record_lateral_connection` | Record a source-to-destination movement path |
+| `track_host_investigation` | Mark a host as investigated |
+| `track_user_investigation` | Mark a user as investigated |
+| `lateral_complete` | Report analysis results back to orchestrator |
+
+## Analysis Workflow
+
+### Step 1: Investigate the Focus Host
+
+Start with the host identified by triage:
+
+```
+get_host_activity(hostname="<focus_host>")
+```
+
+Extract from results:
+- Logon events (Event 4624): Who authenticated TO this host?
+- Logoff events (Event 4634): Session duration
+- Process creation (Event 4688): What ran on this host?
+- Share access (Event 5140/5145): What shares were accessed?
+- Service creation (Event 7045): Were new services installed?
+
+For EVERY host and user found in the results, call `track_host_investigation()` and `track_user_investigation()`.
+
+### Step 2: Investigate the Focus User
+
+Analyze the user identified by triage:
+
+```
+get_user_activity(username="<focus_user>")
+```
+
+Extract from results:
+- Which hosts did this user authenticate to?
+- What logon types were used? (Type 3=network, Type 10=RDP, Type 2=interactive)
+- Were there authentication failures before success?
+- Did the user access sensitive shares (ADMIN$, C$, SYSVOL)?
+
+### Step 3: Map Lateral Movement
+
+For each authentication event, determine the movement direction:
+
+| Field | Meaning |
+|-------|---------|
+| Source host (WorkstationName, IpAddress) | Where the attacker came FROM |
+| Destination host (computer) | Where the attacker went TO |
+| Username (TargetUserName) | Whose credentials were used |
+| Logon type | How the movement occurred |
+
+Record each path:
+```
+record_lateral_connection(
+    source_host="<where the attacker came from>",
+    destination_host="<where the attacker went>",
+    method="<SMB/RDP/WinRM/PsExec/etc>",
+    username="<credentials used>",
+    timestamp="<when it happened>"
+)
+```
+
+### Step 4: Expand the Scope
+
+For EACH newly discovered host or user, investigate further:
+
+```
+For each new host found:
+  -> get_host_activity(hostname=<new_host>)
+  -> Extract users and connected hosts
+  -> track_host_investigation(hostname=<new_host>)
+
+For each new user found:
+  -> get_user_activity(username=<new_user>)
+  -> Extract hosts and authentication patterns
+  -> track_user_investigation(username=<new_user>)
+```
+
+**Scope expansion limit**: Investigate up to 5 hops from the initial host. If the chain extends beyond 5 hops, note this in findings and recommend escalation.
+
+### Step 5: Custom Lateral Movement Queries
+
+When `get_host_activity` and `get_user_activity` are insufficient, use custom LogQL:
+
+```
+# Find all Type 3 (network) logons to a host
+query_loki_logs(
+    logql='{deployment="<deployment>"} |= "4624" |= "<hostname>" |= "LogonType\":\"3"',
+    ...
+)
+
+# Find all share access from a specific IP
+query_loki_logs(
+    logql='{deployment="<deployment>"} |= "5140" |= "<source_ip>"',
+    ...
+)
+
+# Find remote service creation (PsExec indicator)
+query_loki_logs(
+    logql='{deployment="<deployment>"} |= "7045" |= "<hostname>"',
+    ...
+)
+```
+
+## Lateral Movement Indicators
+
+| Indicator | Event IDs | What It Means |
+|-----------|-----------|---------------|
+| Network logon (Type 3) | 4624 | SMB, WMI, or PowerShell remoting |
+| RDP logon (Type 10) | 4624 | Interactive remote desktop session |
+| Service creation | 7045 | PsExec or similar remote execution |
+| Admin share access | 5140 (ADMIN$, C$) | Remote admin activity |
+| NTLM authentication | 4624 (NtlmSsp) | Pass-the-hash or relay attack |
+| Kerberos TGS request | 4769 | Lateral movement with Kerberos ticket |
+
+## Recording Evidence
+
+For EVERY finding, call `record_evidence()`:
+
+| Parameter | Value |
+|-----------|-------|
+| `evidence_type` | ip, hostname, user, artifact, technique |
+| `value` | The indicator |
+| `source` | Query that found this (e.g., "get_host_activity: dc01") |
+| `timestamp` | When the event occurred (ISO8601) |
+| `pyramid_level` | Typically 2 (IP), 4 (artifact/host/user), or 6 (TTP) |
+| `mitre_techniques` | Lateral movement techniques: T1021.002, T1550.002, etc. |
+
+## Completing the Analysis
+
+Call `lateral_complete()` with:
+
+```
+lateral_complete(
+    hosts_investigated=["<list of all hosts analyzed>"],
+    users_investigated=["<list of all users analyzed>"],
+    lateral_paths=[
+        {"source": "<host>", "destination": "<host>", "method": "<method>", "user": "<user>"}
+    ],
+    containment_recommendations="<which hosts to isolate, which users to disable, network segments to block>"
+)
+```
+
+### Containment Recommendations
+
+Base recommendations on scope findings:
+
+| Scope | Recommendation |
+|-------|----------------|
+| Single host, single user | Isolate host, reset user password, monitor |
+| Multiple hosts, single user | Disable user account, isolate all affected hosts |
+| Multiple hosts, multiple users | Network segment isolation, bulk password reset, incident response |
+| Domain controller compromised | Full domain compromise response: krbtgt double-reset, forest recovery |
+
+## Anti-Patterns (AVOID)
+
+- **DO NOT** run detection queries for specific techniques -- leave that to the threat hunter
+- **DO NOT** assess MITRE technique confidence -- leave that to the threat hunter
+- **DO NOT** investigate beyond 5 hops without noting the scope expansion
+- **DO NOT** skip tracking hosts and users -- every entity must be tracked
+- **DO NOT** complete without recording lateral connections for every movement path found
+- **DO NOT** investigate the same host or user twice -- check what's already been tracked

--- a/src/ares/templates/blueteam/agents/lateral_analyst.md.jinja
+++ b/src/ares/templates/blueteam/agents/lateral_analyst.md.jinja
@@ -2,15 +2,28 @@
 
 You determine the scope of a security incident by analyzing lateral movement patterns. Your role is to identify all affected hosts and users, map movement paths, and recommend containment boundaries.
 
+## CRITICAL: You MUST call lateral_complete() before finishing
+
+**You have a LIMITED number of steps. Budget your work:**
+- Steps 1-2: Analyze focus host and user activity, record evidence
+- Steps 3-4: Map lateral connections and expand scope, record evidence
+- **Step 5 (or earlier): Call `lateral_complete()` with ALL findings**
+
+**After EVERY query that returns results, IMMEDIATELY call `record_evidence()` and `add_timeline_event()` before running the next query.**
+
+If you are unsure how many steps remain, call `lateral_complete()` NOW with what you have.
+
 ## Your Responsibilities
 
 1. **Analyze host activity** for signs of compromise or attacker presence
 2. **Analyze user activity** for credential abuse or unauthorized access
 3. **Map lateral movement paths** between hosts
-4. **Record lateral connections** with source, destination, and method
-5. **Track all hosts and users** in the movement chain
-6. **Recommend containment** based on scope findings
-7. **Report analysis results** to the orchestrator
+4. **Record evidence** — call `record_evidence()` after EVERY query for each finding (hosts, users, IPs, artifacts)
+5. **Add timeline events** — call `add_timeline_event()` for every lateral movement event
+6. **Record lateral connections** with source, destination, and method
+7. **Track all hosts and users** in the movement chain
+8. **Recommend containment** based on scope findings
+9. **ALWAYS call `lateral_complete()`** — the orchestrator is waiting for your structured result
 
 ## Available Tools
 
@@ -176,7 +189,12 @@ Base recommendations on scope findings:
 
 - **DO NOT** run detection queries for specific techniques -- leave that to the threat hunter
 - **DO NOT** assess MITRE technique confidence -- leave that to the threat hunter
-- **DO NOT** investigate beyond 5 hops without noting the scope expansion
+- **DO NOT** investigate beyond 3 hops -- you have limited steps
 - **DO NOT** skip tracking hosts and users -- every entity must be tracked
 - **DO NOT** complete without recording lateral connections for every movement path found
 - **DO NOT** investigate the same host or user twice -- check what's already been tracked
+- **DO NOT** finish without calling `lateral_complete()` -- this is MANDATORY
+
+## REMINDER: Call lateral_complete() NOW if you're running low on steps
+
+The orchestrator CANNOT use your findings unless you call `lateral_complete()`. Always call it.

--- a/src/ares/templates/blueteam/agents/lateral_task.md.jinja
+++ b/src/ares/templates/blueteam/agents/lateral_task.md.jinja
@@ -36,8 +36,11 @@ No lateral connections identified yet. Start by analyzing the focus host and use
 3. **Map movement paths**: For every authentication from one host to another, record a lateral connection with `record_lateral_connection()`
 4. **Expand scope**: For each newly discovered host or user, investigate their activity
 5. **Track everything**: Call `track_host_investigation()` and `track_user_investigation()` for every entity found
-6. **Determine containment**: Based on the movement scope, recommend which hosts to isolate and which users to disable
-7. **Report results**: Call `lateral_complete()` with all investigated hosts, users, lateral paths, and containment recommendations
+6. **Record evidence**: After EVERY query, call `record_evidence()` for each finding AND `add_timeline_event()` for significant events
+7. **Determine containment**: Based on the movement scope, recommend which hosts to isolate and which users to disable
+8. **MUST call `lateral_complete()`**: You MUST call this with all investigated hosts, users, lateral paths, and containment recommendations
+
+**IMPORTANT: You have limited steps. After each query, immediately record evidence. Call `lateral_complete()` by step 5 at the latest.**
 
 {% if focus_host %}
 **Start by analyzing activity on {{ focus_host }}.**

--- a/src/ares/templates/blueteam/agents/lateral_task.md.jinja
+++ b/src/ares/templates/blueteam/agents/lateral_task.md.jinja
@@ -1,0 +1,46 @@
+# Lateral Movement Analysis Task
+
+## Focus Targets
+
+{% if focus_host %}
+- **Primary Host**: {{ focus_host }}
+{% endif %}
+{% if focus_user %}
+- **Primary User**: {{ focus_user }}
+{% endif %}
+
+## Context
+
+{{ context }}
+
+## Known Lateral Connections
+
+{% if known_lateral_connections and known_lateral_connections | length > 0 %}
+The following lateral movement paths have already been identified. Use these as starting points to expand the scope.
+
+{% for conn in known_lateral_connections %}
+- **{{ conn.get('source', '?') }}** -> **{{ conn.get('destination', '?') }}** via {{ conn.get('method', 'unknown') }} (user: {{ conn.get('user', 'unknown') }}{% if conn.get('timestamp') %}, at {{ conn['timestamp'] }}{% endif %})
+{% endfor %}
+{% else %}
+No lateral connections identified yet. Start by analyzing the focus host and user activity.
+{% endif %}
+
+## Your Task
+
+{% if focus_host %}
+1. **Analyze host activity**: Call `get_host_activity("{{ focus_host }}")` to see all logon events, process creation, and share access
+{% endif %}
+{% if focus_user %}
+2. **Analyze user activity**: Call `get_user_activity("{{ focus_user }}")` to see all authentication events across hosts
+{% endif %}
+3. **Map movement paths**: For every authentication from one host to another, record a lateral connection with `record_lateral_connection()`
+4. **Expand scope**: For each newly discovered host or user, investigate their activity
+5. **Track everything**: Call `track_host_investigation()` and `track_user_investigation()` for every entity found
+6. **Determine containment**: Based on the movement scope, recommend which hosts to isolate and which users to disable
+7. **Report results**: Call `lateral_complete()` with all investigated hosts, users, lateral paths, and containment recommendations
+
+{% if focus_host %}
+**Start by analyzing activity on {{ focus_host }}.**
+{% elif focus_user %}
+**Start by analyzing activity for {{ focus_user }}.**
+{% endif %}

--- a/src/ares/templates/blueteam/agents/orchestrator.md.jinja
+++ b/src/ares/templates/blueteam/agents/orchestrator.md.jinja
@@ -1,166 +1,118 @@
 # Ares Blue Team Investigation Orchestrator
 
-You coordinate multi-agent security alert investigations. Your role is to **dispatch tasks to specialized worker agents**, synthesize their findings, and produce a complete investigation report.
+You coordinate multi-agent security alert investigations. You **dispatch tasks to specialized workers** and synthesize their findings.
 
-**CRITICAL: You do NOT run queries directly. You dispatch tasks to workers.**
+**You do NOT query logs. You dispatch to workers who query logs.**
 
-## Your Role vs Worker Agents
+## Workers
 
-| Entity | Purpose | Has Query Tools? |
-|--------|---------|------------------|
-| **You (Orchestrator)** | Coordinate, monitor, synthesize | NO - dispatch only |
-| **TRIAGE Worker** | Initial alert assessment, severity classification | YES - Loki queries, correlation |
-| **THREAT_HUNTER Worker** | Deep technique detection, MITRE mapping | YES - detection queries, MITRE lookups |
-| **LATERAL_ANALYST Worker** | Scope determination, lateral movement analysis | YES - host/user activity queries |
+| Worker | Purpose |
+|--------|---------|
+| **TRIAGE** | Initial log queries, severity classification, evidence recording |
+| **THREAT_HUNTER** | Detection queries for specific MITRE techniques, deep analysis |
+| **LATERAL_ANALYST** | Host/user activity analysis, scope determination, lateral paths |
 
-## Investigation Workflow
+## CRITICAL: Speed Through Parallelism
 
-### Phase 1: Triage (ALWAYS runs first)
+**The #1 rule: dispatch independent workers in PARALLEL, not sequentially.**
 
-Dispatch triage FIRST and WAIT for the result before deciding next steps:
+You have `wait_for_result` parameter on every dispatch tool:
+- `wait_for_result=True` (default): Blocks until worker finishes. Use for sequential dependencies.
+- `wait_for_result=False`: Returns immediately with a task_id. Use for parallel work.
+
+After dispatching with `wait_for_result=False`, call `get_task_result(task_id)` to collect results.
+
+## Investigation Strategy by Alert Severity
+
+### Critical / High Alerts (severity=critical or severity=high, or alert has MITRE techniques in labels)
+
+These alerts already contain technique information. **Skip triage. Go directly to parallel deep investigation.**
 
 ```
-dispatch_triage(alert=<alert_dict>, correlation_context=<context>, current_time=<time>)
-  -> Wait for triage_complete result
-  -> Read severity_assessment
+Step 1: Dispatch threat_hunt AND lateral_analysis in PARALLEL (both with wait_for_result=False)
+  - dispatch_threat_hunt(technique_id=<from alert labels>, hostname=<from alert>, wait_for_result=False) → task_id_1
+  - dispatch_lateral_analysis(focus_host=<from alert>, wait_for_result=False) → task_id_2
+
+Step 2: Collect both results
+  - get_task_result(task_id_1) → threat hunt findings
+  - get_task_result(task_id_2) → lateral analysis findings
+
+Step 3: If new techniques discovered, dispatch follow-up hunt (sequential)
+  - dispatch_threat_hunt(technique_id=<new technique>, wait_for_result=True)
+
+Step 4: Synthesize and complete/escalate
 ```
 
-### Phase 2: Decision Gate
+### Medium Alerts
 
-Based on triage severity_assessment, decide the investigation depth:
-
-| Severity | Action | Rationale |
-|----------|--------|-----------|
-| `false_positive` | Complete immediately | No threat detected |
-| `low` | Complete with triage findings | Insufficient risk for deep investigation |
-| `medium` | Dispatch ONE threat hunt | Confirm or deny the technique, then complete |
-| `high` | Dispatch threat hunt + lateral analysis (parallel) | Full investigation required |
-| `critical` | Dispatch threat hunt + lateral analysis + follow-up hunts | Maximum depth, potential escalation |
-
-### Phase 3: Deep Investigation (medium/high/critical only)
-
-For `medium` severity:
 ```
-dispatch_threat_hunt(technique_id=<from triage>, hostname=<from triage>, ...)
-  -> Wait for hunt_complete result
-  -> Synthesize findings
-  -> Complete
+Step 1: dispatch_triage(wait_for_result=True)
+Step 2: Based on triage, dispatch_threat_hunt(wait_for_result=True)
+Step 3: Complete
 ```
 
-For `high` and `critical` severity, dispatch in parallel when possible:
+### Low / Unknown Severity Alerts
+
 ```
-dispatch_threat_hunt(technique_id=<from triage>, hostname=<from triage>, ...)
-dispatch_lateral_analysis(focus_host=<from triage>, focus_user=<from triage>, ...)
-  -> Wait for BOTH results
-  -> Dispatch follow-up hunts if new techniques discovered
-  -> Synthesize all findings
+Step 1: dispatch_triage(wait_for_result=True)
+Step 2: Complete with triage findings (no deep investigation)
 ```
 
-### Phase 4: Synthesis
+## Extracting Info from Alert Labels
 
-After all workers complete:
-1. Call `get_evidence_summary()` to review all collected evidence
-2. Call `get_investigation_status()` to verify all tasks finished
-3. Cross-reference findings across workers
-4. Build the complete attack narrative
+The alert JSON contains rich metadata. USE IT to skip triage:
+
+| Alert Field | Use For |
+|-------------|---------|
+| `labels.severity` | Determines investigation depth |
+| `labels.mitre_technique` | Technique ID for threat hunt (e.g., "T1003") |
+| `annotations.mitre_techniques` | Full list of techniques (e.g., "T1003, T1021, T1550") |
+| `annotations.goad_ref` | Attack type hint (e.g., "Pass-the-Hash, Lateral Movement") |
+| `annotations.description` | Attack context |
+| `labels.escalation_required` | If "true", plan to escalate |
 
 ## Dispatch Tools
 
-| Tool | Target Worker | Use Case |
-|------|---------------|----------|
-| `dispatch_triage` | TRIAGE | Initial alert assessment and severity classification |
-| `dispatch_threat_hunt` | THREAT_HUNTER | Deep technique detection for specific MITRE techniques |
-| `dispatch_lateral_analysis` | LATERAL_ANALYST | Scope analysis for hosts and users |
-| `dispatch_user_investigation` | LATERAL_ANALYST | Focused investigation on a specific user |
-| `dispatch_host_investigation` | LATERAL_ANALYST | Focused investigation on a specific host |
-
-## Monitoring Progress
-
-- `get_investigation_status()` - Check which tasks are pending, running, or complete
-- `get_evidence_summary()` - Review all evidence collected across workers
-- `get_task_result(task_id)` - Read the detailed result from a specific worker
-
-Check status periodically. Do NOT poll in a tight loop -- take action between status checks.
-
-## Parallel vs Sequential Dispatch
-
-**Dispatch in parallel when:**
-- Threat hunting and lateral analysis have no data dependency
-- Multiple independent hosts need investigation
-- Multiple independent users need investigation
-
-**Dispatch sequentially when:**
-- Threat hunt depends on triage findings (always wait for triage first)
-- Follow-up hunt depends on previous hunt discovering new techniques
-- Lateral analysis needs host/user list from threat hunt results
-
-## Synthesizing Findings
-
-When all workers have completed:
-
-1. **Collect all results**: Read each task result with `get_task_result(task_id)`
-2. **Cross-reference evidence**: Do threat hunter findings explain what lateral analyst found?
-3. **Build timeline**: Order events chronologically across all workers
-4. **Identify gaps**: Are there unexplained hosts, users, or techniques?
-5. **Assess confidence**: Confirmed by logs = high confidence; inherited from alert only = low confidence
+| Tool | When to Use |
+|------|-------------|
+| `dispatch_triage` | Unknown severity alerts only |
+| `dispatch_threat_hunt` | For each MITRE technique to investigate |
+| `dispatch_lateral_analysis` | When lateral movement suspected or host/user scope needed |
+| `get_investigation_status` | After workers complete, to review totals |
+| `get_task_result(task_id)` | To collect results from parallel dispatches |
 
 ## Completion
 
-### When to call complete_investigation():
+### complete_investigation(summary, attack_synopsis, recommendations)
+
+Call when you have enough evidence. Include:
+- **summary**: Attack type, confirmed techniques, affected hosts/users, confidence
+- **attack_synopsis**: Chronological narrative of the attack chain
+- **recommendations**: Containment (isolate hosts, disable accounts), remediation (password resets), detection improvements
+
+### escalate_investigation(reason, severity, attack_synopsis, recommendations)
+
+Call when:
+- Active ongoing attack (attacker still present)
+- Domain admin or krbtgt compromise confirmed
+- Alert labels say `escalation_required=true`
+- Scope exceeds capacity
+
+**ALWAYS include `attack_synopsis` and `recommendations`** even when escalating. Write a brief narrative of what was discovered and what actions should be taken. Example:
 
 ```
-complete_investigation(
-    summary="<attack type, key findings, affected assets, confidence>",
-    attack_synopsis="<chronological narrative with hosts, users, IPs, timestamps>",
-    recommendations="<containment and remediation actions>"
+escalate_investigation(
+    reason="Active credential theft attack chain",
+    severity="critical",
+    attack_synopsis="Credential dumping (T1003) detected on winterfell.north.sevenkingdoms.local followed by lateral movement to castelblack within 30 minutes. Attacker used pass-the-hash with compromised NTLM hashes.",
+    recommendations=["Isolate winterfell and castelblack immediately", "Reset all credentials on affected hosts", "Check for golden ticket activity"]
 )
 ```
 
-**Summary** must include:
-- Attack type and MITRE techniques (confirmed vs suspected)
-- Key findings from each worker
-- Affected assets (hosts, users, IPs)
-- Overall confidence level
-
-**Attack synopsis** must include:
-- Chronological narrative spanning ALL correlated alerts
-- Every host and user referenced in evidence
-- How the attacker progressed through stages
-- Timestamps from log evidence, not just alert timestamps
-
-**Recommendations** must include:
-- Immediate containment actions (block IPs, disable accounts, isolate hosts)
-- Remediation steps (password resets, patch vulnerabilities)
-- Detection improvements (new rules, tuning existing rules)
-
-### When to call escalate_investigation():
-
-```
-escalate_investigation(reason="<why escalation is needed>", severity="<critical/high>")
-```
-
-Escalate when:
-- Active ongoing attack detected (attacker still present)
-- Scope exceeds investigation capacity (too many hosts/users compromised)
-- Domain admin or krbtgt compromise confirmed
-- Human decision needed (legal, PR, executive notification)
-
-## Decision Criteria Checklist
-
-Before completing, verify:
-- [ ] Triage was dispatched and completed
-- [ ] Severity-appropriate depth was reached (no over/under-investigation)
-- [ ] All worker tasks are in `completed` state
-- [ ] Evidence summary has been reviewed
-- [ ] Attack synopsis covers ALL correlated alerts, not just this one
-- [ ] Every host and user in the synopsis was tracked by a worker
-- [ ] Recommendations are specific and actionable
-
 ## Anti-Patterns (AVOID)
 
-- **DO NOT** run Loki queries yourself -- dispatch to workers
-- **DO NOT** skip triage and jump to threat hunting
-- **DO NOT** dispatch threat hunt before triage completes
-- **DO NOT** complete with `false_positive` severity if triage found actual evidence
-- **DO NOT** dispatch lateral analysis for `low` severity alerts
-- **DO NOT** leave tasks in `running` state when completing -- wait for them or cancel
+- **DO NOT** dispatch triage for critical alerts that already have MITRE techniques — go straight to hunting
+- **DO NOT** dispatch workers sequentially when they can run in parallel
+- **DO NOT** wait for lateral analysis to finish before starting threat hunt (or vice versa)
+- **DO NOT** dispatch more than 3 follow-up hunts — diminishing returns
+- **DO NOT** forget to call complete_investigation or escalate_investigation when done

--- a/src/ares/templates/blueteam/agents/orchestrator.md.jinja
+++ b/src/ares/templates/blueteam/agents/orchestrator.md.jinja
@@ -1,0 +1,166 @@
+# Ares Blue Team Investigation Orchestrator
+
+You coordinate multi-agent security alert investigations. Your role is to **dispatch tasks to specialized worker agents**, synthesize their findings, and produce a complete investigation report.
+
+**CRITICAL: You do NOT run queries directly. You dispatch tasks to workers.**
+
+## Your Role vs Worker Agents
+
+| Entity | Purpose | Has Query Tools? |
+|--------|---------|------------------|
+| **You (Orchestrator)** | Coordinate, monitor, synthesize | NO - dispatch only |
+| **TRIAGE Worker** | Initial alert assessment, severity classification | YES - Loki queries, correlation |
+| **THREAT_HUNTER Worker** | Deep technique detection, MITRE mapping | YES - detection queries, MITRE lookups |
+| **LATERAL_ANALYST Worker** | Scope determination, lateral movement analysis | YES - host/user activity queries |
+
+## Investigation Workflow
+
+### Phase 1: Triage (ALWAYS runs first)
+
+Dispatch triage FIRST and WAIT for the result before deciding next steps:
+
+```
+dispatch_triage(alert=<alert_dict>, correlation_context=<context>, current_time=<time>)
+  -> Wait for triage_complete result
+  -> Read severity_assessment
+```
+
+### Phase 2: Decision Gate
+
+Based on triage severity_assessment, decide the investigation depth:
+
+| Severity | Action | Rationale |
+|----------|--------|-----------|
+| `false_positive` | Complete immediately | No threat detected |
+| `low` | Complete with triage findings | Insufficient risk for deep investigation |
+| `medium` | Dispatch ONE threat hunt | Confirm or deny the technique, then complete |
+| `high` | Dispatch threat hunt + lateral analysis (parallel) | Full investigation required |
+| `critical` | Dispatch threat hunt + lateral analysis + follow-up hunts | Maximum depth, potential escalation |
+
+### Phase 3: Deep Investigation (medium/high/critical only)
+
+For `medium` severity:
+```
+dispatch_threat_hunt(technique_id=<from triage>, hostname=<from triage>, ...)
+  -> Wait for hunt_complete result
+  -> Synthesize findings
+  -> Complete
+```
+
+For `high` and `critical` severity, dispatch in parallel when possible:
+```
+dispatch_threat_hunt(technique_id=<from triage>, hostname=<from triage>, ...)
+dispatch_lateral_analysis(focus_host=<from triage>, focus_user=<from triage>, ...)
+  -> Wait for BOTH results
+  -> Dispatch follow-up hunts if new techniques discovered
+  -> Synthesize all findings
+```
+
+### Phase 4: Synthesis
+
+After all workers complete:
+1. Call `get_evidence_summary()` to review all collected evidence
+2. Call `get_investigation_status()` to verify all tasks finished
+3. Cross-reference findings across workers
+4. Build the complete attack narrative
+
+## Dispatch Tools
+
+| Tool | Target Worker | Use Case |
+|------|---------------|----------|
+| `dispatch_triage` | TRIAGE | Initial alert assessment and severity classification |
+| `dispatch_threat_hunt` | THREAT_HUNTER | Deep technique detection for specific MITRE techniques |
+| `dispatch_lateral_analysis` | LATERAL_ANALYST | Scope analysis for hosts and users |
+| `dispatch_user_investigation` | LATERAL_ANALYST | Focused investigation on a specific user |
+| `dispatch_host_investigation` | LATERAL_ANALYST | Focused investigation on a specific host |
+
+## Monitoring Progress
+
+- `get_investigation_status()` - Check which tasks are pending, running, or complete
+- `get_evidence_summary()` - Review all evidence collected across workers
+- `get_task_result(task_id)` - Read the detailed result from a specific worker
+
+Check status periodically. Do NOT poll in a tight loop -- take action between status checks.
+
+## Parallel vs Sequential Dispatch
+
+**Dispatch in parallel when:**
+- Threat hunting and lateral analysis have no data dependency
+- Multiple independent hosts need investigation
+- Multiple independent users need investigation
+
+**Dispatch sequentially when:**
+- Threat hunt depends on triage findings (always wait for triage first)
+- Follow-up hunt depends on previous hunt discovering new techniques
+- Lateral analysis needs host/user list from threat hunt results
+
+## Synthesizing Findings
+
+When all workers have completed:
+
+1. **Collect all results**: Read each task result with `get_task_result(task_id)`
+2. **Cross-reference evidence**: Do threat hunter findings explain what lateral analyst found?
+3. **Build timeline**: Order events chronologically across all workers
+4. **Identify gaps**: Are there unexplained hosts, users, or techniques?
+5. **Assess confidence**: Confirmed by logs = high confidence; inherited from alert only = low confidence
+
+## Completion
+
+### When to call complete_investigation():
+
+```
+complete_investigation(
+    summary="<attack type, key findings, affected assets, confidence>",
+    attack_synopsis="<chronological narrative with hosts, users, IPs, timestamps>",
+    recommendations="<containment and remediation actions>"
+)
+```
+
+**Summary** must include:
+- Attack type and MITRE techniques (confirmed vs suspected)
+- Key findings from each worker
+- Affected assets (hosts, users, IPs)
+- Overall confidence level
+
+**Attack synopsis** must include:
+- Chronological narrative spanning ALL correlated alerts
+- Every host and user referenced in evidence
+- How the attacker progressed through stages
+- Timestamps from log evidence, not just alert timestamps
+
+**Recommendations** must include:
+- Immediate containment actions (block IPs, disable accounts, isolate hosts)
+- Remediation steps (password resets, patch vulnerabilities)
+- Detection improvements (new rules, tuning existing rules)
+
+### When to call escalate_investigation():
+
+```
+escalate_investigation(reason="<why escalation is needed>", severity="<critical/high>")
+```
+
+Escalate when:
+- Active ongoing attack detected (attacker still present)
+- Scope exceeds investigation capacity (too many hosts/users compromised)
+- Domain admin or krbtgt compromise confirmed
+- Human decision needed (legal, PR, executive notification)
+
+## Decision Criteria Checklist
+
+Before completing, verify:
+- [ ] Triage was dispatched and completed
+- [ ] Severity-appropriate depth was reached (no over/under-investigation)
+- [ ] All worker tasks are in `completed` state
+- [ ] Evidence summary has been reviewed
+- [ ] Attack synopsis covers ALL correlated alerts, not just this one
+- [ ] Every host and user in the synopsis was tracked by a worker
+- [ ] Recommendations are specific and actionable
+
+## Anti-Patterns (AVOID)
+
+- **DO NOT** run Loki queries yourself -- dispatch to workers
+- **DO NOT** skip triage and jump to threat hunting
+- **DO NOT** dispatch threat hunt before triage completes
+- **DO NOT** complete with `false_positive` severity if triage found actual evidence
+- **DO NOT** dispatch lateral analysis for `low` severity alerts
+- **DO NOT** leave tasks in `running` state when completing -- wait for them or cancel

--- a/src/ares/templates/blueteam/agents/threat_hunt_task.md.jinja
+++ b/src/ares/templates/blueteam/agents/threat_hunt_task.md.jinja
@@ -40,7 +40,9 @@ No prior evidence available. Start detection from scratch.
 {% if hostname %}
 5. **Follow the host**: Check what other activity occurred on `{{ hostname }}` around the same time
 {% endif %}
-6. **Record all evidence**: Every finding must be recorded with `record_evidence()` at the appropriate pyramid level
-7. **Report results**: Call `hunt_complete()` with confirmed techniques, evidence highlights, and detection gaps
+6. **Record all evidence**: After EVERY query, call `record_evidence()` for each finding AND `add_timeline_event()` for significant events
+7. **MUST call `hunt_complete()`**: You MUST call this with confirmed techniques, evidence highlights, and detection gaps
+
+**IMPORTANT: You have limited steps. After each query, immediately record evidence. Call `hunt_complete()` by step 7 at the latest.**
 
 **Start by running the detection query for {{ technique_id }}.**

--- a/src/ares/templates/blueteam/agents/threat_hunt_task.md.jinja
+++ b/src/ares/templates/blueteam/agents/threat_hunt_task.md.jinja
@@ -1,0 +1,46 @@
+# Threat Hunt Task: Investigate {{ technique_id }}
+
+## Hunt Target
+
+- **Technique**: {{ technique_id }}
+{% if detection_method %}
+- **Detection Method**: {{ detection_method }}
+{% endif %}
+{% if hostname %}
+- **Host**: {{ hostname }}
+{% endif %}
+{% if username %}
+- **User**: {{ username }}
+{% endif %}
+
+## Context
+
+{{ context }}
+
+## Existing Evidence
+
+{% if evidence_so_far and evidence_so_far | length > 0 %}
+The following evidence has already been collected by triage. Build on these findings -- do NOT re-run the same queries.
+
+{% for item in evidence_so_far %}
+- **{{ item.get('evidence_type', 'unknown') }}**: {{ item.get('value', 'N/A') }} (source: {{ item.get('source', 'unknown') }}, pyramid level: {{ item.get('pyramid_level', '?') }})
+{% endfor %}
+{% else %}
+No prior evidence available. Start detection from scratch.
+{% endif %}
+
+## Your Task
+
+1. **Validate the technique**: Run `run_detection_query()` for `{{ technique_id }}` to confirm or deny
+2. **Investigate related techniques**: Use `get_related_techniques("{{ technique_id }}")` to find what comes before and after
+3. **Hunt the attack chain**: Run detection queries for precursor and follow-on techniques
+{% if username %}
+4. **Follow the user**: Track all activity by `{{ username }}` -- what did they access, where did they authenticate?
+{% endif %}
+{% if hostname %}
+5. **Follow the host**: Check what other activity occurred on `{{ hostname }}` around the same time
+{% endif %}
+6. **Record all evidence**: Every finding must be recorded with `record_evidence()` at the appropriate pyramid level
+7. **Report results**: Call `hunt_complete()` with confirmed techniques, evidence highlights, and detection gaps
+
+**Start by running the detection query for {{ technique_id }}.**

--- a/src/ares/templates/blueteam/agents/threat_hunter.md.jinja
+++ b/src/ares/templates/blueteam/agents/threat_hunter.md.jinja
@@ -1,0 +1,182 @@
+# Ares Threat Hunter Worker Agent
+
+You perform deep technique detection and MITRE ATT&CK mapping. Your role is to confirm or deny specific attack techniques, discover additional techniques in the kill chain, and build a comprehensive evidence base.
+
+## Your Responsibilities
+
+1. **Run detection queries** for specific MITRE ATT&CK techniques
+2. **Validate alert-sourced techniques** with log evidence
+3. **Discover related techniques** in the attack chain
+4. **Record evidence** with proper Pyramid of Pain levels
+5. **Track all hosts and users** encountered during hunting
+6. **Map findings to MITRE ATT&CK** with confidence ratings
+7. **Report hunt results** to the orchestrator
+
+## Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `run_detection_query` | Run pre-built detection queries for specific techniques |
+| `query_loki_logs` | Run custom LogQL queries for manual hunting |
+| `lookup_technique` | Look up MITRE ATT&CK technique details |
+| `get_related_techniques` | Find techniques related to a known technique |
+| `record_evidence` | Record findings with type, value, source, pyramid level |
+| `track_host_investigation` | Mark a host as seen/investigated |
+| `track_user_investigation` | Mark a user as seen/investigated |
+| `hunt_complete` | Report hunt results back to orchestrator |
+
+## Hunt Workflow
+
+### Step 1: Validate the Primary Technique
+
+Start by running the detection query for the technique you were asked to hunt:
+
+```
+run_detection_query(
+    technique="<technique_id>",
+    deployment="<deployment>",
+    start_time="<query_start>",
+    end_time="<current_time>"
+)
+```
+
+If the detection query confirms activity, record the evidence immediately. If it returns empty, that is still a finding -- document the negative result.
+
+### Step 2: Investigate Related Techniques
+
+Use `get_related_techniques()` to find techniques commonly seen alongside the primary:
+
+```
+get_related_techniques(technique_id="<primary_technique>")
+```
+
+For each related technique, decide whether to hunt based on:
+- Is it a known precursor? (Hunt it -- understand how the attacker got here)
+- Is it a known follow-on? (Hunt it -- understand what the attacker did next)
+- Is it unrelated to the current context? (Skip it)
+
+### Step 3: Run Follow-On Detection Queries
+
+For `high` and `critical` investigations, hunt the full chain:
+
+| Attack Stage | Techniques to Check |
+|--------------|---------------------|
+| Initial Access | T1078 (Valid Accounts), T1110 (Brute Force) |
+| Credential Access | T1558.003 (Kerberoasting), T1558.004 (AS-REP), T1003.006 (DCSync) |
+| Privilege Escalation | T1134 (Token Manipulation), T1484 (Group Policy Modification) |
+| Lateral Movement | T1021.002 (SMB), T1550.002 (Pass-the-Hash), T1550.003 (Pass-the-Ticket) |
+| Domain Compromise | T1003.006 (DCSync), T1558.001 (Golden Ticket) |
+
+### Step 4: Custom Hunting with LogQL
+
+When pre-built detection queries are insufficient, write custom LogQL:
+
+```
+query_loki_logs(
+    datasourceUid=<datasource>,
+    logql='<custom_query>',
+    startRfc3339=<start>,
+    endRfc3339=<end>,
+    limit=100
+)
+```
+
+Custom hunting targets:
+- Unusual process execution patterns
+- Abnormal authentication sequences
+- Suspicious service creation or modification
+- Anomalous network connections from compromised hosts
+
+### Step 5: MITRE ATT&CK Enrichment
+
+For every confirmed technique:
+1. Call `lookup_technique(technique_id)` for full details
+2. Record evidence at pyramid level 6 (TTP)
+3. Note the tactic (initial access, execution, persistence, etc.)
+4. Identify detection gaps -- techniques that SHOULD have evidence but don't
+
+## Climbing the Pyramid of Pain
+
+Work UP the pyramid, not down. Start with what you find, then seek higher-value indicators:
+
+| Level | Type | Examples | Action |
+|-------|------|----------|--------|
+| 1 | Hash Values | MD5, SHA256 of malicious files | Record, but low defensive value |
+| 2 | IP Addresses | Source IPs, C2 addresses | Record, check for other connections |
+| 3 | Domain Names | FQDNs, DNS queries | Record, check resolution history |
+| 4 | Artifacts | Usernames, hostnames, processes, registry keys | Record, investigate activity |
+| 5 | Tools | mimikatz, rubeus, impacket | Record, search for tool signatures |
+| 6 | TTPs | MITRE techniques confirmed by evidence | **Goal** -- highest defensive value |
+
+**Every hunt should aim to reach level 5-6.** If you only have IPs and hashes, look for the tools and techniques that generated them.
+
+## Evidence Recording Standards
+
+For EVERY finding, call `record_evidence()`:
+
+| Parameter | Value |
+|-----------|-------|
+| `evidence_type` | technique, tool, process, user, ip, hostname, artifact |
+| `value` | The indicator (technique ID, tool name, process path, etc.) |
+| `source` | Detection query or custom query that found this |
+| `timestamp` | When the event occurred (ISO8601) |
+| `pyramid_level` | 1-6 based on the Pyramid of Pain |
+| `mitre_techniques` | List of technique IDs this evidence supports |
+
+### Confidence Levels
+
+| Confidence | Criteria |
+|------------|----------|
+| 0.9 | Technique confirmed by log evidence (event IDs, process execution, etc.) |
+| 0.7 | Technique strongly suggested by circumstantial evidence |
+| 0.5 | Technique from alert metadata only -- not confirmed by independent log evidence |
+| 0.3 | Technique theoretically possible but no supporting evidence |
+
+**NEVER record an alert-sourced technique at 0.9 unless your queries independently confirm it.**
+
+## Credential Attack Chain (MANDATORY)
+
+When credential attacks are detected, follow the FULL chain:
+
+```
+Kerberoasting detected (T1558.003)
+  -> Run detect_kerberoasting: identify affected service accounts
+  -> For EACH affected user: track_user_investigation()
+  -> Run detect_pass_the_hash: check if cracked creds were used
+  -> Run detect_lateral_movement: check for movement from compromised accounts
+  -> Run detect_dcsync: check for privilege escalation
+  -> Run detect_golden_ticket: check for domain compromise
+```
+
+Do NOT stop after confirming the initial technique. The initial credential theft is just the entry point -- the attacker's goal is domain compromise.
+
+## Completing the Hunt
+
+Call `hunt_complete()` with:
+
+```
+hunt_complete(
+    techniques_found=["<list of confirmed MITRE technique IDs>"],
+    evidence_highlights=["<key findings with sources and confidence>"],
+    detection_gaps=["<techniques that should have evidence but don't>"]
+)
+```
+
+**techniques_found**: Only include techniques confirmed by log evidence (confidence >= 0.7).
+
+**evidence_highlights**: The most important findings. Include:
+- What was found
+- Which query found it
+- Confidence level
+- Impact assessment
+
+**detection_gaps**: Techniques you looked for but could not confirm or deny. These inform the orchestrator about investigation limitations.
+
+## Anti-Patterns (AVOID)
+
+- **DO NOT** run all 39 detection queries blindly -- target queries based on context
+- **DO NOT** skip recording evidence between queries
+- **DO NOT** mark alert-sourced techniques as confirmed without log evidence
+- **DO NOT** stop at the first confirmed technique -- follow the chain
+- **DO NOT** investigate lateral movement scope -- leave that to the lateral analyst
+- **DO NOT** run more than 8-10 detection queries per hunt -- focus on the most relevant

--- a/src/ares/templates/blueteam/agents/threat_hunter.md.jinja
+++ b/src/ares/templates/blueteam/agents/threat_hunter.md.jinja
@@ -2,15 +2,27 @@
 
 You perform deep technique detection and MITRE ATT&CK mapping. Your role is to confirm or deny specific attack techniques, discover additional techniques in the kill chain, and build a comprehensive evidence base.
 
+## CRITICAL: You MUST call hunt_complete() before finishing
+
+**You have a LIMITED number of steps. Budget your work:**
+- Steps 1-3: Run detection queries and record evidence
+- Steps 4-6: Hunt related techniques and record evidence
+- **Step 7 (or earlier): Call `hunt_complete()` with ALL findings**
+
+**After EVERY query that returns results, IMMEDIATELY call `record_evidence()` and `add_timeline_event()` before running the next query.**
+
+If you are unsure how many steps remain, call `hunt_complete()` NOW with what you have. A partial report with findings is infinitely better than no report.
+
 ## Your Responsibilities
 
 1. **Run detection queries** for specific MITRE ATT&CK techniques
 2. **Validate alert-sourced techniques** with log evidence
 3. **Discover related techniques** in the attack chain
-4. **Record evidence** with proper Pyramid of Pain levels
-5. **Track all hosts and users** encountered during hunting
-6. **Map findings to MITRE ATT&CK** with confidence ratings
-7. **Report hunt results** to the orchestrator
+4. **Record evidence** with proper Pyramid of Pain levels — call `record_evidence()` after EVERY query
+5. **Add timeline events** — call `add_timeline_event()` for every significant finding
+6. **Track all hosts and users** encountered during hunting
+7. **Map findings to MITRE ATT&CK** with confidence ratings
+8. **ALWAYS call `hunt_complete()`** — the orchestrator is waiting for your structured result
 
 ## Available Tools
 
@@ -179,4 +191,9 @@ hunt_complete(
 - **DO NOT** mark alert-sourced techniques as confirmed without log evidence
 - **DO NOT** stop at the first confirmed technique -- follow the chain
 - **DO NOT** investigate lateral movement scope -- leave that to the lateral analyst
-- **DO NOT** run more than 8-10 detection queries per hunt -- focus on the most relevant
+- **DO NOT** run more than 5-6 detection queries per hunt -- focus on the most relevant
+- **DO NOT** finish without calling `hunt_complete()` -- this is MANDATORY
+
+## REMINDER: Call hunt_complete() NOW if you're running low on steps
+
+The orchestrator CANNOT use your findings unless you call `hunt_complete()`. Always call it.

--- a/src/ares/templates/blueteam/agents/triage.md.jinja
+++ b/src/ares/templates/blueteam/agents/triage.md.jinja
@@ -1,0 +1,137 @@
+# Ares Triage Worker Agent
+
+You perform initial alert assessment and severity classification. Your role is to quickly determine whether an alert is a true positive, assess its severity, and provide the orchestrator with enough context to decide investigation depth.
+
+## Your Responsibilities
+
+1. **Query Loki logs** for the alert's deployment and host
+2. **Check for correlated alerts** that share hosts, users, or IPs
+3. **Record evidence** for every finding (MANDATORY after every query)
+4. **Track all hosts and users** seen in query results
+5. **Assess severity** based on evidence
+6. **Report triage results** to the orchestrator
+
+## Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `query_loki_logs` | Query Loki for log evidence |
+| `list_loki_label_names` | Discover available Loki labels |
+| `list_loki_label_values` | List values for a specific label |
+| `get_correlated_alerts` | Find related alerts sharing hosts/users/IPs |
+| `record_evidence` | Record each finding with type, value, source, pyramid level |
+| `track_host_investigation` | Mark a host as seen/investigated |
+| `track_user_investigation` | Mark a user as seen/investigated |
+| `triage_complete` | Report triage results back to orchestrator |
+
+## Triage Workflow
+
+### Step 1: Discover Data Sources
+
+Call `list_loki_label_names()` to confirm available labels, then `list_loki_label_values()` for `deployment` or `job` to verify the alert's data source exists.
+
+### Step 2: Query Alert Logs
+
+Query Loki for the alert's specific activity:
+
+```
+query_loki_logs(
+    datasourceUid=<from list_datasources>,
+{% if labels and labels.deployment %}
+    logql='{deployment="{{ labels.deployment }}"} |= "<event_id_or_keyword>"',
+{% else %}
+    logql='{job="windows-security"} |= "<event_id_or_keyword>"',
+{% endif %}
+    startRfc3339=<query_start>,
+    endRfc3339=<current_time>,
+    limit=100
+)
+```
+
+### Step 3: Parse and Record
+
+For EVERY query result, extract and record:
+
+| Field Location | Evidence Type | Example |
+|----------------|---------------|---------|
+| `line.computer` | hostname | dc01.contoso.local |
+| `event_data.TargetUserName` | user | carol.ng |
+| `event_data.SubjectUserName` | user | SYSTEM |
+| `event_data.IpAddress` | ip | 10.0.4.186 |
+| `event_data.ProcessName` | process | C:\Windows\System32\lsass.exe |
+
+**MANDATORY**: Call `record_evidence()` after EVERY query. Call `track_host_investigation()` and `track_user_investigation()` for EVERY host and user found.
+
+### Step 4: Check Correlation
+
+Call `get_correlated_alerts()` to find related alerts:
+- If `related_alert_count > 0`: note all common hosts, users, IPs, and techniques
+- This context informs severity -- a single alert is less concerning than a cluster
+
+### Step 5: Assess Severity
+
+| Severity | Criteria |
+|----------|----------|
+| `false_positive` | No log evidence supports the alert; known benign pattern |
+| `low` | Minimal activity; isolated event; no lateral indicators |
+| `medium` | Confirmed technique but limited scope; single host/user |
+| `high` | Confirmed technique with multiple hosts/users; or credential compromise |
+| `critical` | Active attack chain; domain admin/krbtgt involvement; multiple correlated alerts |
+
+### Step 6: Complete Triage
+
+Call `triage_complete()` with:
+
+```
+triage_complete(
+    summary="<what was found, key indicators, affected assets>",
+    severity_assessment="<false_positive|low|medium|high|critical>",
+    initial_techniques=["<MITRE technique IDs confirmed or suspected>"],
+    needs_deep_investigation=<true|false>
+)
+```
+
+## LogQL Best Practices
+
+1. **Use the deployment label** when available:
+   - `{deployment="range-campfire-0"}` -- scoped to the alert's environment
+   - NEVER use `{job=~".+"}` -- this scans all streams and will timeout
+
+2. **Narrow time windows**:
+   - Start with 1-hour window around current time
+   - Expand to 2 hours only if initial query returns nothing
+   - For precursor investigation, expand up to 24 hours back
+
+3. **Use structured metadata filters**:
+   - `|= "4625"` for event ID matching (fastest)
+   - `|= "TargetUserName" |= "carol.ng"` for user filtering
+   - Prefer `|=` (contains) over `|~` (regex) -- 10x faster
+
+4. **Combine event IDs** for related activity:
+   - `|~ "4625|4624|4771"` for authentication activity
+   - `|~ "4662|4624"` for DCSync indicators
+
+5. **Most selective filter first**:
+   - `{deployment="X"} |= "4769" |= "0x17"` -- event ID then encryption type
+
+## Evidence Recording Standards
+
+For every finding, call `record_evidence()` with:
+
+| Parameter | Description |
+|-----------|-------------|
+| `evidence_type` | ip, domain, hash, process, user, file, artifact, tool, technique |
+| `value` | The actual indicator value |
+| `source` | Which query found this (e.g., "Loki: Event 4625 query") |
+| `timestamp` | When the event occurred (ISO8601) |
+| `pyramid_level` | 1=hash, 2=IP, 3=domain, 4=artifact, 5=tool, 6=TTP |
+| `mitre_techniques` | List of technique IDs if applicable |
+
+**Alert-sourced techniques** (from the alert itself, not confirmed by logs) should be noted as suspected, not confirmed. The threat hunter will validate them.
+
+## Stop Conditions
+
+- Call `triage_complete()` when you have assessed severity and recorded evidence
+- Do NOT continue investigating beyond triage scope
+- Leave deep technique analysis to the threat hunter
+- Leave lateral movement analysis to the lateral analyst

--- a/src/ares/templates/blueteam/agents/triage.md.jinja
+++ b/src/ares/templates/blueteam/agents/triage.md.jinja
@@ -1,137 +1,75 @@
 # Ares Triage Worker Agent
 
-You perform initial alert assessment and severity classification. Your role is to quickly determine whether an alert is a true positive, assess its severity, and provide the orchestrator with enough context to decide investigation depth.
+You perform rapid initial alert assessment. Your goal: **classify severity and extract key indicators in 3-5 tool calls**, then call `triage_complete()`.
 
-## Your Responsibilities
+## SPEED IS CRITICAL
 
-1. **Query Loki logs** for the alert's deployment and host
-2. **Check for correlated alerts** that share hosts, users, or IPs
-3. **Record evidence** for every finding (MANDATORY after every query)
-4. **Track all hosts and users** seen in query results
-5. **Assess severity** based on evidence
-6. **Report triage results** to the orchestrator
+You must complete triage FAST. The orchestrator is waiting. Follow this exact sequence:
 
-## Available Tools
+### Step 1: Parse Alert (NO tool calls needed)
 
-| Tool | Purpose |
-|------|---------|
-| `query_loki_logs` | Query Loki for log evidence |
-| `list_loki_label_names` | Discover available Loki labels |
-| `list_loki_label_values` | List values for a specific label |
-| `get_correlated_alerts` | Find related alerts sharing hosts/users/IPs |
-| `record_evidence` | Record each finding with type, value, source, pyramid level |
-| `track_host_investigation` | Mark a host as seen/investigated |
-| `track_user_investigation` | Mark a user as seen/investigated |
-| `triage_complete` | Report triage results back to orchestrator |
+Read the alert data passed to you. Extract:
+- `labels.severity` → base severity
+- `labels.mitre_technique` → technique ID
+- `annotations.mitre_techniques` → full technique list
+- `annotations.description` → attack description
+- `annotations.goad_ref` → attack type
 
-## Triage Workflow
+If the alert already has severity=critical/high AND MITRE techniques, you can go directly to Step 4.
 
-### Step 1: Discover Data Sources
+### Step 2: One Loki Query (1 tool call)
 
-Call `list_loki_label_names()` to confirm available labels, then `list_loki_label_values()` for `deployment` or `job` to verify the alert's data source exists.
-
-### Step 2: Query Alert Logs
-
-Query Loki for the alert's specific activity:
+Run ONE targeted query for the alert's core activity:
 
 ```
 query_loki_logs(
-    datasourceUid=<from list_datasources>,
-{% if labels and labels.deployment %}
-    logql='{deployment="{{ labels.deployment }}"} |= "<event_id_or_keyword>"',
-{% else %}
-    logql='{job="windows-security"} |= "<event_id_or_keyword>"',
-{% endif %}
-    startRfc3339=<query_start>,
-    endRfc3339=<current_time>,
-    limit=100
+    datasourceUid="loki",
+    logql='{deployment="<from_alert>"} |= "<primary_event_id>"',
+    startRfc3339=<1 hour ago>,
+    endRfc3339=<now>,
+    limit=50
 )
 ```
 
-### Step 3: Parse and Record
+Pick the most relevant event ID:
+- Credential theft: `4625` or `4624`
+- Kerberos: `4769` or `4768`
+- Lateral movement: `4624` with `|= "LogonType" |= "3"`
+- DCSync: `4662`
 
-For EVERY query result, extract and record:
+### Step 3: Record Evidence (1-2 tool calls)
 
-| Field Location | Evidence Type | Example |
-|----------------|---------------|---------|
-| `line.computer` | hostname | dc01.contoso.local |
-| `event_data.TargetUserName` | user | carol.ng |
-| `event_data.SubjectUserName` | user | SYSTEM |
-| `event_data.IpAddress` | ip | 10.0.4.186 |
-| `event_data.ProcessName` | process | C:\Windows\System32\lsass.exe |
+For findings from Step 2, call `record_evidence()` for the most important indicators (hosts, users, IPs, techniques).
 
-**MANDATORY**: Call `record_evidence()` after EVERY query. Call `track_host_investigation()` and `track_user_investigation()` for EVERY host and user found.
+Call `track_host_investigation()` and `track_user_investigation()` for every host/user found.
 
-### Step 4: Check Correlation
+### Step 4: Complete Triage (1 tool call)
 
-Call `get_correlated_alerts()` to find related alerts:
-- If `related_alert_count > 0`: note all common hosts, users, IPs, and techniques
-- This context informs severity -- a single alert is less concerning than a cluster
-
-### Step 5: Assess Severity
-
-| Severity | Criteria |
-|----------|----------|
-| `false_positive` | No log evidence supports the alert; known benign pattern |
-| `low` | Minimal activity; isolated event; no lateral indicators |
-| `medium` | Confirmed technique but limited scope; single host/user |
-| `high` | Confirmed technique with multiple hosts/users; or credential compromise |
-| `critical` | Active attack chain; domain admin/krbtgt involvement; multiple correlated alerts |
-
-### Step 6: Complete Triage
-
-Call `triage_complete()` with:
+Call `triage_complete()`:
 
 ```
 triage_complete(
-    summary="<what was found, key indicators, affected assets>",
+    summary="<what was found>",
     severity_assessment="<false_positive|low|medium|high|critical>",
-    initial_techniques=["<MITRE technique IDs confirmed or suspected>"],
-    needs_deep_investigation=<true|false>
+    initial_techniques=["<technique IDs>"],
+    needs_deep_investigation=<true for medium+, false for low/false_positive>
 )
 ```
 
-## LogQL Best Practices
+## Severity Criteria
 
-1. **Use the deployment label** when available:
-   - `{deployment="range-campfire-0"}` -- scoped to the alert's environment
-   - NEVER use `{job=~".+"}` -- this scans all streams and will timeout
+| Severity | Criteria |
+|----------|----------|
+| `false_positive` | No evidence in logs; known benign pattern |
+| `low` | Isolated event, no lateral indicators |
+| `medium` | Confirmed technique, single host/user |
+| `high` | Multiple hosts/users, credential compromise |
+| `critical` | Active attack chain, domain admin involvement, multiple correlated alerts |
 
-2. **Narrow time windows**:
-   - Start with 1-hour window around current time
-   - Expand to 2 hours only if initial query returns nothing
-   - For precursor investigation, expand up to 24 hours back
+## Rules
 
-3. **Use structured metadata filters**:
-   - `|= "4625"` for event ID matching (fastest)
-   - `|= "TargetUserName" |= "carol.ng"` for user filtering
-   - Prefer `|=` (contains) over `|~` (regex) -- 10x faster
-
-4. **Combine event IDs** for related activity:
-   - `|~ "4625|4624|4771"` for authentication activity
-   - `|~ "4662|4624"` for DCSync indicators
-
-5. **Most selective filter first**:
-   - `{deployment="X"} |= "4769" |= "0x17"` -- event ID then encryption type
-
-## Evidence Recording Standards
-
-For every finding, call `record_evidence()` with:
-
-| Parameter | Description |
-|-----------|-------------|
-| `evidence_type` | ip, domain, hash, process, user, file, artifact, tool, technique |
-| `value` | The actual indicator value |
-| `source` | Which query found this (e.g., "Loki: Event 4625 query") |
-| `timestamp` | When the event occurred (ISO8601) |
-| `pyramid_level` | 1=hash, 2=IP, 3=domain, 4=artifact, 5=tool, 6=TTP |
-| `mitre_techniques` | List of technique IDs if applicable |
-
-**Alert-sourced techniques** (from the alert itself, not confirmed by logs) should be noted as suspected, not confirmed. The threat hunter will validate them.
-
-## Stop Conditions
-
-- Call `triage_complete()` when you have assessed severity and recorded evidence
-- Do NOT continue investigating beyond triage scope
-- Leave deep technique analysis to the threat hunter
-- Leave lateral movement analysis to the lateral analyst
+- **Maximum 5-6 tool calls total** — you are triage, not deep investigation
+- **DO NOT** investigate multiple techniques — leave that for the threat hunter
+- **DO NOT** expand time windows beyond 2 hours — leave deep history to the threat hunter
+- **DO NOT** run more than 2 Loki queries — one focused query is enough for triage
+- **ALWAYS** call `triage_complete()` — the orchestrator is waiting for your result

--- a/src/ares/templates/blueteam/agents/triage_task.md.jinja
+++ b/src/ares/templates/blueteam/agents/triage_task.md.jinja
@@ -1,0 +1,68 @@
+# Triage Task: Assess Alert Severity
+
+## Alert Details
+
+- **Alert Name**: {{ alert.get('alertname', alert.get('name', 'Unknown')) }}
+{% if alert.get('labels', {}).get('rulename') and alert.get('labels', {}).get('rulename') != alert.get('alertname', '') %}
+- **Original Rule**: {{ alert['labels']['rulename'] }}
+{% endif %}
+- **Severity**: {{ alert.get('severity', alert.get('labels', {}).get('severity', 'unknown')) }}
+- **Summary**: {{ alert.get('summary', alert.get('annotations', {}).get('summary', 'N/A')) }}
+- **Description**: {{ alert.get('description', alert.get('annotations', {}).get('description', 'N/A')) }}
+- **Started At**: {{ alert.get('startsAt', 'unknown') }}
+
+### Labels
+{% for key, value in alert.get('labels', {}).items() %}
+- **{{ key }}**: {{ value }}
+{% endfor %}
+
+{% if alert.get('labels', {}).get('deployment') %}
+### Deployment Scope
+**FILTER ALL QUERIES** with: `{deployment="{{ alert['labels']['deployment'] }}"}`
+{% endif %}
+
+{% if alert.get('labels', {}).get('mitre_technique') or alert.get('annotations', {}).get('mitre_technique') %}
+### MITRE Technique (from alert -- NOT yet confirmed)
+**{{ alert.get('labels', {}).get('mitre_technique', alert.get('annotations', {}).get('mitre_technique', '')) }}**
+This technique is a hypothesis from the alert rule. You must validate it with log evidence.
+{% endif %}
+
+## Correlation Context
+
+{% if correlation_context and correlation_context.get('related_alert_count', 0) > 0 %}
+**This alert is part of a cluster of {{ correlation_context['related_alert_count'] }} related alerts.**
+
+{% if correlation_context.get('common_hosts') %}
+- **Common Hosts**: {{ correlation_context['common_hosts'] | join(', ') }}
+{% endif %}
+{% if correlation_context.get('common_users') %}
+- **Common Users**: {{ correlation_context['common_users'] | join(', ') }}
+{% endif %}
+{% if correlation_context.get('common_ips') %}
+- **Common IPs**: {{ correlation_context['common_ips'] | join(', ') }}
+{% endif %}
+{% if correlation_context.get('techniques_in_cluster') %}
+- **Techniques in Cluster**: {{ correlation_context['techniques_in_cluster'] | join(', ') }}
+{% endif %}
+
+**Investigate ALL common hosts and users** -- they link this alert to the broader attack chain.
+{% else %}
+No correlated alerts found. This appears to be an isolated event.
+{% endif %}
+
+## Time Window
+
+- **Current Time**: {{ current_time }}
+- **Query from**: 2 hours before current time to current time
+- **DO NOT** use the alert's `startsAt` as the query window -- it may be stale
+
+## Your Task
+
+1. Query Loki logs for this alert's activity within the time window
+2. Parse results and record evidence for every finding
+3. Track all hosts and users discovered
+4. Check for correlated alerts with `get_correlated_alerts()`
+5. Assess severity: `false_positive`, `low`, `medium`, `high`, or `critical`
+6. Call `triage_complete()` with your assessment
+
+**Start by querying Loki for the alert's primary event activity.**

--- a/src/ares/templates/blueteam/agents/user_investigation_task.md.jinja
+++ b/src/ares/templates/blueteam/agents/user_investigation_task.md.jinja
@@ -1,0 +1,46 @@
+# User Investigation Task: {{ username }}
+
+## Target User
+
+- **Username**: {{ username }}
+
+## Known Activity
+
+{{ known_activity }}
+
+## Context
+
+{{ context }}
+
+## Your Task
+
+1. **Get full user activity**: Call `get_user_activity("{{ username }}")` to retrieve all authentication events, share access, and process execution for this user
+
+2. **Identify all hosts**: Extract every host where `{{ username }}` authenticated. For each host:
+   - What logon type was used? (Type 3=network, Type 10=RDP, Type 2=interactive)
+   - Was the logon successful or failed?
+   - What was the source IP/workstation?
+   - Call `track_host_investigation()` for each host
+
+3. **Check for credential abuse patterns**:
+   - Multiple failed logons followed by success (brute force / password spray)
+   - Network logons from unusual source hosts (lateral movement)
+   - Access to ADMIN$, C$, or IPC$ shares (remote admin activity)
+   - Kerberos TGS requests with RC4 encryption (pass-the-hash indicator)
+
+4. **Map the user's movement**:
+   - Record each host-to-host connection with `record_lateral_connection()`
+   - Identify the first and last hosts in the movement chain
+   - Determine the direction of movement (inward toward DCs, or outward toward workstations)
+
+5. **Record all evidence**: Every finding must be recorded with `record_evidence()`:
+   - Hosts accessed: evidence_type="hostname", pyramid_level=4
+   - Source IPs: evidence_type="ip", pyramid_level=2
+   - Techniques observed: evidence_type="technique", pyramid_level=6
+
+6. **Report results**: Call `lateral_complete()` with:
+   - All hosts this user accessed
+   - All lateral paths involving this user
+   - Containment recommendation (disable account, reset password, monitor)
+
+**Start by calling `get_user_activity("{{ username }}")`.**

--- a/src/ares/tools/blue/__init__.py
+++ b/src/ares/tools/blue/__init__.py
@@ -4,6 +4,7 @@ Imports are lazy to prevent loading blue team code in red team contexts.
 """
 
 __all__ = [
+    "BlueWorkerCallbackTools",
     "CompletionTools",
     "GrafanaTools",
     "InvestigationTools",
@@ -12,10 +13,12 @@ __all__ = [
     "PrometheusTools",
     "QueryTemplateTools",
     "QuestionEngineTools",
+    "SharedInvestigationTools",
     "connect_grafana_mcp",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "BlueWorkerCallbackTools": ("ares.tools.blue.callbacks", "BlueWorkerCallbackTools"),
     "CompletionTools": ("ares.tools.blue.actions", "CompletionTools"),
     "GrafanaTools": ("ares.tools.blue.grafana", "GrafanaTools"),
     "connect_grafana_mcp": ("ares.tools.blue.grafana", "connect_grafana_mcp"),
@@ -25,6 +28,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LokiTools": ("ares.tools.blue.observability", "LokiTools"),
     "PrometheusTools": ("ares.tools.blue.observability", "PrometheusTools"),
     "QueryTemplateTools": ("ares.tools.blue.query_templates", "QueryTemplateTools"),
+    "SharedInvestigationTools": ("ares.tools.blue.shared_wrappers", "SharedInvestigationTools"),
 }
 
 

--- a/src/ares/tools/blue/callbacks.py
+++ b/src/ares/tools/blue/callbacks.py
@@ -1,0 +1,158 @@
+"""Worker completion callback tools for blue team multi-agent system.
+
+Each worker agent (triage, threat_hunter, lateral_analyst) calls its
+corresponding *_complete tool when finished. This sets an asyncio.Event
+so the worker loop knows the agent is done and can extract the result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import dreadnode as dn
+from dreadnode.agent.tools.base import Toolset
+from loguru import logger
+
+
+class BlueWorkerCallbackTools(Toolset):  # type: ignore[misc]
+    """Completion callback tools for blue team worker agents.
+
+    Each worker type calls its role-specific completion method when done.
+    The completion sets an asyncio.Event so the worker loop can extract
+    the result data and report back to the dispatcher.
+
+    Attributes:
+        _completion_event: Set when worker calls a *_complete method.
+        _result_data: Populated by the completion call.
+    """
+
+    _completion_event: asyncio.Event | None = None
+    _result_data: dict[str, Any] = {}
+
+    def set_completion_event(self, event: asyncio.Event) -> None:
+        """Set the completion event (called by worker before agent.run)."""
+        self._completion_event = event
+        self._result_data = {}
+
+    @property
+    def result_data(self) -> dict[str, Any]:
+        """Get the result data populated by the completion call."""
+        return self._result_data
+
+    def _signal_completion(self, data: dict[str, Any]) -> None:
+        """Signal completion with result data."""
+        self._result_data = data
+        if self._completion_event:
+            self._completion_event.set()
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    def triage_complete(
+        self,
+        summary: str,
+        severity_assessment: str,
+        initial_techniques: list[str] | None = None,
+        recommended_next_steps: list[str] | None = None,
+        needs_deep_investigation: bool = True,
+    ) -> str:
+        """Signal that triage analysis is complete.
+
+        Call this when you have finished the initial triage of the alert.
+        Include your assessment of severity and what the alert represents.
+
+        Args:
+            summary: Brief summary of triage findings.
+            severity_assessment: Your assessment: critical, high, medium, low, or false_positive.
+            initial_techniques: MITRE ATT&CK technique IDs identified during triage.
+            recommended_next_steps: What should be investigated next.
+            needs_deep_investigation: Whether deeper threat hunting is warranted.
+
+        Returns:
+            Confirmation message.
+        """
+        logger.info(f"Triage complete: severity={severity_assessment}, deep={needs_deep_investigation}")
+        self._signal_completion({
+            "type": "triage",
+            "summary": summary,
+            "severity_assessment": severity_assessment,
+            "initial_techniques": initial_techniques or [],
+            "recommended_next_steps": recommended_next_steps or [],
+            "needs_deep_investigation": needs_deep_investigation,
+        })
+        return f"[+] Triage complete. Severity: {severity_assessment}. Findings reported to orchestrator."
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    def hunt_complete(
+        self,
+        findings_summary: str,
+        techniques_found: list[str] | None = None,
+        evidence_highlights: list[str] | None = None,
+        detection_gaps: list[str] | None = None,
+        recommended_pivots: list[str] | None = None,
+    ) -> str:
+        """Signal that threat hunting is complete.
+
+        Call this when you have finished investigating the assigned
+        detection methods and techniques.
+
+        Args:
+            findings_summary: Summary of what was found during hunting.
+            techniques_found: MITRE technique IDs confirmed by hunting.
+            evidence_highlights: Key evidence items discovered.
+            detection_gaps: Areas where detection data was insufficient.
+            recommended_pivots: Hosts/users that warrant further investigation.
+
+        Returns:
+            Confirmation message.
+        """
+        logger.info(f"Hunt complete: techniques={len(techniques_found or [])}")
+        self._signal_completion({
+            "type": "hunt",
+            "findings_summary": findings_summary,
+            "techniques_found": techniques_found or [],
+            "evidence_highlights": evidence_highlights or [],
+            "detection_gaps": detection_gaps or [],
+            "recommended_pivots": recommended_pivots or [],
+        })
+        return f"[+] Threat hunt complete. {len(techniques_found or [])} techniques confirmed."
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    def lateral_complete(
+        self,
+        scope_summary: str,
+        hosts_investigated: list[str] | None = None,
+        users_investigated: list[str] | None = None,
+        lateral_paths: list[str] | None = None,
+        containment_recommendations: list[str] | None = None,
+    ) -> str:
+        """Signal that lateral movement analysis is complete.
+
+        Call this when you have finished analyzing the scope of
+        lateral movement and compromise.
+
+        Args:
+            scope_summary: Summary of the lateral movement scope.
+            hosts_investigated: Hosts that were analyzed.
+            users_investigated: Users that were analyzed.
+            lateral_paths: Identified lateral movement paths.
+            containment_recommendations: Recommended containment actions.
+
+        Returns:
+            Confirmation message.
+        """
+        logger.info(
+            f"Lateral analysis complete: "
+            f"hosts={len(hosts_investigated or [])}, users={len(users_investigated or [])}"
+        )
+        self._signal_completion({
+            "type": "lateral",
+            "scope_summary": scope_summary,
+            "hosts_investigated": hosts_investigated or [],
+            "users_investigated": users_investigated or [],
+            "lateral_paths": lateral_paths or [],
+            "containment_recommendations": containment_recommendations or [],
+        })
+        return (
+            f"[+] Lateral analysis complete. "
+            f"{len(hosts_investigated or [])} hosts, {len(users_investigated or [])} users analyzed."
+        )

--- a/src/ares/tools/blue/callbacks.py
+++ b/src/ares/tools/blue/callbacks.py
@@ -7,12 +7,14 @@ so the worker loop knows the agent is done and can extract the result.
 
 from __future__ import annotations
 
-import asyncio
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import dreadnode as dn
 from dreadnode.agent.tools.base import Toolset
 from loguru import logger
+
+if TYPE_CHECKING:
+    import asyncio
 
 
 class BlueWorkerCallbackTools(Toolset):  # type: ignore[misc]
@@ -28,7 +30,10 @@ class BlueWorkerCallbackTools(Toolset):  # type: ignore[misc]
     """
 
     _completion_event: asyncio.Event | None = None
-    _result_data: dict[str, Any] = {}
+    _result_data: dict[str, Any]
+
+    def __init__(self) -> None:
+        self._result_data = {}
 
     def set_completion_event(self, event: asyncio.Event) -> None:
         """Set the completion event (called by worker before agent.run)."""
@@ -70,15 +75,19 @@ class BlueWorkerCallbackTools(Toolset):  # type: ignore[misc]
         Returns:
             Confirmation message.
         """
-        logger.info(f"Triage complete: severity={severity_assessment}, deep={needs_deep_investigation}")
-        self._signal_completion({
-            "type": "triage",
-            "summary": summary,
-            "severity_assessment": severity_assessment,
-            "initial_techniques": initial_techniques or [],
-            "recommended_next_steps": recommended_next_steps or [],
-            "needs_deep_investigation": needs_deep_investigation,
-        })
+        logger.info(
+            f"Triage complete: severity={severity_assessment}, deep={needs_deep_investigation}"
+        )
+        self._signal_completion(
+            {
+                "type": "triage",
+                "summary": summary,
+                "severity_assessment": severity_assessment,
+                "initial_techniques": initial_techniques or [],
+                "recommended_next_steps": recommended_next_steps or [],
+                "needs_deep_investigation": needs_deep_investigation,
+            }
+        )
         return f"[+] Triage complete. Severity: {severity_assessment}. Findings reported to orchestrator."
 
     @dn.tool_method  # type: ignore[untyped-decorator]
@@ -106,14 +115,16 @@ class BlueWorkerCallbackTools(Toolset):  # type: ignore[misc]
             Confirmation message.
         """
         logger.info(f"Hunt complete: techniques={len(techniques_found or [])}")
-        self._signal_completion({
-            "type": "hunt",
-            "findings_summary": findings_summary,
-            "techniques_found": techniques_found or [],
-            "evidence_highlights": evidence_highlights or [],
-            "detection_gaps": detection_gaps or [],
-            "recommended_pivots": recommended_pivots or [],
-        })
+        self._signal_completion(
+            {
+                "type": "hunt",
+                "findings_summary": findings_summary,
+                "techniques_found": techniques_found or [],
+                "evidence_highlights": evidence_highlights or [],
+                "detection_gaps": detection_gaps or [],
+                "recommended_pivots": recommended_pivots or [],
+            }
+        )
         return f"[+] Threat hunt complete. {len(techniques_found or [])} techniques confirmed."
 
     @dn.tool_method  # type: ignore[untyped-decorator]
@@ -144,14 +155,16 @@ class BlueWorkerCallbackTools(Toolset):  # type: ignore[misc]
             f"Lateral analysis complete: "
             f"hosts={len(hosts_investigated or [])}, users={len(users_investigated or [])}"
         )
-        self._signal_completion({
-            "type": "lateral",
-            "scope_summary": scope_summary,
-            "hosts_investigated": hosts_investigated or [],
-            "users_investigated": users_investigated or [],
-            "lateral_paths": lateral_paths or [],
-            "containment_recommendations": containment_recommendations or [],
-        })
+        self._signal_completion(
+            {
+                "type": "lateral",
+                "scope_summary": scope_summary,
+                "hosts_investigated": hosts_investigated or [],
+                "users_investigated": users_investigated or [],
+                "lateral_paths": lateral_paths or [],
+                "containment_recommendations": containment_recommendations or [],
+            }
+        )
         return (
             f"[+] Lateral analysis complete. "
             f"{len(hosts_investigated or [])} hosts, {len(users_investigated or [])} users analyzed."

--- a/src/ares/tools/blue/shared_wrappers.py
+++ b/src/ares/tools/blue/shared_wrappers.py
@@ -1,0 +1,381 @@
+"""Shared investigation tools that publish to the blue team dispatcher.
+
+SharedInvestigationTools subclasses InvestigationTools but redirects
+state mutations to the BlueStateBackend (Redis) instead of mutating
+a local InvestigationState. This allows multiple worker agents to
+share a single investigation state via Redis.
+
+Read methods fetch from the backend snapshot so all agents see
+consistent data.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import dreadnode as dn
+from loguru import logger
+
+from ares.core.evidence_validation import (
+    adjust_confidence_for_validation,
+    validate_evidence_value,
+)
+from ares.core.models import (
+    Evidence,
+    InvestigationStage,
+    PyramidLevel,
+    TimelineEvent,
+)
+from ares.tools.blue.investigation import (
+    PYRAMID_EMOJI,
+    STATUS_INFO,
+    STATUS_SUCCESS,
+    InvestigationTools,
+)
+
+if TYPE_CHECKING:
+    from ares.core.blue_state_backend import BlueStateBackend
+    from ares.core.models import SharedBlueTeamState
+    from ares.integrations.mitre import MITREAttackClient
+
+
+class SharedInvestigationTools(InvestigationTools):
+    """Investigation tools that publish state to Redis via BlueStateBackend.
+
+    Instead of mutating a local InvestigationState, all writes go through
+    the backend so that all worker agents share consistent state.
+
+    Attributes:
+        _backend: The BlueStateBackend for Redis persistence.
+        _shared_state: Reference to the shared state object.
+        _mitre_client: MITRE client for technique lookups.
+    """
+
+    _backend: BlueStateBackend | None = None
+    _shared_state: SharedBlueTeamState | None = None
+    _mitre_client: MITREAttackClient | None = None
+    _evidence_counter: int = 0
+    _timeline_counter: int = 0
+
+    def set_backend(self, backend: BlueStateBackend) -> None:
+        """Set the Redis backend for state persistence."""
+        self._backend = backend
+
+    def set_shared_state(self, shared_state: SharedBlueTeamState) -> None:
+        """Set reference to shared state for reads."""
+        self._shared_state = shared_state
+
+    def set_mitre_client(self, client: MITREAttackClient) -> None:
+        """Set the MITRE client for technique lookups."""
+        self._mitre_client = client
+        # Also set on parent class
+        self.mitre_client = client
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def record_evidence(  # type: ignore[override]
+        self,
+        evidence_type: str,
+        value: str,
+        source: str,
+        timestamp: str | None,
+        pyramid_level: int,
+        mitre_techniques: list[str] | None = None,
+        confidence: float = 0.5,
+    ) -> str:
+        """Record evidence and publish to shared state via Redis.
+
+        CALL THIS FOR EVERY FINDING. Evidence types include:
+        - ip, domain, hash, url (IOCs)
+        - process, file, user, service (host artifacts)
+        - artifact, certificate, user_agent (network artifacts)
+        - tool, malware (tools)
+        - technique, behavior (TTPs)
+
+        Pyramid levels (higher = more valuable):
+        1. Hash Values, 2. IP Addresses, 3. Domain Names,
+        4. Network/Host Artifacts, 5. Tools, 6. TTPs (the goal!)
+
+        Args:
+            evidence_type: Type of evidence (ip, domain, hash, process, etc.).
+            value: The actual evidence value.
+            source: What query or tool found this.
+            timestamp: ISO8601 timestamp (can be None).
+            pyramid_level: Pyramid of Pain level 1-6.
+            mitre_techniques: Optional MITRE technique IDs.
+            confidence: Confidence score 0.0-1.0.
+
+        Returns:
+            Evidence ID and validation status.
+        """
+        if not self._backend:
+            return "ERROR: No backend configured"
+
+        self._evidence_counter += 1
+        evidence_id = f"ev-{self._evidence_counter:04d}"
+
+        ts = None
+        if timestamp:
+            with contextlib.suppress(ValueError):
+                ts = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+        # Validate evidence against recent query results
+        validated, source_query_id = validate_evidence_value(value)
+        adjusted_confidence = adjust_confidence_for_validation(confidence, validated)
+
+        level = PyramidLevel(min(max(pyramid_level, 1), 6))
+
+        ev = Evidence(
+            id=evidence_id,
+            type=evidence_type,
+            value=value,
+            source=source,
+            timestamp=ts,
+            pyramid_level=level,
+            mitre_techniques=mitre_techniques or [],
+            confidence=adjusted_confidence,
+            source_query_id=source_query_id,
+            validated=validated,
+        )
+
+        # Publish to Redis backend
+        added = await self._backend.add_evidence(ev.to_dict())
+
+        # Track techniques
+        if mitre_techniques:
+            for tech_id in mitre_techniques:
+                name = ""
+                if self._mitre_client:
+                    technique = self._mitre_client.get_technique(tech_id)
+                    if technique:
+                        name = technique.name
+                        if technique.tactic:
+                            await self._backend.add_tactic(technique.tactic)
+                await self._backend.add_technique(tech_id, name)
+
+        dn.log_metric("evidence_count", 1, mode="count")
+        dn.log_metric("highest_pyramid_level", pyramid_level, mode="max")
+
+        validation_status = "validated" if validated else "UNVALIDATED - confidence reduced"
+        level_emoji = PYRAMID_EMOJI.get(pyramid_level, "")
+        value_preview = value[:60] + "..." if len(value) > 60 else value
+
+        if not added:
+            return f"{STATUS_INFO} Evidence already recorded (dedup): {evidence_type}={value_preview}"
+
+        lines = [
+            f"{STATUS_SUCCESS} Recorded evidence: {evidence_id}",
+            f"  {level_emoji} Type: {evidence_type} | Level: {pyramid_level}/6",
+            f"  Value: {value_preview}",
+            f"  Status: {'v' if validated else '!'} {validation_status}",
+        ]
+        if mitre_techniques:
+            lines.append(f"  Techniques: {', '.join(mitre_techniques)}")
+
+        return "\n".join(lines)
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def add_timeline_event(  # type: ignore[override]
+        self,
+        timestamp: str,
+        description: str,
+        evidence_ids: list[str],
+        mitre_techniques: list[str] | None = None,
+        confidence: float = 0.5,
+    ) -> str:
+        """Add an event to the shared investigation timeline.
+
+        Args:
+            timestamp: ISO8601 timestamp of when this occurred.
+            description: Human-readable description of what happened.
+            evidence_ids: List of evidence IDs supporting this event.
+            mitre_techniques: MITRE technique IDs for this event.
+            confidence: Confidence score 0.0-1.0.
+
+        Returns:
+            Timeline event ID.
+        """
+        if not self._backend:
+            return "ERROR: No backend configured"
+
+        self._timeline_counter += 1
+        event_id = f"tl-{self._timeline_counter:04d}"
+
+        try:
+            ts = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            ts = datetime.now(timezone.utc)
+
+        event = TimelineEvent(
+            id=event_id,
+            timestamp=ts,
+            description=description,
+            evidence_ids=evidence_ids,
+            mitre_techniques=mitre_techniques or [],
+            confidence=confidence,
+        )
+
+        await self._backend.add_timeline_event(event.to_dict())
+        dn.log_metric("timeline_events", 1, mode="count")
+        logger.info(f"Timeline event: {description[:50]}...")
+
+        return event_id
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def track_host_investigation(self, hostname: str) -> str:  # type: ignore[override]
+        """Mark a host as investigated in shared state.
+
+        Args:
+            hostname: The hostname to track.
+
+        Returns:
+            Confirmation message.
+        """
+        if not self._backend:
+            return "ERROR: No backend configured"
+
+        hostname_lower = hostname.strip().lower()
+        await self._backend.track_host(hostname_lower)
+        logger.debug(f"Tracked host: {hostname_lower}")
+        return f"{STATUS_SUCCESS} Tracking host: {hostname}"
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def track_user_investigation(self, username: str) -> str:  # type: ignore[override]
+        """Mark a user as investigated in shared state.
+
+        Args:
+            username: The username to track.
+
+        Returns:
+            Confirmation message.
+        """
+        if not self._backend:
+            return "ERROR: No backend configured"
+
+        username_lower = username.strip().lower()
+        await self._backend.track_user(username_lower)
+        logger.debug(f"Tracked user: {username_lower}")
+        return f"{STATUS_SUCCESS} Tracking user: {username}"
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def record_lateral_connection(  # type: ignore[override]
+        self,
+        source: str,
+        destination: str,
+        connection_type: str,
+        user: str = "",
+        mitre_technique: str = "",
+    ) -> str:
+        """Record a lateral movement connection in shared state.
+
+        Args:
+            source: Source host.
+            destination: Destination host.
+            connection_type: Type of connection (rdp, smb, wmi, etc.).
+            user: User account used for the connection.
+            mitre_technique: Associated MITRE technique ID.
+
+        Returns:
+            Confirmation message.
+        """
+        if not self._backend:
+            return "ERROR: No backend configured"
+
+        connection = {
+            "source": source,
+            "destination": destination,
+            "connection_type": connection_type,
+            "user": user,
+            "mitre_technique": mitre_technique,
+        }
+        await self._backend.add_lateral_connection(connection)
+
+        # Track hosts
+        await self._backend.track_host(source.strip().lower())
+        await self._backend.track_host(destination.strip().lower())
+
+        logger.info(f"Lateral connection: {source} -> {destination} ({connection_type})")
+        return f"{STATUS_SUCCESS} Recorded lateral connection: {source} -> {destination} via {connection_type}"
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def get_investigation_summary(self) -> dict:  # type: ignore[override]
+        """Get current investigation summary from shared state.
+
+        Returns:
+            Summary dict with evidence count, techniques, etc.
+        """
+        if not self._backend:
+            return {"error": "No backend configured"}
+
+        snapshot = await self._backend.snapshot()
+        meta = snapshot.get("meta", {})
+
+        return {
+            "investigation_id": snapshot["investigation_id"],
+            "stage": meta.get("stage", "triage"),
+            "evidence_count": len(snapshot["evidence"]),
+            "timeline_events": len(snapshot["timeline"]),
+            "techniques_identified": list(snapshot["techniques"]),
+            "highest_pyramid_level": max(
+                (e.get("pyramid_level", 0) for e in snapshot["evidence"]),
+                default=0,
+            ),
+            "hosts_investigated": list(snapshot["hosts"]),
+            "users_investigated": list(snapshot["users"]),
+            "pending_tasks": len(snapshot["pending_tasks"]),
+            "completed_tasks": len(snapshot["completed_tasks"]),
+        }
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def get_queued_queries(self) -> dict:  # type: ignore[override]
+        """Get auto-queued pivot and chain queries from shared state.
+
+        Returns:
+            Dict with queued_pivot_queries and queued_chain_queries.
+        """
+        if not self._backend:
+            return {"error": "No backend configured"}
+
+        snapshot = await self._backend.snapshot()
+        return {
+            "queued_pivot_queries": snapshot["pivot_queue"],
+            "queued_chain_queries": snapshot["chain_queue"],
+            "total_queued": len(snapshot["pivot_queue"]) + len(snapshot["chain_queue"]),
+        }
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def get_correlated_alerts(self) -> dict:  # type: ignore[override]
+        """Get correlated alert context from shared state.
+
+        Returns:
+            Correlation context dict.
+        """
+        if not self._backend:
+            return {"error": "No backend configured"}
+
+        meta = await self._backend.get_meta("correlation_context")
+        if meta:
+            return meta
+        return {"related_alerts": 0, "message": "No correlation context available"}
+
+    @dn.tool_method  # type: ignore[untyped-decorator]
+    async def transition_stage(self, new_stage: str) -> str:  # type: ignore[override]
+        """Transition the investigation to a new stage.
+
+        Args:
+            new_stage: One of: triage, causation, lateral, synthesis.
+
+        Returns:
+            Confirmation message.
+        """
+        if not self._backend:
+            return "ERROR: No backend configured"
+
+        valid_stages = {s.value for s in InvestigationStage}
+        if new_stage not in valid_stages:
+            return f"ERROR: Invalid stage '{new_stage}'. Must be one of: {', '.join(valid_stages)}"
+
+        await self._backend.set_meta("stage", new_stage)
+        logger.info(f"Investigation stage transition -> {new_stage}")
+        return f"{STATUS_SUCCESS} Transitioned to stage: {new_stage}"

--- a/src/ares/tools/blue/shared_wrappers.py
+++ b/src/ares/tools/blue/shared_wrappers.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import contextlib
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import dreadnode as dn
 from loguru import logger
@@ -162,7 +162,9 @@ class SharedInvestigationTools(InvestigationTools):
         value_preview = value[:60] + "..." if len(value) > 60 else value
 
         if not added:
-            return f"{STATUS_INFO} Evidence already recorded (dedup): {evidence_type}={value_preview}"
+            return (
+                f"{STATUS_INFO} Evidence already recorded (dedup): {evidence_type}={value_preview}"
+            )
 
         lines = [
             f"{STATUS_SUCCESS} Recorded evidence: {evidence_id}",

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -7,12 +7,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ares.main import (
+    HIGH_SEVERITY_LEVELS,
     Args,
     DreadnodeArgs,
+    EvalArgs,
     _resolve_model,
     app,
     investigate_alert,
     main,
+    should_use_multi_agent,
     version,
 )
 
@@ -166,7 +169,7 @@ class TestMainFunction:
 
     @pytest.mark.asyncio
     async def test_main_processes_alerts(self, tmp_path: Path):
-        """Test main processes alerts in --once mode."""
+        """Test main processes alerts in --once mode with monolithic orchestrator."""
         with (
             patch("ares.main.dn.configure"),
             patch("ares.agents.blue.InvestigationOrchestrator") as mock_orchestrator_class,
@@ -208,10 +211,12 @@ class TestMainFunction:
             mock_correlator.get_cluster_context.return_value = {"related_alerts": 0}
             mock_correlator_class.return_value = mock_correlator
 
+            # Disable auto_route to test monolithic path
             args = Args(
                 model="test-model",
                 once=True,
                 report_dir=str(tmp_path),
+                auto_route=False,
             )
 
             await main(args=args)
@@ -343,3 +348,94 @@ class TestAppObject:
     def test_app_help_text(self):
         """Test app has help text."""
         assert "Autonomous SOC Investigation Agent" in app.help
+
+
+class TestEvalArgsDataclass:
+    """Tests for EvalArgs dataclass with multi-agent support."""
+
+    def test_default_values(self):
+        """Test EvalArgs has correct default values."""
+        eval_args = EvalArgs()
+        assert eval_args.output_dir == "./eval_results"
+        assert eval_args.poll_timeout == 60
+        assert eval_args.ci is False
+        assert eval_args.synthetic is False
+        assert eval_args.min_score == 0.5
+        assert eval_args.min_ioc_rate == 0.5
+        assert eval_args.min_technique_rate == 0.5
+        assert eval_args.parallel == 1
+        # New multi-agent fields
+        assert eval_args.multi_agent is False
+        assert eval_args.redis_url == ""
+
+    def test_multi_agent_values(self):
+        """Test EvalArgs accepts multi-agent configuration."""
+        eval_args = EvalArgs(
+            multi_agent=True,
+            redis_url="redis://localhost:6379",
+        )
+        assert eval_args.multi_agent is True
+        assert eval_args.redis_url == "redis://localhost:6379"
+
+
+class TestShouldUseMultiAgent:
+    """Tests for severity-based multi-agent routing."""
+
+    def test_critical_severity_uses_multi_agent(self):
+        """Critical severity should use multi-agent."""
+        assert should_use_multi_agent("critical") is True
+        assert should_use_multi_agent("CRITICAL") is True
+        assert should_use_multi_agent("Critical") is True
+
+    def test_high_severity_uses_multi_agent(self):
+        """High severity should use multi-agent."""
+        assert should_use_multi_agent("high") is True
+        assert should_use_multi_agent("HIGH") is True
+        assert should_use_multi_agent("High") is True
+
+    def test_medium_severity_uses_monolithic(self):
+        """Medium severity should use monolithic."""
+        assert should_use_multi_agent("medium") is False
+        assert should_use_multi_agent("MEDIUM") is False
+
+    def test_low_severity_uses_monolithic(self):
+        """Low severity should use monolithic."""
+        assert should_use_multi_agent("low") is False
+        assert should_use_multi_agent("LOW") is False
+
+    def test_unknown_severity_uses_monolithic(self):
+        """Unknown severity should use monolithic."""
+        assert should_use_multi_agent("warning") is False
+        assert should_use_multi_agent("info") is False
+        assert should_use_multi_agent("") is False
+
+    def test_force_multi_agent_overrides_severity(self):
+        """force_multi_agent=True should always use multi-agent."""
+        assert should_use_multi_agent("low", force_multi_agent=True) is True
+        assert should_use_multi_agent("medium", force_multi_agent=True) is True
+        assert should_use_multi_agent("high", force_multi_agent=True) is True
+        assert should_use_multi_agent("critical", force_multi_agent=True) is True
+
+
+class TestHighSeverityLevels:
+    """Tests for HIGH_SEVERITY_LEVELS constant."""
+
+    def test_contains_critical(self):
+        """HIGH_SEVERITY_LEVELS should contain 'critical'."""
+        assert "critical" in HIGH_SEVERITY_LEVELS
+
+    def test_contains_high(self):
+        """HIGH_SEVERITY_LEVELS should contain 'high'."""
+        assert "high" in HIGH_SEVERITY_LEVELS
+
+    def test_does_not_contain_medium(self):
+        """HIGH_SEVERITY_LEVELS should not contain 'medium'."""
+        assert "medium" not in HIGH_SEVERITY_LEVELS
+
+    def test_does_not_contain_low(self):
+        """HIGH_SEVERITY_LEVELS should not contain 'low'."""
+        assert "low" not in HIGH_SEVERITY_LEVELS
+
+    def test_is_frozenset(self):
+        """HIGH_SEVERITY_LEVELS should be a frozenset for immutability."""
+        assert isinstance(HIGH_SEVERITY_LEVELS, frozenset)

--- a/tests/eval/__init__.py
+++ b/tests/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for evaluation framework."""

--- a/tests/eval/test_workflow.py
+++ b/tests/eval/test_workflow.py
@@ -1,0 +1,156 @@
+"""Tests for evaluation workflow with multi-agent support."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ares.eval.workflow import EvaluationRunner
+
+
+class TestEvaluationRunnerInit:
+    """Tests for EvaluationRunner initialization."""
+
+    def test_default_values(self, tmp_path: Path):
+        """Test EvaluationRunner has correct default values."""
+        runner = EvaluationRunner(
+            model="test-model",
+            grafana_url="http://grafana:3000",
+            grafana_api_key="test-key",  # pragma: allowlist secret
+            output_dir=tmp_path,
+        )
+        assert runner.model == "test-model"
+        assert runner.grafana_url == "http://grafana:3000"
+        assert runner.grafana_api_key == "test-key"  # pragma: allowlist secret
+        assert runner.max_steps == 150
+        assert runner.inject_synthetic_alerts is False
+        # Multi-agent defaults
+        assert runner.multi_agent is False
+        assert runner.redis_url == ""
+
+    def test_multi_agent_configuration(self, tmp_path: Path):
+        """Test EvaluationRunner accepts multi-agent configuration."""
+        runner = EvaluationRunner(
+            model="test-model",
+            grafana_url="http://grafana:3000",
+            grafana_api_key="test-key",  # pragma: allowlist secret
+            output_dir=tmp_path,
+            multi_agent=True,
+            redis_url="redis://localhost:6379",
+        )
+        assert runner.multi_agent is True
+        assert runner.redis_url == "redis://localhost:6379"
+
+    def test_creates_output_directory(self, tmp_path: Path):
+        """Test EvaluationRunner creates output directory if needed."""
+        output_dir = tmp_path / "nested" / "output"
+        runner = EvaluationRunner(
+            model="test-model",
+            grafana_url="http://grafana:3000",
+            grafana_api_key="test-key",  # pragma: allowlist secret
+            output_dir=output_dir,
+        )
+        assert output_dir.exists()
+        assert runner.output_dir == output_dir
+
+
+class TestEvaluationRunnerMultiAgent:
+    """Tests for multi-agent investigation execution."""
+
+    @pytest.mark.asyncio
+    async def test_run_investigation_monolithic(self, tmp_path: Path):
+        """Test _run_investigation uses monolithic orchestrator by default."""
+        runner = EvaluationRunner(
+            model="test-model",
+            grafana_url="http://grafana:3000",
+            grafana_api_key="test-key",  # pragma: allowlist secret
+            output_dir=tmp_path,
+            multi_agent=False,
+        )
+
+        with (
+            patch("ares.eval.workflow.EvaluationRunner._get_mitre_client") as mock_get_mitre,
+            patch("ares.agents.blue.InvestigationOrchestrator") as mock_orch_class,
+        ):
+            mock_mitre = MagicMock()
+            mock_get_mitre.return_value = mock_mitre
+
+            mock_state = MagicMock()
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.investigate = AsyncMock(return_value={"state": mock_state})
+            mock_orch_class.return_value = mock_orchestrator
+
+            alert = {"labels": {"alertname": "TestAlert"}}
+            state, _orch = await runner._run_investigation(alert)
+
+            # Verify monolithic orchestrator was used
+            mock_orch_class.assert_called_once()
+            assert state == mock_state
+
+    @pytest.mark.asyncio
+    async def test_run_investigation_multi_agent(self, tmp_path: Path):
+        """Test _run_investigation uses multi-agent orchestrator when configured."""
+        runner = EvaluationRunner(
+            model="test-model",
+            grafana_url="http://grafana:3000",
+            grafana_api_key="test-key",  # pragma: allowlist secret
+            output_dir=tmp_path,
+            multi_agent=True,
+            redis_url="redis://localhost:6379",
+        )
+
+        with (
+            patch("ares.eval.workflow.EvaluationRunner._get_mitre_client") as mock_get_mitre,
+            patch(
+                "ares.agents.blue.multi_agent_orchestrator.BlueTeamOrchestrator"
+            ) as mock_orch_class,
+        ):
+            mock_mitre = MagicMock()
+            mock_get_mitre.return_value = mock_mitre
+
+            mock_state = MagicMock()
+            mock_orchestrator = MagicMock()
+            mock_orchestrator.investigate = AsyncMock(return_value={"state": mock_state})
+            mock_orch_class.return_value = mock_orchestrator
+
+            alert = {"labels": {"alertname": "TestAlert"}}
+            state, _orch = await runner._run_investigation(alert)
+
+            # Verify multi-agent orchestrator was used
+            mock_orch_class.assert_called_once()
+            # Verify redis_url was passed
+            call_kwargs = mock_orch_class.call_args[1]
+            assert call_kwargs["redis_url"] == "redis://localhost:6379"
+            assert state == mock_state
+
+    @pytest.mark.asyncio
+    async def test_run_investigation_multi_agent_requires_redis(self, tmp_path: Path):
+        """Test _run_investigation raises error when multi-agent lacks redis_url."""
+        runner = EvaluationRunner(
+            model="test-model",
+            grafana_url="http://grafana:3000",
+            grafana_api_key="test-key",  # pragma: allowlist secret
+            output_dir=tmp_path,
+            multi_agent=True,
+            redis_url="",  # Missing redis_url
+        )
+
+        with patch("ares.eval.workflow.EvaluationRunner._get_mitre_client") as mock_get_mitre:
+            mock_mitre = MagicMock()
+            mock_get_mitre.return_value = mock_mitre
+
+            alert = {"labels": {"alertname": "TestAlert"}}
+
+            with pytest.raises(RuntimeError, match="Multi-agent mode requires redis_url"):
+                await runner._run_investigation(alert)
+
+
+class TestEvaluationRunnerHighSeverityLevels:
+    """Tests for HIGH_SEVERITY_LEVELS constant in EvaluationRunner."""
+
+    def test_high_severity_levels_exists(self, tmp_path: Path):
+        """Test EvaluationRunner has HIGH_SEVERITY_LEVELS class attribute."""
+        assert hasattr(EvaluationRunner, "HIGH_SEVERITY_LEVELS")
+        assert "critical" in EvaluationRunner.HIGH_SEVERITY_LEVELS
+        assert "high" in EvaluationRunner.HIGH_SEVERITY_LEVELS
+        assert "medium" not in EvaluationRunner.HIGH_SEVERITY_LEVELS


### PR DESCRIPTION
**Key Changes:**

- Introduced multi-agent blue team investigation system with Redis-backed state sharing
- Implemented severity-based routing for orchestrator: HIGH/CRITICAL alerts use multi-agent mode
- Added new dispatcher, worker, and state backend for blue team multi-agent coordination
- Extended evaluation and CLI workflows to support auto-routing and forced multi-agent execution

**Added:**

- Multi-agent orchestrator (`BlueTeamOrchestrator`) that coordinates triage, threat hunter, and lateral analyst workers, using Redis for shared state and supporting both parallel and sequential dispatch strategies
- Blue team dispatcher (`BlueTeamDispatcher`) and state backend (`BlueStateBackend`) for shared investigation state, including evidence, timeline, lateral connections, and task tracking via Redis
- Worker agent (`BlueWorkerAgent`) and supporting tools/callbacks for role-specific investigation execution and completion signaling
- Rich Jinja templates for all blue team agent roles and tasks, covering orchestrator, triage, threat hunting, lateral analysis, host/user investigation, and reporting
- Shared investigation tools (`SharedInvestigationTools`) that publish all findings and state updates to the Redis-backed backend, ensuring coordination among agents
- Test coverage for routing logic, multi-agent config, and high-severity alert handling in evaluation and CLI flows

**Changed:**

- Main CLI, evaluation, and dataset evaluation workflows to support new arguments: `multi_agent`, `auto_route`, and `redis_url`
- Routing logic in CLI and evaluation flows to select orchestrator (monolithic or multi-agent) based on alert severity and configuration
- Default behavior to auto-route HIGH/CRITICAL alerts to multi-agent orchestrator when Redis is available, with fallback to single-agent otherwise
- Red team report generation to simplify user and credential deduplication (now relies on pre-deduped state) and clarify attack path summary
- Adjusted test suites to cover new multi-agent, routing, and severity logic

**Removed:**

- Threaded Redis share persistence code from dispatcher publishing (now simplified due to backend changes)
- User and credential deduplication logic from red team report generator (now handled upstream in state)
- Redundant attack path fallback in red team executive summary (now streamlined to always show timeline if path is absent)
