### PR TITLE
feat: improve red team report deduplication and share persistence logic

### DIFF
--- a/src/ares/core/dispatcher/publishing.py
+++ b/src/ares/core/dispatcher/publishing.py
@@ -406,21 +406,39 @@ class PublishingMixin:
         except Exception as e:
             logger.warning(f"Failed to dispatch immediate crack: {e}")
 
-    async def publish_share(self: RedTeamDispatcher, share: Share, source_agent: str) -> bool:
+    async def publish_share(
+        self: RedTeamDispatcher,
+        share: Share,
+        source_agent: str,
+        task_queue: Any = None,
+    ) -> bool:
         """
         Record share discovery in shared state.
 
         Args:
             share: The discovered share.
             source_agent: Agent that discovered it.
+            task_queue: Task queue for direct Redis persistence from threaded consumers.
 
         Returns:
             True if share was new and added.
         """
         added = self.shared_state.add_share(share)
         if added:
-            if threading.current_thread() is threading.main_thread():
+            is_main_thread = threading.current_thread() is threading.main_thread()
+            if is_main_thread:
                 await self._checkpoint()
+            elif task_queue is not None:
+                # Persist directly to Redis using the threaded consumer's client
+                try:
+                    from ares.core.state_backend import RedisStateBackend
+
+                    backend = RedisStateBackend(task_queue.redis, self.shared_state.operation_id)
+                    await backend.add_share(share)
+                    logger.debug(f"Share persisted directly to Redis: {share.host}/{share.name}")
+                except Exception as e:
+                    logger.warning(f"Direct Redis persist failed for share: {e}")
+                    self._checkpoint_requested.set()
             else:
                 self._checkpoint_requested.set()
             logger.info(f"Share recorded: {share.host}/{share.name}")

--- a/src/ares/core/dispatcher/result_processing.py
+++ b/src/ares/core/dispatcher/result_processing.py
@@ -765,7 +765,7 @@ class ResultProcessingMixin:
 
         # Extract shares from netexec --shares output
         for share in self._extract_shares_from_output(output):
-            await self.publish_share(share, source_agent)
+            await self.publish_share(share, source_agent, task_queue=task_queue)
 
         # Extract hashes (Kerberoast, AS-REP, NTLM) from tool output
         # Always extract as a backup - real-time hooks may fail silently or not complete

--- a/src/ares/reports/redteam.py
+++ b/src/ares/reports/redteam.py
@@ -44,10 +44,34 @@ class RedTeamReportGenerator:
         vulnerability_count = len(state.discovered_vulnerabilities)
         exploited_count = len(state.exploited_vulnerabilities)
 
+        # Deduplicate users (case-insensitive on domain+username)
+        seen_users: set[tuple[str, str]] = set()
+        unique_users = []
+        for user in state.all_users:
+            user_key = (user.domain.lower(), user.username.lower())
+            if user_key not in seen_users:
+                seen_users.add(user_key)
+                unique_users.append(user)
+
+        # Deduplicate credentials (case-insensitive on domain+username+password)
+        seen_creds: set[tuple[str, str, str]] = set()
+        unique_creds = []
+        for cred in state.all_credentials:
+            cred_key = (cred.domain.lower(), cred.username.lower(), cred.password)
+            if cred_key not in seen_creds:
+                seen_creds.add(cred_key)
+                unique_creds.append(cred)
+
         # Calculate counts from SharedRedTeamState
         host_count = len(state.all_hosts)
-        credential_count = len(state.all_credentials)
-        admin_count = sum(1 for c in state.all_credentials if c.is_admin)
+        credential_count = len(unique_creds)
+
+        # Count admins - check is_admin flag OR known admin usernames
+        admin_count = sum(
+            1
+            for c in unique_creds
+            if c.is_admin or c.username.lower() in ("administrator", "krbtgt")
+        )
 
         # Render the report using the template
         return self.loader.render(
@@ -57,20 +81,20 @@ class RedTeamReportGenerator:
             started_at=state.started_at.strftime("%Y-%m-%d %H:%M:%S UTC"),
             completed_at=completed_at.strftime("%Y-%m-%d %H:%M:%S UTC"),
             duration=duration_str,
-            stage="completed" if state.completed else "in_progress",
+            stage="completed" if (state.completed or state.completed_at) else "in_progress",
             executive_summary=executive_summary,
             has_domain_admin=state.has_domain_admin,
             has_golden_ticket=state.has_golden_ticket,
             host_count=host_count,
-            user_count=len(state.all_users),
+            user_count=len(unique_users),
             credential_count=credential_count,
             admin_count=admin_count,
             vulnerability_count=vulnerability_count,
             exploited_count=exploited_count,
             share_count=len(state.all_shares),
             hosts=state.all_hosts,
-            users=state.all_users,
-            credentials=state.all_credentials,
+            users=unique_users,
+            credentials=unique_creds,
             shares=state.all_shares,
             weaknesses=state.all_weaknesses,
             timeline=state.operation_timeline,
@@ -130,14 +154,15 @@ class RedTeamReportGenerator:
             f"- Vulnerabilities Exploited: {exploited_count}"
         )
 
-        # Attack path summary
+        # Attack path summary - use actual captured path, not generic text
         if state.has_domain_admin or state.has_golden_ticket:
-            summary_parts.append(
-                "\n\n**Attack Path:**\n"
-                "The operation successfully achieved privileged access through systematic "
-                "recon, credential harvesting, and lateral movement techniques. "
-                "Detailed attack timeline is provided below."
-            )
+            if state.domain_admin_path:
+                summary_parts.append(f"\n\n**Attack Path:**\n{state.domain_admin_path}")
+            else:
+                # Fallback only if no path was captured
+                summary_parts.append(
+                    "\n\n**Attack Path:**\nDomain admin achieved. See timeline below for details."
+                )
 
         # Security posture assessment
         if state.has_domain_admin or state.has_golden_ticket:

--- a/src/ares/templates/redteam/reports/comprehensive_report.md.jinja
+++ b/src/ares/templates/redteam/reports/comprehensive_report.md.jinja
@@ -115,10 +115,10 @@ No NTLM hashes captured.
 ### Key Events
 
 {% if timeline %}
+| Time (UTC) | Event | MITRE |
+|------------|-------|-------|
 {% for event in timeline %}
-**{{ event.timestamp }}** - {{ event.description }}
-{% if event.mitre_techniques %}- MITRE ATT&CK: {{ event.mitre_techniques|join(', ') }}{% endif %}
-
+| {{ event.timestamp }} | {{ event.description }} | {{ event.mitre_techniques|join(', ') if event.mitre_techniques else '-' }} |
 {% endfor %}
 {% else %}
 No timeline events recorded.

--- a/src/ares/templates/redteam/reports/operation_summary.md.jinja
+++ b/src/ares/templates/redteam/reports/operation_summary.md.jinja
@@ -62,9 +62,11 @@
 ## Attack Path
 
 ### Timeline of Key Events
+
+| Time (UTC) | Event | MITRE |
+|------------|-------|-------|
 {% for event in timeline %}
-**{{ event.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}** - {{ event.description }}
-{% if event.mitre_techniques %}  - MITRE ATT&CK: {{ event.mitre_techniques|join(', ') }}{% endif %}
+| {{ event.timestamp.strftime('%Y-%m-%d %H:%M:%S') }} | {{ event.description }} | {{ event.mitre_techniques|join(', ') if event.mitre_techniques else '-' }} |
 {% endfor %}
 
 ---

--- a/tests/core/dispatcher/test_publishing.py
+++ b/tests/core/dispatcher/test_publishing.py
@@ -48,6 +48,14 @@ class MockRedisClient:
         self.calls.append(("expire", key, seconds))
         return True
 
+    async def rpush(self, key: str, value: str) -> int:
+        """Append value to a list."""
+        self.calls.append(("rpush", key, value))
+        if key not in self.data:
+            self.data[key] = []
+        self.data[key].append(value)
+        return len(self.data[key])
+
 
 class MockTaskQueue:
     """Mock task queue with Redis client for threaded consumer tests."""
@@ -220,3 +228,154 @@ class TestPublishHashDAPersistence:
         # Main thread should use checkpoint
         assert checkpoint_called, "Main thread should call _checkpoint()"
         assert dispatcher.shared_state.has_domain_admin is True
+
+
+class TestPublishSharePersistence:
+    """Tests for Share persistence to Redis from threaded consumers.
+
+    When the threaded result consumer discovers shares, it must
+    persist them directly to Redis using task_queue.redis.
+    """
+
+    @pytest.fixture
+    def dispatcher(self):
+        """Create a dispatcher with mocked internals."""
+        d = RedTeamDispatcher()
+        d._shared_state = SharedRedTeamState(operation_id="test-op-share")
+        d._checkpoint_requested = MagicMock()
+        return d
+
+    @pytest.mark.asyncio
+    async def test_share_persists_to_redis_from_threaded_consumer(self, dispatcher, monkeypatch):
+        """Test that share discovery triggers direct Redis persistence from threaded consumer."""
+        from ares.core.models import Share
+
+        task_queue = MockTaskQueue()
+
+        share = Share(
+            host="dc01.contoso.local",
+            name="SYSVOL",
+            permissions="READ",
+        )
+
+        # Mock threading to simulate threaded consumer context
+        monkeypatch.setattr(
+            "ares.core.dispatcher.publishing.threading.current_thread",
+            lambda: MagicMock(name="ResultConsumer"),
+        )
+        monkeypatch.setattr(
+            "ares.core.dispatcher.publishing.threading.main_thread",
+            lambda: MagicMock(name="MainThread"),
+        )
+
+        result = await dispatcher.publish_share(share, "ares-recon", task_queue=task_queue)
+
+        assert result is True
+        assert share in dispatcher.shared_state.all_shares
+
+        # Verify Redis calls include share persistence (shares use rpush to LIST)
+        redis_calls = task_queue.redis.calls
+        rpush_calls = [c for c in redis_calls if c[0] == "rpush" and "share" in c[1].lower()]
+        assert len(rpush_calls) >= 1, (
+            f"Should persist share to Redis via rpush, got calls: {redis_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_share_without_task_queue_sets_checkpoint_requested(
+        self, dispatcher, monkeypatch
+    ):
+        """Test that share discovery without task_queue sets checkpoint_requested flag."""
+        from ares.core.models import Share
+
+        share = Share(
+            host="dc01.contoso.local",
+            name="C$",
+            permissions="READ,WRITE",
+        )
+
+        # Mock threading to simulate threaded consumer context (no main thread)
+        monkeypatch.setattr(
+            "ares.core.dispatcher.publishing.threading.current_thread",
+            lambda: MagicMock(name="ResultConsumer"),
+        )
+        monkeypatch.setattr(
+            "ares.core.dispatcher.publishing.threading.main_thread",
+            lambda: MagicMock(name="MainThread"),
+        )
+
+        result = await dispatcher.publish_share(share, "ares-recon", task_queue=None)
+
+        assert result is True
+        assert share in dispatcher.shared_state.all_shares
+        # Should request checkpoint since no task_queue for direct persist
+        dispatcher._checkpoint_requested.set.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_main_thread_uses_checkpoint_for_share(self, dispatcher, monkeypatch):
+        """Test that main thread uses checkpoint (not direct Redis) for share persistence."""
+        from ares.core.models import Share
+
+        checkpoint_called = False
+
+        async def mock_checkpoint():
+            nonlocal checkpoint_called
+            checkpoint_called = True
+
+        dispatcher._checkpoint = mock_checkpoint
+
+        share = Share(
+            host="sql01.contoso.local",
+            name="SQLData",
+            permissions="READ",
+        )
+
+        # Simulate main thread context
+        main_thread = MagicMock(name="MainThread")
+        monkeypatch.setattr(
+            "ares.core.dispatcher.publishing.threading.current_thread",
+            lambda: main_thread,
+        )
+        monkeypatch.setattr(
+            "ares.core.dispatcher.publishing.threading.main_thread",
+            lambda: main_thread,
+        )
+
+        result = await dispatcher.publish_share(share, "ares-recon", task_queue=None)
+
+        assert result is True
+        assert checkpoint_called, "Main thread should call _checkpoint()"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_share_not_added(self, dispatcher, monkeypatch):
+        """Test that duplicate shares are not re-added."""
+        from ares.core.models import Share
+
+        share = Share(
+            host="dc01.contoso.local",
+            name="NETLOGON",
+            permissions="READ",
+        )
+
+        # Simulate main thread
+        main_thread = MagicMock(name="MainThread")
+        monkeypatch.setattr(
+            "ares.core.dispatcher.publishing.threading.current_thread",
+            lambda: main_thread,
+        )
+        monkeypatch.setattr(
+            "ares.core.dispatcher.publishing.threading.main_thread",
+            lambda: main_thread,
+        )
+
+        async def mock_checkpoint():
+            pass
+
+        dispatcher._checkpoint = mock_checkpoint
+
+        # Add share first time
+        result1 = await dispatcher.publish_share(share, "ares-recon")
+        assert result1 is True
+
+        # Add same share again
+        result2 = await dispatcher.publish_share(share, "ares-recon")
+        assert result2 is False  # Duplicate should return False

--- a/tests/reports/test_redteam.py
+++ b/tests/reports/test_redteam.py
@@ -401,3 +401,227 @@ class TestGenerateComprehensiveReport:
         assert "T1552" in report  # From timeline
         assert "T1078" in report  # From identified_techniques
         assert "T1003" in report  # From identified_techniques
+
+
+class TestDeduplication:
+    """Tests for user and credential deduplication in reports."""
+
+    @pytest.fixture
+    def generator(self) -> RedTeamReportGenerator:
+        return RedTeamReportGenerator()
+
+    def test_user_deduplication_case_insensitive(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that duplicate users are deduplicated case-insensitively."""
+        # Add duplicate users with different cases
+        red_team_state.all_users = [
+            User(username="Administrator", domain="CONTOSO.LOCAL"),
+            User(username="administrator", domain="contoso.local"),  # Duplicate
+            User(username="ADMINISTRATOR", domain="Contoso.Local"),  # Duplicate
+            User(username="testuser", domain="contoso.local"),
+        ]
+
+        report = generator.generate(red_team_state)
+
+        # Report should show 2 unique users, not 4
+        assert "User" in report
+        # The report includes user_count in the template
+        assert "2" in report or "two" in report.lower()
+
+    def test_credential_deduplication_case_insensitive(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that duplicate credentials are deduplicated case-insensitively."""
+        # Add duplicate credentials with different cases
+        red_team_state.all_credentials = [
+            Credential(
+                username="Admin",
+                password="P@ssw0rd!",  # pragma: allowlist secret
+                domain="CONTOSO.LOCAL",
+            ),
+            Credential(
+                username="admin",
+                password="P@ssw0rd!",  # pragma: allowlist secret
+                domain="contoso.local",
+            ),  # Duplicate
+            Credential(
+                username="svc_backup",
+                password="backup123",  # pragma: allowlist secret
+                domain="contoso.local",
+            ),
+        ]
+
+        report = generator.generate(red_team_state)
+
+        # Should have 2 unique credentials
+        assert isinstance(report, str)
+        assert len(report) > 0
+
+    def test_credentials_with_different_passwords_not_deduplicated(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that same user with different passwords are NOT deduplicated."""
+        red_team_state.all_credentials = [
+            Credential(
+                username="admin",
+                password="OldP@ss",  # pragma: allowlist secret
+                domain="contoso.local",
+            ),
+            Credential(
+                username="admin",
+                password="NewP@ss",  # pragma: allowlist secret
+                domain="contoso.local",
+            ),  # Different password = different cred
+        ]
+
+        report = generator.generate(red_team_state)
+        assert isinstance(report, str)
+
+
+class TestAdminCount:
+    """Tests for admin count logic including known admin usernames.
+
+    The new admin count logic (checking for administrator/krbtgt usernames)
+    is applied in generate() when calculating admin_count for the template.
+    """
+
+    @pytest.fixture
+    def generator(self) -> RedTeamReportGenerator:
+        return RedTeamReportGenerator()
+
+    def test_administrator_username_counted_as_admin(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that 'administrator' username is counted as admin even without is_admin flag."""
+        red_team_state.all_credentials = [
+            Credential(
+                username="Administrator",
+                password="AdminP@ss",  # pragma: allowlist secret
+                domain="contoso.local",
+                is_admin=False,  # No flag but should still count
+            ),
+        ]
+
+        report = generator.generate(red_team_state)
+
+        # Report should show admin count of 1 (administrator username counts)
+        # The template shows "Administrator Accounts: X"
+        assert "Administrator Accounts**: 1" in report
+
+    def test_krbtgt_username_counted_as_admin(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that 'krbtgt' username is counted as admin."""
+        red_team_state.all_credentials = [
+            Credential(
+                username="krbtgt",
+                password="",
+                domain="contoso.local",
+                is_admin=False,  # No flag but krbtgt is always admin-level
+            ),
+        ]
+
+        report = generator.generate(red_team_state)
+
+        # Report should show admin count of 1 (krbtgt username counts)
+        assert "Administrator Accounts**: 1" in report
+
+    def test_is_admin_flag_still_works(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that is_admin=True still counts as admin."""
+        red_team_state.all_credentials = [
+            Credential(
+                username="svc_backup",
+                password="backup123",  # pragma: allowlist secret
+                domain="contoso.local",
+                is_admin=True,
+            ),
+        ]
+
+        report = generator.generate(red_team_state)
+        # Report should show admin count of 1
+        assert "Administrator Accounts**: 1" in report
+
+
+class TestCompletionStatus:
+    """Tests for operation completion status detection."""
+
+    @pytest.fixture
+    def generator(self) -> RedTeamReportGenerator:
+        return RedTeamReportGenerator()
+
+    def test_completed_at_marks_operation_completed(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that completed_at alone marks operation as completed."""
+        # Set completed_at but not completed flag
+        red_team_state.completed = False
+        red_team_state.completed_at = datetime.now(timezone.utc)
+
+        report = generator.generate(red_team_state)
+
+        # Stage field should show "completed", not "in_progress"
+        assert "**Stage**: completed" in report
+
+    def test_neither_completed_shows_in_progress(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that without completed or completed_at, stage is in_progress."""
+        red_team_state.completed = False
+        red_team_state.completed_at = None
+
+        report = generator.generate(red_team_state)
+
+        assert "**Stage**: in_progress" in report
+
+
+class TestAttackPathDisplay:
+    """Tests for attack path display in executive summary."""
+
+    @pytest.fixture
+    def generator(self) -> RedTeamReportGenerator:
+        return RedTeamReportGenerator()
+
+    def test_actual_attack_path_shown_when_available(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that actual domain_admin_path is shown instead of generic text."""
+        red_team_state.has_domain_admin = True
+        red_team_state.domain_admin_path = (
+            "LLMNR Poisoning → svc_backup creds → Constrained Delegation → DC01 → krbtgt hash"
+        )
+
+        summary = generator._generate_executive_summary(red_team_state)
+
+        # Should contain the actual path
+        assert "LLMNR Poisoning" in summary
+        assert "svc_backup" in summary
+        assert "Constrained Delegation" in summary
+
+    def test_fallback_when_no_path_captured(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test fallback message when domain_admin_path is not set."""
+        red_team_state.has_domain_admin = True
+        red_team_state.domain_admin_path = None
+
+        summary = generator._generate_executive_summary(red_team_state)
+
+        # Should contain fallback text
+        assert "Attack Path" in summary
+        assert "timeline" in summary.lower() or "details" in summary.lower()
+
+    def test_no_attack_path_without_da(
+        self, generator: RedTeamReportGenerator, red_team_state: SharedRedTeamState
+    ):
+        """Test that attack path section is not shown without DA."""
+        red_team_state.has_domain_admin = False
+        red_team_state.has_golden_ticket = False
+        red_team_state.domain_admin_path = "Some path"  # Should be ignored
+
+        summary = generator._generate_executive_summary(red_team_state)
+
+        # Should NOT contain attack path section
+        assert "Attack Path" not in summary


### PR DESCRIPTION

**Key Changes:**

- Implement deduplication for users and credentials in red team reports
- Enhance share persistence to Redis when discovered by threaded consumers
- Update timeline event rendering in report templates to use markdown tables
- Add comprehensive tests for deduplication, admin counting, and share persistence

**Added:**

- User and credential deduplication logic to the report generator to ensure counts
  and lists reflect unique entries (case-insensitive, credentials unique on
  domain/username/password)
- New tests covering:
  - Deduplication of users and credentials in reports
  - Admin account counting logic (including known admin usernames like
    "administrator" and "krbtgt")
  - Operation completion status detection and reporting
  - Attack path display logic in executive summary
  - Share persistence from threaded consumers and duplicate share handling
- Support for `rpush` in the mock Redis client to simulate share persistence

**Changed:**

- `publish_share` method now supports direct persistence to Redis from threaded
  consumers using a provided task queue; falls back to checkpoint request if
  unavailable
- Updated result processing to pass the task queue to `publish_share` for
  threaded persistence
- Report generator now deduplicates users and credentials before counting and
  rendering, improving accuracy in report statistics and listings
- Admin count logic in reports now checks both `is_admin` flag and known admin
  usernames
- Timeline event sections in markdown templates (`comprehensive_report.md.jinja`
  and `operation_summary.md.jinja`) now render as markdown tables for improved
  readability

**Removed:**

- Redundant or duplicate user and credential entries from report statistics and
  listings by applying deduplication logic before rendering