### PR TITLE
feat: improve hostname/FQDN normalization, fix dict iteration safety, and add Redis circuit breaker

### DIFF
--- a/.taskfiles/blue/Taskfile.yaml
+++ b/.taskfiles/blue/Taskfile.yaml
@@ -7,15 +7,15 @@ vars:
   PROFILE: '{{.PROFILE | default "infrastructure"}}'
   REGION: '{{.REGION | default "us-west-2"}}'
 
-  # 1Password API keys (shared across tasks)
+  # 1Password API keys (shared across tasks) - read from .env if exists, otherwise 1Password
   ANTHROPIC_API_KEY:
-    sh: op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
+    sh: grep -E '^ANTHROPIC_API_KEY=' .env 2>/dev/null | cut -d= -f2- | tr -d '"' || op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
   DREADNODE_API_KEY:
-    sh: op item get "Dreadnode Dev Platform" --fields api-key --reveal 2>/dev/null || echo ""
+    sh: grep -E '^DREADNODE_API_KEY=' .env 2>/dev/null | cut -d= -f2- | tr -d '"' || op item get "Dreadnode Dev Platform" --fields api-key --reveal 2>/dev/null || echo ""
   GRAFANA_SERVICE_ACCOUNT_TOKEN:
-    sh: op item get "Ares Grafana MCP" --fields api-token --reveal 2>/dev/null || echo ""
+    sh: grep -E '^GRAFANA_SERVICE_ACCOUNT_TOKEN=' .env 2>/dev/null | cut -d= -f2- | tr -d '"' || op item get "Ares Grafana MCP" --fields api-token --reveal 2>/dev/null || echo ""
   OPENAI_API_KEY:
-    sh: op item get "Dreadnode Openai" --fields dreadnode-ares-api-key --reveal 2>/dev/null || echo ""
+    sh: grep -E '^OPENAI_API_KEY=' .env 2>/dev/null | cut -d= -f2- | tr -d '"' || op item get "Dreadnode Openai" --fields dreadnode-ares-api-key --reveal 2>/dev/null || echo ""
 
   # Model selection (MODEL_ALL takes precedence over MODEL)
   MODEL_ARG:

--- a/.taskfiles/red/Taskfile.yaml
+++ b/.taskfiles/red/Taskfile.yaml
@@ -23,15 +23,15 @@ tasks:
       OPERATION_ID: '{{.OPERATION_ID | default ""}}'
       RESUME: '{{.RESUME | default "false"}}'
       TARGET_ENV: '{{.TARGET_ENV | default "staging"}}'
-      # Computed vars
+      # Computed vars (skip 1Password if .env exists - use multi:local instead)
       ANTHROPIC_API_KEY:
-        sh: op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
+        sh: test -f .env && echo "" || op item get "Dreadnode Claude" --fields api-key --reveal 2>/dev/null || echo ""
       DREADNODE_API_KEY:
-        sh: op item get "Dreadnode Dev Platform" --fields api-key --reveal 2>/dev/null || echo ""
+        sh: test -f .env && echo "" || op item get "Dreadnode Dev Platform" --fields api-key --reveal 2>/dev/null || echo ""
       GRAFANA_SERVICE_ACCOUNT_TOKEN:
-        sh: op item get "Ares Grafana MCP" --fields grafana-token --reveal 2>/dev/null || echo ""
+        sh: test -f .env && echo "" || op item get "Ares Grafana MCP" --fields grafana-token --reveal 2>/dev/null || echo ""
       OPENAI_API_KEY:
-        sh: op item get "Dreadnode Openai" --fields dreadnode-ares-api-key --reveal 2>/dev/null || echo ""
+        sh: test -f .env && echo "" || op item get "Dreadnode Openai" --fields dreadnode-ares-api-key --reveal 2>/dev/null || echo ""
       ARES_MODEL:
         sh: |
           if [ -n "{{.MODEL_ALL}}" ]; then

--- a/config/multi-agent-production.yaml
+++ b/config/multi-agent-production.yaml
@@ -9,9 +9,10 @@ operation:
   # redis_url is derived from namespace (redis://redis.{namespace}.svc.cluster.local:6379)
   checkpoint_interval: 60  # seconds
   # Rate limiting - balance concurrency with 500k TPM budget
-  # 3 concurrent tasks allows recon + cred access + exploit in parallel
-  max_concurrent_tasks: 3
-  task_dispatch_delay: 2.0
+  # 8 concurrent tasks matches worker pod count while staying under TPM limit
+  # At ~35k tokens/task, 8 concurrent = 280k TPM (safe margin under 500k)
+  max_concurrent_tasks: 8
+  task_dispatch_delay: 1.0
   rate_limit_backoff: 15.0
   rate_limit_threshold: 2
   # Stop operation immediately when domain admin is achieved (default: false)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "kubernetes>=29.0.0",
     "tenacity>=8.2.0",
     "sentence-transformers>=2.2.0",
+    "aiobreaker>=1.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ares/cli_blue_ops.py
+++ b/src/ares/cli_blue_ops.py
@@ -1090,14 +1090,28 @@ async def from_operation(
 
         # Add operation_context to all alerts BEFORE correlation
         # This allows the correlator to group by operation_id
+        #
+        # CRITICAL: Include target deployment for Loki query scoping.
+        # Without this, blue team queries {job="windows-security"} which returns
+        # logs from ALL environments, causing noise and missed detections.
+        target_deployment = ""
+        if state.target and state.target.environment:
+            target_deployment = state.target.environment
+            logger.info(f"Target deployment for Loki scoping: {target_deployment}")
+
         operation_context = {
             "operation_id": operation_id,
             "attack_window_start": window_start.isoformat(),
             "attack_window_end": window_end.isoformat(),
             "techniques_used": list(playbook.techniques_used)[:20],
+            "deployment": target_deployment,  # For Loki query scoping
         }
         for alert in alerts:
             alert["operation_context"] = operation_context
+            # Inject deployment into alert labels if not already present
+            # This ensures blue team agents filter Loki queries correctly
+            if target_deployment and "deployment" not in alert.get("labels", {}):
+                alert.setdefault("labels", {})["deployment"] = target_deployment
 
         # Batch alerts using AlertCorrelator if enabled
         if batch and len(alerts) > 1:

--- a/src/ares/core/circuit_breaker.py
+++ b/src/ares/core/circuit_breaker.py
@@ -1,0 +1,546 @@
+"""Circuit breaker and error debouncing for Redis resilience.
+
+This module provides:
+- A shared circuit breaker for Redis operations that prevents thundering herd
+- Debounced error logging to reduce log spam during outages
+- Coordinated health monitoring across multiple background tasks
+
+Circuit Breaker States:
+- CLOSED: Normal operation, calls pass through
+- OPEN: Fast-fail mode after threshold breaches (no Redis calls)
+- HALF-OPEN: Testing recovery with single probe
+
+Configuration (environment variables):
+- REDIS_CIRCUIT_FAIL_MAX: Failures before opening (default: 5)
+- REDIS_CIRCUIT_RESET_TIMEOUT: Seconds before half-open (default: 30)
+- REDIS_ERROR_DEBOUNCE_WINDOW: Seconds to group similar errors (default: 10)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+# Configuration
+_CIRCUIT_FAIL_MAX = int(os.getenv("REDIS_CIRCUIT_FAIL_MAX", "5"))
+_CIRCUIT_RESET_TIMEOUT = float(os.getenv("REDIS_CIRCUIT_RESET_TIMEOUT", "30"))
+_ERROR_DEBOUNCE_WINDOW = float(os.getenv("REDIS_ERROR_DEBOUNCE_WINDOW", "10"))
+
+
+class CircuitState(Enum):
+    """Circuit breaker states."""
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitBreakerError(Exception):
+    """Raised when circuit is open and calls are rejected."""
+
+    def __init__(self, circuit_name: str, remaining_time: float):
+        self.circuit_name = circuit_name
+        self.remaining_time = remaining_time
+        super().__init__(
+            f"Circuit breaker '{circuit_name}' is OPEN. Retry after {remaining_time:.1f}s"
+        )
+
+
+class RedisCircuitBreaker:
+    """Circuit breaker for Redis operations.
+
+    Shared across all background tasks (heartbeat monitor, result consumer,
+    deferred queue processor) to coordinate recovery. When one task detects
+    Redis is down, all tasks fail-fast instead of hammering Redis.
+
+    Thread-safe: Uses threading.Lock for state transitions so it works
+    across the main thread and the threaded result consumer.
+
+    Usage:
+        circuit = RedisCircuitBreaker("redis")
+
+        async with circuit.protect():
+            await redis.ping()
+
+        # Or manually:
+        circuit.record_failure(exception)
+        circuit.record_success()
+    """
+
+    def __init__(
+        self,
+        name: str = "redis",
+        fail_max: int | None = None,
+        reset_timeout: float | None = None,
+    ):
+        self.name = name
+        self.fail_max = fail_max or _CIRCUIT_FAIL_MAX
+        self.reset_timeout = reset_timeout or _CIRCUIT_RESET_TIMEOUT
+
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._last_failure_time: float = 0
+        self._opened_at: float = 0
+        # Use threading.Lock instead of asyncio.Lock for cross-thread safety
+        # The threaded result consumer runs on a different event loop
+        self._lock = threading.Lock()
+
+        # Event listeners for monitoring
+        self._listeners: list[CircuitBreakerListener] = []
+
+    @property
+    def state(self) -> CircuitState:
+        """Current circuit state."""
+        return self._state
+
+    @property
+    def failure_count(self) -> int:
+        """Current consecutive failure count."""
+        return self._failure_count
+
+    @property
+    def is_closed(self) -> bool:
+        """True if circuit is closed (normal operation)."""
+        return self._state == CircuitState.CLOSED
+
+    @property
+    def is_open(self) -> bool:
+        """True if circuit is open (fast-fail mode)."""
+        return self._state == CircuitState.OPEN
+
+    def add_listener(self, listener: CircuitBreakerListener) -> None:
+        """Add a listener for state change events."""
+        self._listeners.append(listener)
+
+    def remove_listener(self, listener: CircuitBreakerListener) -> None:
+        """Remove a listener."""
+        if listener in self._listeners:
+            self._listeners.remove(listener)
+
+    def _notify_state_change_sync(self, old_state: CircuitState, new_state: CircuitState) -> None:
+        """Notify listeners of state change (sync version for use within lock)."""
+        for listener in self._listeners:
+            try:
+                # Listeners are notified synchronously since we hold a threading.Lock
+                # Async listeners should handle this internally
+                listener.on_state_change_sync(self.name, old_state, new_state)
+            except Exception as e:
+                logger.warning(f"Circuit breaker listener error: {e}")
+
+    def _check_state_locked(self) -> None:
+        """Check if circuit should transition from OPEN to HALF_OPEN.
+
+        Must be called while holding self._lock.
+        """
+        if self._state == CircuitState.OPEN:
+            elapsed = time.monotonic() - self._opened_at
+            if elapsed >= self.reset_timeout:
+                old_state = self._state
+                self._state = CircuitState.HALF_OPEN
+                logger.info(
+                    f"Circuit breaker '{self.name}' -> HALF_OPEN "
+                    f"(testing recovery after {elapsed:.1f}s)"
+                )
+                self._notify_state_change_sync(old_state, self._state)
+
+    def _get_remaining_open_time(self) -> float:
+        """Get remaining time before circuit transitions to half-open."""
+        if self._state != CircuitState.OPEN:
+            return 0
+        elapsed = time.monotonic() - self._opened_at
+        return max(0, self.reset_timeout - elapsed)
+
+    def record_failure_sync(self, exception: Exception | None = None) -> None:
+        """Record a failure (sync version). May trigger circuit open."""
+        with self._lock:
+            self._failure_count += 1
+            self._last_failure_time = time.monotonic()
+            old_state: CircuitState | None = None
+
+            if self._state == CircuitState.HALF_OPEN:
+                # Failure during probe - reopen circuit
+                old_state = self._state
+                self._state = CircuitState.OPEN
+                self._opened_at = time.monotonic()
+                logger.warning(f"Circuit breaker '{self.name}' -> OPEN (probe failed: {exception})")
+
+            elif self._state == CircuitState.CLOSED:
+                if self._failure_count >= self.fail_max:
+                    old_state = self._state
+                    self._state = CircuitState.OPEN
+                    self._opened_at = time.monotonic()
+                    logger.warning(
+                        f"Circuit breaker '{self.name}' -> OPEN "
+                        f"(failures: {self._failure_count}/{self.fail_max}, "
+                        f"reset in {self.reset_timeout}s)"
+                    )
+
+            if old_state is not None:
+                self._notify_state_change_sync(old_state, self._state)
+
+    async def record_failure(self, exception: Exception | None = None) -> None:
+        """Record a failure. May trigger circuit open."""
+        # Use sync version since we use threading.Lock
+        self.record_failure_sync(exception)
+
+    def record_success_sync(self) -> None:
+        """Record a success (sync version). May close circuit.
+
+        Optimized: Only acquires lock if circuit is not CLOSED, since
+        resetting failure_count when CLOSED is not critical.
+        """
+        # Fast path: if circuit is CLOSED, just reset failure count without lock
+        # This is safe because:
+        # 1. Reading _state is atomic in Python (GIL)
+        # 2. Worst case: we miss a state change and reset count unnecessarily
+        if self._state == CircuitState.CLOSED:
+            self._failure_count = 0
+            return
+
+        # Slow path: circuit is OPEN or HALF_OPEN, need lock for state transition
+        with self._lock:
+            if self._state == CircuitState.HALF_OPEN:
+                # Successful probe - close circuit
+                old_state: CircuitState = self._state
+                self._state = CircuitState.CLOSED
+                self._failure_count = 0
+                logger.info(f"Circuit breaker '{self.name}' -> CLOSED (recovered successfully)")
+                self._notify_state_change_sync(old_state, self._state)
+            # Note: CLOSED handled by fast path above; OPEN requires no action on success
+
+    async def record_success(self) -> None:
+        """Record a success. May close circuit."""
+        # Use sync version since we use threading.Lock
+        self.record_success_sync()
+
+    def allow_request_sync(self) -> bool:
+        """Check if a request should be allowed through (sync version).
+
+        Returns:
+            True if request can proceed, False if circuit is open
+        """
+        with self._lock:
+            self._check_state_locked()
+            # Allow requests when CLOSED or HALF_OPEN (probe)
+            # Reject when OPEN
+            return self._state in (CircuitState.CLOSED, CircuitState.HALF_OPEN)
+
+    async def allow_request(self) -> bool:
+        """Check if a request should be allowed through.
+
+        Returns:
+            True if request can proceed, False if circuit is open
+        """
+        # Use sync version since we use threading.Lock
+        return self.allow_request_sync()
+
+    @asynccontextmanager
+    async def protect(self) -> AsyncGenerator[None, None]:
+        """Context manager that protects a Redis operation.
+
+        Raises:
+            CircuitBreakerError: If circuit is open
+
+        Example:
+            async with circuit.protect():
+                await redis.ping()
+        """
+        if not await self.allow_request():
+            remaining = self._get_remaining_open_time()
+            raise CircuitBreakerError(self.name, remaining)
+
+        try:
+            yield
+            await self.record_success()
+        except Exception as e:
+            await self.record_failure(e)
+            raise
+
+    def get_status(self) -> dict[str, Any]:
+        """Get current circuit breaker status for monitoring."""
+        return {
+            "name": self.name,
+            "state": self._state.value,
+            "failure_count": self._failure_count,
+            "fail_max": self.fail_max,
+            "reset_timeout": self.reset_timeout,
+            "remaining_open_time": self._get_remaining_open_time(),
+        }
+
+
+class CircuitBreakerListener:
+    """Base class for circuit breaker event listeners."""
+
+    def on_state_change_sync(
+        self,
+        circuit_name: str,
+        old_state: CircuitState,
+        new_state: CircuitState,
+    ) -> None:
+        """Called when circuit state changes (sync version)."""
+
+
+class LoggingCircuitListener(CircuitBreakerListener):
+    """Listener that logs state changes with appropriate severity."""
+
+    def on_state_change_sync(
+        self,
+        circuit_name: str,
+        old_state: CircuitState,
+        new_state: CircuitState,
+    ) -> None:
+        if new_state == CircuitState.OPEN:
+            logger.error(
+                f"Redis circuit breaker OPENED - all Redis operations will "
+                f"fail-fast for {_CIRCUIT_RESET_TIMEOUT}s"
+            )
+        elif new_state == CircuitState.CLOSED:
+            logger.info("Redis circuit breaker CLOSED - normal operation resumed")
+        elif new_state == CircuitState.HALF_OPEN:
+            logger.info("Redis circuit breaker testing recovery...")
+
+
+class DebouncedErrorLogger:
+    """Debounces similar error messages to reduce log spam.
+
+    When Redis becomes unavailable, multiple background tasks may all
+    fail simultaneously, creating a flood of similar error messages.
+    This class groups similar errors within a time window.
+
+    Thread-safe: Uses threading.Lock for cross-thread safety.
+
+    Usage:
+        debouncer = DebouncedErrorLogger(window_sec=10)
+
+        # Instead of: logger.error(f"Redis error: {e}")
+        debouncer.log_error("redis_timeout", f"Redis error: {e}")
+
+        # On cleanup:
+        debouncer.flush()  # Log any suppressed counts
+    """
+
+    def __init__(self, window_sec: float | None = None):
+        self.window_sec = window_sec or _ERROR_DEBOUNCE_WINDOW
+        self._last_logged: dict[str, float] = defaultdict(float)
+        self._suppressed_counts: dict[str, int] = defaultdict(int)
+        # Use threading.Lock for cross-thread safety
+        self._lock = threading.Lock()
+
+    def log_error_sync(
+        self,
+        error_key: str,
+        message: str,
+        *,
+        level: str = "warning",
+    ) -> bool:
+        """Log an error, potentially debouncing it (sync version).
+
+        Args:
+            error_key: Key to group similar errors (e.g., "redis_timeout")
+            message: Full error message to log
+            level: Log level ("warning", "error", "info")
+
+        Returns:
+            True if message was logged, False if suppressed
+        """
+        with self._lock:
+            now = time.monotonic()
+            last_time = self._last_logged[error_key]
+
+            if now - last_time < self.window_sec:
+                # Within debounce window - suppress
+                self._suppressed_counts[error_key] += 1
+                return False
+
+            # Outside window - log with suppression count
+            suppressed = self._suppressed_counts[error_key]
+            self._suppressed_counts[error_key] = 0
+            self._last_logged[error_key] = now
+
+            if suppressed > 0:
+                message = f"{message} (suppressed {suppressed} similar in last {self.window_sec}s)"
+
+            log_func = getattr(logger, level, logger.warning)
+            log_func(message)
+            return True
+
+    async def log_error(
+        self,
+        error_key: str,
+        message: str,
+        *,
+        level: str = "warning",
+    ) -> bool:
+        """Log an error, potentially debouncing it.
+
+        Args:
+            error_key: Key to group similar errors (e.g., "redis_timeout")
+            message: Full error message to log
+            level: Log level ("warning", "error", "info")
+
+        Returns:
+            True if message was logged, False if suppressed
+        """
+        return self.log_error_sync(error_key, message, level=level)
+
+    def flush_sync(self) -> None:
+        """Flush any pending suppressed error counts (sync version)."""
+        with self._lock:
+            for error_key, count in self._suppressed_counts.items():
+                if count > 0:
+                    logger.info(f"Suppressed {count} '{error_key}' errors in final window")
+            self._suppressed_counts.clear()
+
+    async def flush(self) -> None:
+        """Flush any pending suppressed error counts."""
+        self.flush_sync()
+
+    def get_stats(self) -> dict[str, int]:
+        """Get current suppression stats."""
+        with self._lock:
+            return dict(self._suppressed_counts)
+
+
+class RedisHealthMonitor:
+    """Coordinates Redis health checks across multiple background tasks.
+
+    Instead of each task independently discovering Redis is down (thundering
+    herd), this monitor provides a shared health status. Tasks check
+    `is_healthy` before attempting Redis operations.
+
+    Usage:
+        monitor = RedisHealthMonitor(circuit_breaker)
+
+        # Background tasks check before Redis ops:
+        if not monitor.is_healthy:
+            await monitor.wait_for_healthy(timeout=30)
+
+        # Single health check loop updates status:
+        async def health_loop():
+            while running:
+                try:
+                    await redis.ping()
+                    monitor.mark_healthy()
+                except Exception:
+                    monitor.mark_unhealthy()
+                await asyncio.sleep(5)
+    """
+
+    def __init__(self, circuit_breaker: RedisCircuitBreaker | None = None):
+        self._circuit = circuit_breaker
+        self._healthy = asyncio.Event()
+        self._healthy.set()  # Start healthy
+        self._last_check_time: float = 0
+        self._consecutive_failures: int = 0
+
+    @property
+    def is_healthy(self) -> bool:
+        """True if Redis is believed to be healthy."""
+        # If circuit is open, we know Redis is unhealthy
+        if self._circuit and self._circuit.is_open:
+            return False
+        return self._healthy.is_set()
+
+    def mark_healthy(self) -> None:
+        """Mark Redis as healthy (call after successful ping)."""
+        self._consecutive_failures = 0
+        self._last_check_time = time.monotonic()
+        if not self._healthy.is_set():
+            logger.info("Redis health restored")
+            self._healthy.set()
+
+    def mark_unhealthy(self) -> None:
+        """Mark Redis as unhealthy (call after failed ping)."""
+        self._consecutive_failures += 1
+        self._last_check_time = time.monotonic()
+        if self._healthy.is_set():
+            logger.warning(f"Redis health check failed ({self._consecutive_failures} consecutive)")
+            self._healthy.clear()
+
+    async def wait_for_healthy(self, timeout: float = 30) -> bool:
+        """Wait for Redis to become healthy.
+
+        Args:
+            timeout: Max seconds to wait
+
+        Returns:
+            True if Redis is healthy, False if timeout
+        """
+        try:
+            await asyncio.wait_for(self._healthy.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    def get_status(self) -> dict[str, Any]:
+        """Get current health status for monitoring."""
+        return {
+            "is_healthy": self.is_healthy,
+            "consecutive_failures": self._consecutive_failures,
+            "circuit_state": self._circuit.state.value if self._circuit else None,
+        }
+
+
+# Global instances for shared use across background tasks
+_redis_circuit: RedisCircuitBreaker | None = None
+_error_debouncer: DebouncedErrorLogger | None = None
+_health_monitor: RedisHealthMonitor | None = None
+
+
+def get_redis_circuit() -> RedisCircuitBreaker:
+    """Get the shared Redis circuit breaker instance."""
+    global _redis_circuit
+    if _redis_circuit is None:
+        _redis_circuit = RedisCircuitBreaker("redis")
+        _redis_circuit.add_listener(LoggingCircuitListener())
+    return _redis_circuit
+
+
+def get_error_debouncer() -> DebouncedErrorLogger:
+    """Get the shared error debouncer instance."""
+    global _error_debouncer
+    if _error_debouncer is None:
+        _error_debouncer = DebouncedErrorLogger()
+    return _error_debouncer
+
+
+def get_health_monitor() -> RedisHealthMonitor:
+    """Get the shared Redis health monitor instance."""
+    global _health_monitor
+    if _health_monitor is None:
+        _health_monitor = RedisHealthMonitor(get_redis_circuit())
+    return _health_monitor
+
+
+def reset_circuit_breaker_state() -> None:
+    """Reset circuit breaker state (for testing)."""
+    global _redis_circuit, _error_debouncer, _health_monitor
+    _redis_circuit = None
+    _error_debouncer = None
+    _health_monitor = None
+
+
+__all__ = [
+    "CircuitBreakerError",
+    "CircuitBreakerListener",
+    "CircuitState",
+    "DebouncedErrorLogger",
+    "LoggingCircuitListener",
+    "RedisCircuitBreaker",
+    "RedisHealthMonitor",
+    "get_error_debouncer",
+    "get_health_monitor",
+    "get_redis_circuit",
+    "reset_circuit_breaker_state",
+]

--- a/src/ares/core/dispatcher/deferred_queue.py
+++ b/src/ares/core/dispatcher/deferred_queue.py
@@ -473,11 +473,23 @@ class DeferredQueueMixin:
                     for task in critical_tasks:
                         await self._submit_deferred_task(task, is_critical=True)
 
-                if llm_count >= max_tasks:
+                # At soft cap but below hard cap: still process deferred tasks for starved roles
+                # This mirrors the minimum-slots logic in throttling - roles with 0 pending
+                # tasks shouldn't be starved just because recon/exploit are filling slots
+                hard_cap = int(max_tasks * 1.5)
+                if llm_count >= hard_cap:
+                    # At hard cap - only critical tasks (already processed above)
                     continue
 
                 # Process remaining tasks from deferred queue
-                for task in await self._get_highest_priority_deferred(available_slots):
+                if available_slots > 0:
+                    # Below soft cap - process normally with available slots
+                    tasks_to_process = await self._get_highest_priority_deferred(available_slots)
+                else:
+                    # At soft cap - only process tasks for starved roles (0 pending)
+                    tasks_to_process = await self._get_deferred_for_starved_roles()
+
+                for task in tasks_to_process:
                     success = await self._submit_deferred_task(task)
                     if not success:
                         # Re-queue on failure
@@ -567,6 +579,66 @@ class DeferredQueueMixin:
         except Exception as e:
             logger.error(f"Failed to get highest priority deferred tasks: {e}")
             return []
+
+    async def _get_deferred_for_starved_roles(
+        self: RedTeamDispatcher,
+    ) -> list[DeferredTask]:
+        """Get highest priority deferred task for each role that has 0 pending tasks.
+
+        This prevents role starvation when at soft cap - roles with no pending
+        tasks get priority over adding more tasks to already-busy roles.
+
+        Returns:
+            List of tasks, one per starved role (highest priority for that role)
+        """
+        if not self._task_queue or not self._task_queue.redis:
+            return []
+
+        redis = self._task_queue.redis
+        result: list[DeferredTask] = []
+
+        try:
+            # Group deferred tasks by target_role
+            # Store (key, member, score, task) to avoid double deserialization
+            role_tasks: dict[str, list[tuple[str, str, float, DeferredTask]]] = {}
+
+            for task_type in await self._get_all_deferred_task_types():
+                key = self._deferred_queue_key(task_type)
+                items = await redis.zrange(key, 0, -1, withscores=True)
+
+                for member, score in items:
+                    task = DeferredTask.from_json(member)
+                    role = task.target_role
+                    if role not in role_tasks:
+                        role_tasks[role] = []
+                    role_tasks[role].append((key, member, score, task))
+
+            if not role_tasks:
+                return []
+
+            # For each role, check if it's starved and pick highest priority task
+            for role, tasks in role_tasks.items():
+                pending_count = await self._get_pending_count_by_role(role)
+                if pending_count > 0:
+                    # Role already has tasks - not starved
+                    continue
+
+                # Role is starved - pick highest priority task (lowest score)
+                tasks.sort(key=lambda x: x[2])
+                key, member, _score, task = tasks[0]
+
+                # Remove from Redis and add to result
+                await redis.zrem(key, member)
+                result.append(task)
+                logger.info(
+                    f"Processing deferred {task.task_type} task for starved role {role} "
+                    f"(priority {task.priority})"
+                )
+
+        except Exception as e:
+            logger.error(f"Failed to get deferred tasks for starved roles: {e}")
+
+        return result
 
     async def get_deferred_queue_status(
         self: RedTeamDispatcher,

--- a/src/ares/core/dispatcher/extraction.py
+++ b/src/ares/core/dispatcher/extraction.py
@@ -157,12 +157,78 @@ def extract_plaintext_passwords_from_output(output: str) -> list[tuple[str, str,
 
     creds: list[tuple[str, str, str]] = []
     seen: set[tuple[str, str, str]] = set()
+
+    # Extract from LDAP entries (handles password before username case)
+    if "\ndn:" in output or output.strip().lower().startswith("dn:"):
+        for username, password in _extract_passwords_from_ldap_entries(output):
+            key = (username.lower(), password, "")
+            if key not in seen:
+                seen.add(key)
+                creds.append((username, password, ""))
+
+    # Extract from line-based formats (netexec, LSA, etc.)
+    for username, password, domain in _extract_passwords_line_by_line(output):
+        key = (username.lower(), password, domain.lower())
+        if key not in seen:
+            seen.add(key)
+            creds.append((username, password, domain))
+
+    return creds
+
+
+def _extract_passwords_from_ldap_entries(output: str) -> list[tuple[str, str]]:
+    """Extract credentials from LDAP-formatted output.
+
+    LDAP entries start with 'dn:' and can have password (in description)
+    appear before sAMAccountName. We must parse each entry as a complete
+    unit to correctly associate passwords with usernames.
+    """
+    creds: list[tuple[str, str]] = []
+
+    # Split into LDAP entries (each starts with dn:)
+    entries = re.split(r"(?=^dn:)", output, flags=re.MULTILINE | re.IGNORECASE)
+
+    for entry in entries:
+        if not entry.strip():
+            continue
+
+        # Extract username from sAMAccountName
+        username = ""
+        sam_match = re.search(r"samaccountname:\s*([A-Za-z0-9_.-]+)", entry, re.IGNORECASE)
+        if sam_match:
+            username = sam_match.group(1).strip()
+
+        # Extract password from description or other fields
+        password = ""  # nosec B105 - initialization, not hardcoded password
+        pass_match = re.search(r"Password\s*:\s*([^\s()]+)", entry, re.IGNORECASE)
+        if pass_match:
+            password = pass_match.group(1).strip().rstrip(".,;:()")
+
+        if username and password:
+            # Filter out invalid entries
+            if "/" in username or "\\" in username or username.endswith(".txt"):
+                continue
+            if "/" in password or "\\" in password or password.endswith(".txt"):
+                continue
+            creds.append((username, password))
+
+    return creds
+
+
+def _extract_passwords_line_by_line(output: str) -> list[tuple[str, str, str]]:
+    """Extract credentials from line-based output (netexec, LSA, etc.)."""
+    creds: list[tuple[str, str, str]] = []
     current_user = ""
     expecting_default_password = False
 
     for line in output.splitlines():
         stripped = line.strip()
         if not stripped:
+            continue
+
+        # Skip LDAP entry markers (handled by _extract_passwords_from_ldap_entries)
+        if stripped.lower().startswith("dn:"):
+            current_user = ""
             continue
 
         # Handle LSA DefaultPassword format from secretsdump:
@@ -181,10 +247,7 @@ def extract_plaintext_passwords_from_output(output: str) -> list[tuple[str, str,
                 username = lsa_match.group(2).strip()
                 password = lsa_match.group(3).strip()
                 if username and password:
-                    key = (username.lower(), password, domain.lower())
-                    if key not in seen:
-                        seen.add(key)
-                        creds.append((username, password, domain))
+                    creds.append((username, password, domain))
             continue
 
         # Track current user from various patterns
@@ -218,7 +281,9 @@ def extract_plaintext_passwords_from_output(output: str) -> list[tuple[str, str,
         )
         if smb_match:
             username = smb_match.group(1).strip()
-        elif current_user:
+
+        # Only fall back to current_user for non-LDAP lines
+        if not username and current_user:
             username = current_user
 
         if not username:
@@ -230,11 +295,6 @@ def extract_plaintext_passwords_from_output(output: str) -> list[tuple[str, str,
         if "/" in password or "\\" in password or password.endswith(".txt"):
             continue
 
-        key = (username.lower(), password, "")
-        if key in seen:
-            continue
-
-        seen.add(key)
         creds.append((username, password, ""))
 
     return creds

--- a/src/ares/core/dispatcher/monitoring.py
+++ b/src/ares/core/dispatcher/monitoring.py
@@ -777,7 +777,8 @@ class MonitoringMixin:
             vuln_id = f"{normalized_type}_{target}_{uuid.uuid4().hex[:8]}"
 
         # Check for duplicates by type+target (same logic as queue_vulnerability)
-        for existing in self.shared_state.discovered_vulnerabilities.values():
+        # Snapshot to avoid "dict changed size during iteration" from threaded consumer
+        for existing in list(self.shared_state.discovered_vulnerabilities.values()):
             if existing.vuln_type.lower() == normalized_type and existing.target == target:
                 logger.debug(
                     f"Skipping duplicate vulnerability: {existing.vuln_id} "

--- a/src/ares/core/dispatcher/persistence.py
+++ b/src/ares/core/dispatcher/persistence.py
@@ -420,7 +420,8 @@ class PersistenceMixin:
             )
 
             # Persist DC map and meta flags
-            for domain, dc_ip in self.shared_state.domain_controllers.items():
+            # Snapshot to avoid "dict changed size during iteration" from threaded consumer
+            for domain, dc_ip in list(self.shared_state.domain_controllers.items()):
                 await backend.set_dc(domain, dc_ip)
 
             # ADDITIVE pattern: only upgrade False→True, never downgrade

--- a/src/ares/core/dispatcher/publishing.py
+++ b/src/ares/core/dispatcher/publishing.py
@@ -541,7 +541,8 @@ class PublishingMixin:
             return
 
         # Check if we already have an MSSQL vuln queued for this host
-        existing_vulns = self.shared_state.discovered_vulnerabilities.values()
+        # Snapshot to avoid "dict changed size during iteration" from threaded consumer
+        existing_vulns = list(self.shared_state.discovered_vulnerabilities.values())
         for vuln in existing_vulns:
             if vuln.target == host.ip and vuln.vuln_type.startswith("mssql_"):
                 logger.debug(f"MSSQL vulnerability already queued for {host.ip}")
@@ -827,9 +828,10 @@ class PublishingMixin:
                 continue
 
             # Check if we already have an MSSQL vuln queued for this host
+            # Snapshot to avoid "dict changed size during iteration" from threaded consumer
             already_queued = any(
                 vuln.target == host.ip and vuln.vuln_type.startswith("mssql_")
-                for vuln in self.shared_state.discovered_vulnerabilities.values()
+                for vuln in list(self.shared_state.discovered_vulnerabilities.values())
             )
 
             if already_queued:

--- a/src/ares/core/dispatcher/result_processing.py
+++ b/src/ares/core/dispatcher/result_processing.py
@@ -552,9 +552,10 @@ class ResultProcessingMixin:
                 continue
 
             # Also check for logical duplicates (same type + target)
+            # Snapshot to avoid "dict changed size during iteration" from threaded consumer
             already_exists = any(
                 v.vuln_type == vuln_type and v.target.lower() == target.lower()
-                for v in self.shared_state.discovered_vulnerabilities.values()
+                for v in list(self.shared_state.discovered_vulnerabilities.values())
             )
             if already_exists:
                 continue
@@ -649,7 +650,8 @@ class ResultProcessingMixin:
         exploit_vuln_id = vuln_id
         if not exploit_vuln_id:
             # Find matching vulnerability in discovered_vulnerabilities
-            for vid, vuln in self.shared_state.discovered_vulnerabilities.items():
+            # Snapshot to avoid "dict changed size during iteration" from threaded consumer
+            for vid, vuln in list(self.shared_state.discovered_vulnerabilities.items()):
                 if vuln.vuln_type != "constrained_delegation":
                     continue
                 # Defensive: ensure vuln.details is a dict before calling .get()
@@ -1617,10 +1619,11 @@ class ResultProcessingMixin:
                 existing_gmsa.add(account_lower)
 
             # Check if already queued as vulnerability
+            # Snapshot to avoid "dict changed size during iteration" from threaded consumer
             vuln_key = f"gmsa_readable:{account_lower}"
             if vuln_key in [
                 v.vuln_type + ":" + v.target.lower()
-                for v in self.shared_state.discovered_vulnerabilities.values()
+                for v in list(self.shared_state.discovered_vulnerabilities.values())
             ]:
                 continue
 
@@ -1779,9 +1782,10 @@ class ResultProcessingMixin:
                 continue
 
             # Check if already queued
+            # Snapshot to avoid "dict changed size during iteration" from threaded consumer
             already_queued = any(
                 v.vuln_type == vuln_type and account.lower() in v.target.lower()
-                for v in self.shared_state.discovered_vulnerabilities.values()
+                for v in list(self.shared_state.discovered_vulnerabilities.values())
             )
             if already_queued:
                 continue
@@ -2174,9 +2178,10 @@ class ResultProcessingMixin:
                 continue
 
             # Check if already queued
+            # Snapshot to avoid "dict changed size during iteration" from threaded consumer
             already_queued = any(
                 v.vuln_type == vuln_type and target.lower() in v.target.lower()
-                for v in self.shared_state.discovered_vulnerabilities.values()
+                for v in list(self.shared_state.discovered_vulnerabilities.values())
             )
             if already_queued:
                 continue

--- a/src/ares/core/dispatcher/throttling.py
+++ b/src/ares/core/dispatcher/throttling.py
@@ -408,10 +408,10 @@ class ThrottlingMixin:
             },
             "privilege_escalation": {
                 # PRIVESC critical (S4U, ESC1-8), ACL critical (WriteDACL)
-                # CREDENTIAL_ACCESS high (secretsdump), LATERAL growing
+                # CREDENTIAL_ACCESS critical (secretsdump feeds lateral), LATERAL growing
                 "exploit": -2,  # 0.35 - S4U, ESC1/4/8, MSSQL impersonation
                 "acl_analysis": -2,  # 0.25 - shadow creds, password resets
-                "credential_access": -1,  # 0.15 - secretsdump owned hosts
+                "credential_access": -2,  # 0.20 - secretsdump owned hosts → feeds lateral
                 "crack": 0,  # 0.10 - NTLM from secretsdump
                 "lateral": 0,  # 0.10 - test new creds, expand footprint
                 "coercion": +1,  # 0.05 - ESC8 relay, DC coercion

--- a/src/ares/core/dispatcher/vulnerability.py
+++ b/src/ares/core/dispatcher/vulnerability.py
@@ -252,10 +252,13 @@ class VulnerabilityMixin:
         Returns:
             Vulnerability ID for tracking, or existing ID if duplicate, or empty string if invalid
         """
-        # Validate target to prevent error messages from being stored
+        # Validate target to prevent error messages or account names from being stored
+        # Target must be a hostname or IP (like Metasploit RHOSTS), not DOMAIN\User
         if not self._is_valid_target(target):
             logger.warning(
-                f"Rejecting vulnerability with invalid target: {vuln_type} on {target!r}"
+                f"Rejecting vulnerability with invalid target: {vuln_type} on {target!r}. "
+                f"Target must be hostname/IP (e.g., 'dc01.contoso.local'), not DOMAIN\\User. "
+                f"Put account info in details dict instead."
             )
             return ""
 
@@ -263,7 +266,8 @@ class VulnerabilityMixin:
         normalized_type = vuln_type.lower()
 
         # Check for existing vulnerability with same type and target (deduplication)
-        for existing in self.shared_state.discovered_vulnerabilities.values():
+        # Snapshot to avoid "dict changed size during iteration" from threaded consumer
+        for existing in list(self.shared_state.discovered_vulnerabilities.values()):
             if existing.vuln_type.lower() == normalized_type and existing.target == target:
                 logger.debug(
                     f"Vulnerability already exists: {existing.vuln_id} "
@@ -392,7 +396,8 @@ class VulnerabilityMixin:
     ) -> list[tuple[int, str, dict[str, Any]]]:
         """Fetch unexploited vulnerability candidates from shared state."""
         candidates: list[tuple[int, str, dict[str, Any]]] = []
-        for vuln in self.shared_state.discovered_vulnerabilities.values():
+        # Snapshot to avoid "dict changed size during iteration" from threaded consumer
+        for vuln in list(self.shared_state.discovered_vulnerabilities.values()):
             if vuln.vuln_id in exclude_ids:
                 continue
             # Skip already dequeued vulns (in-progress exploitation)

--- a/src/ares/core/factories/blue_agents.py
+++ b/src/ares/core/factories/blue_agents.py
@@ -436,12 +436,12 @@ def create_blue_hooks(role: BlueRole) -> list:
                             if not target_ip:
                                 target_ip = val
                         elif "." in val and is_likely_fqdn(val):
-                            # FQDN - extract hostname
-                            target_fqdn = val
-                            target_hostname = val.split(".")[0]
+                            # FQDN - extract hostname (lowercase for consistent graph nodes)
+                            target_fqdn = val.lower()
+                            target_hostname = val.split(".")[0].lower()
                         elif "." not in val:
-                            # Plain hostname (no dots)
-                            target_hostname = val
+                            # Plain hostname (no dots, lowercase for consistent graph nodes)
+                            target_hostname = val.lower()
                         # else: value with dot but not FQDN (e.g., username) - skip
                         break
 

--- a/src/ares/core/factories/red_agents.py
+++ b/src/ares/core/factories/red_agents.py
@@ -340,12 +340,12 @@ def create_role_hooks(
                             if not target_ip:
                                 target_ip = val
                         elif "." in val and is_likely_fqdn(val):
-                            # FQDN - extract hostname
-                            target_fqdn = val
-                            target_hostname = val.split(".")[0]
+                            # FQDN - extract hostname (lowercase for consistent graph nodes)
+                            target_fqdn = val.lower()
+                            target_hostname = val.split(".")[0].lower()
                         elif "." not in val:
-                            # Plain hostname (no dots)
-                            target_hostname = val
+                            # Plain hostname (no dots, lowercase for consistent graph nodes)
+                            target_hostname = val.lower()
                         # else: value with dot but not FQDN (e.g., username) - skip
                         break
 
@@ -370,9 +370,9 @@ def create_role_hooks(
         if target_ip and not target_fqdn and shared_state:
             for host in shared_state.all_hosts:
                 if host.ip == target_ip and host.hostname and "." in host.hostname:
-                    target_fqdn = host.hostname
+                    target_fqdn = host.hostname.lower()
                     if not target_hostname:
-                        target_hostname = host.hostname.split(".")[0]
+                        target_hostname = host.hostname.split(".")[0].lower()
                     # Check if it's a DC
                     if host.is_dc:
                         target_type = "domain_controller"

--- a/src/ares/core/factories/red_agents.py
+++ b/src/ares/core/factories/red_agents.py
@@ -332,6 +332,7 @@ def create_role_hooks(
                         break
 
                 # Extract FQDN/hostname from host args
+                raw_hostname = None
                 for arg in ("target", "host", "hostname"):
                     val = args.get(arg)
                     if val:
@@ -340,14 +341,36 @@ def create_role_hooks(
                             if not target_ip:
                                 target_ip = val
                         elif "." in val and is_likely_fqdn(val):
-                            # FQDN - extract hostname (lowercase for consistent graph nodes)
-                            target_fqdn = val.lower()
-                            target_hostname = val.split(".")[0].lower()
+                            # FQDN - capture raw value for resolution
+                            raw_hostname = val
                         elif "." not in val:
-                            # Plain hostname (no dots, lowercase for consistent graph nodes)
-                            target_hostname = val.lower()
+                            # Plain hostname (no dots) - capture for resolution
+                            raw_hostname = val
                         # else: value with dot but not FQDN (e.g., username) - skip
                         break
+
+                # Normalize hostname to canonical FQDN from discovered hosts
+                # This resolves NetBIOS names (WINTERFELL) and wrong domain suffixes
+                # (winterfell.sevenkingdoms.local) to the canonical FQDN
+                # (winterfell.north.sevenkingdoms.local)
+                if raw_hostname and shared_state:
+                    canonical_fqdn = shared_state.resolve_hostname_to_fqdn(raw_hostname, target_ip)
+                    if canonical_fqdn:
+                        target_fqdn = canonical_fqdn
+                        target_hostname = canonical_fqdn.split(".")[0]
+                    # Resolution failed - use raw value (lowercased)
+                    elif "." in raw_hostname:
+                        target_fqdn = raw_hostname.lower()
+                        target_hostname = raw_hostname.split(".")[0].lower()
+                    else:
+                        target_hostname = raw_hostname.lower()
+                elif raw_hostname:
+                    # No shared_state - fall back to raw value (lowercased)
+                    if "." in raw_hostname:
+                        target_fqdn = raw_hostname.lower()
+                        target_hostname = raw_hostname.split(".")[0].lower()
+                    else:
+                        target_hostname = raw_hostname.lower()
 
                 # Extract domain and user
                 target_domain = args.get("domain") or args.get("target_domain")
@@ -368,14 +391,15 @@ def create_role_hooks(
 
         # Try to resolve IP → FQDN from shared_state if we only have an IP
         if target_ip and not target_fqdn and shared_state:
+            resolved_fqdn = shared_state.resolve_hostname_to_fqdn("", target_ip)
+            if resolved_fqdn:
+                target_fqdn = resolved_fqdn
+                if not target_hostname:
+                    target_hostname = resolved_fqdn.split(".")[0]
+            # Check if target IP is a DC (separate from FQDN resolution)
             for host in shared_state.all_hosts:
-                if host.ip == target_ip and host.hostname and "." in host.hostname:
-                    target_fqdn = host.hostname.lower()
-                    if not target_hostname:
-                        target_hostname = host.hostname.split(".")[0].lower()
-                    # Check if it's a DC
-                    if host.is_dc:
-                        target_type = "domain_controller"
+                if host.ip == target_ip and host.is_dc:
+                    target_type = "domain_controller"
                     break
 
         # If we still don't have target_type but have an IP, check if it's a DC

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -1421,6 +1421,67 @@ class SharedRedTeamState:
         # No FQDN found, return original
         return netbios_lower
 
+    def resolve_hostname_to_fqdn(self, hostname: str, target_ip: str | None = None) -> str | None:
+        """Resolve a hostname to its canonical FQDN from discovered hosts.
+
+        When tools output hostnames like 'WINTERFELL' (NetBIOS) or
+        'winterfell.sevenkingdoms.local' (wrong/partial domain suffix),
+        this method resolves them to the canonical FQDN based on
+        discovered hosts in all_hosts.
+
+        This is the "right" fix for normalizing hostnames at the span emission
+        layer - always emit the canonical FQDN, not variants.
+
+        Resolution strategy:
+        1. If target_ip is provided, find host by IP and return its FQDN
+        2. If hostname is already an exact FQDN match, return it
+        3. If hostname is a NetBIOS name (no dot), match by short hostname
+        4. If hostname is a partial/wrong FQDN, match by short hostname prefix
+
+        Args:
+            hostname: The hostname to resolve (NetBIOS, short, or partial FQDN)
+            target_ip: Optional IP address for disambiguation when multiple
+                       hosts share the same short hostname
+
+        Returns:
+            Canonical FQDN (lowercased) if found, None otherwise
+        """
+        # Strategy 1: If we have an IP, find exact host match first
+        # This is the most reliable since IPs are unique
+        # This handles the case where we only have an IP (no hostname)
+        if target_ip:
+            for host in self.all_hosts:
+                if host.ip == target_ip and host.hostname and "." in host.hostname:
+                    return host.hostname.lower()
+
+        # If no hostname provided and IP resolution didn't find a match, return None
+        if not hostname:
+            return None
+
+        hostname_lower = hostname.lower().strip()
+
+        # Strategy 2-4: Match by hostname
+        # Extract the short name from input (before first dot, if any)
+        input_short = hostname_lower.split(".")[0]
+
+        for host in self.all_hosts:
+            host_hostname = (host.hostname or "").lower()
+            if not host_hostname or "." not in host_hostname:
+                continue  # Skip hosts without FQDN
+
+            host_short = host_hostname.split(".")[0]
+
+            # Strategy 2: Exact FQDN match - already canonical
+            if hostname_lower == host_hostname:
+                return host_hostname
+
+            # Strategy 3 & 4: Short name matches (works for both NetBIOS and partial FQDN)
+            if input_short == host_short:
+                return host_hostname
+
+        # No match found
+        return None
+
     def _validate_hash_domain(self, username: str, domain: str, source_agent: str) -> str:
         """Validate and correct hash domain by cross-referencing with known user domains.
 
@@ -2523,15 +2584,31 @@ class SharedRedTeamState:
                 new_hostname = (host.hostname or "").strip()
                 if new_hostname:
                     existing_lower = existing_hostname.lower()
+                    new_lower = new_hostname.lower()
                     existing_is_short = "." not in existing_hostname
                     new_is_fqdn = "." in new_hostname
                     existing_is_ptr = (
                         existing_lower.startswith("ip-") and "compute.internal" in existing_lower
                     )
+
+                    # Check if new FQDN is more specific (more domain levels) than existing
+                    # e.g., "winterfell.north.sevenkingdoms.local" is more specific than
+                    # "winterfell.sevenkingdoms.local" and should be preferred
+                    new_is_more_specific = False
+                    if new_is_fqdn and "." in existing_hostname:
+                        existing_parts = existing_lower.split(".")
+                        new_parts = new_lower.split(".")
+                        # Same short hostname but new has more domain levels
+                        if existing_parts[0] == new_parts[0] and len(new_parts) > len(
+                            existing_parts
+                        ):
+                            new_is_more_specific = True
+
                     if (
                         not existing_hostname
                         or existing_is_ptr
                         or (existing_is_short and new_is_fqdn)
+                        or new_is_more_specific
                     ):
                         existing.hostname = new_hostname
                         data_changed = True

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -2848,7 +2848,8 @@ class SharedRedTeamState:
         if vuln.vuln_id in self.discovered_vulnerabilities:
             return False
         # Also check for same (type, target) combination to prevent logical duplicates
-        for existing in self.discovered_vulnerabilities.values():
+        # Snapshot to avoid "dict changed size during iteration" from concurrent access
+        for existing in list(self.discovered_vulnerabilities.values()):
             if existing.vuln_type == vuln.vuln_type and existing.target == vuln.target:
                 return False
         self.discovered_vulnerabilities[vuln.vuln_id] = vuln
@@ -2877,9 +2878,10 @@ class SharedRedTeamState:
 
     def get_unexploited_vulnerabilities(self) -> list[VulnerabilityInfo]:
         """Get vulnerabilities that haven't been exploited yet."""
+        # Snapshot to avoid "dict changed size during iteration" from concurrent access
         return [
             v
-            for vid, v in self.discovered_vulnerabilities.items()
+            for vid, v in list(self.discovered_vulnerabilities.items())
             if vid not in self.exploited_vulnerabilities
         ]
 
@@ -2932,7 +2934,8 @@ class SharedRedTeamState:
                     dc_hosts_by_ip[host.ip] = host
 
         # Check all local_admin vulnerabilities for this user
-        for vuln in self.discovered_vulnerabilities.values():
+        # Snapshot to avoid "dict changed size during iteration" from concurrent access
+        for vuln in list(self.discovered_vulnerabilities.values()):
             if vuln.vuln_type != "local_admin":
                 continue
 
@@ -3127,9 +3130,10 @@ class SharedRedTeamState:
     @property
     def weaknesses(self) -> list[str]:
         """Return combined weaknesses and vulnerability descriptions for reporting."""
+        # Snapshot to avoid "dict changed size during iteration" from concurrent access
         vuln_descriptions = [
             f"{v.vuln_type} on {v.target} ({v.vuln_id})"
-            for v in self.discovered_vulnerabilities.values()
+            for v in list(self.discovered_vulnerabilities.values())
         ]
         return self.all_weaknesses + vuln_descriptions
 

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -1908,33 +1908,77 @@ def _get_dc_ips(state: SharedRedTeamState) -> set[str]:
     return dc_ips
 
 
-def _has_constrained_delegation_for_target(state: SharedRedTeamState, target_ip: str) -> bool:
-    """Check if there's a constrained delegation vulnerability targeting this host.
+def _has_exploitable_constrained_delegation_for_target(
+    state: SharedRedTeamState, target_ip: str
+) -> bool:
+    """Check if there's an EXPLOITABLE constrained delegation vulnerability targeting this host.
 
-    If true, we should use the S4U attack path instead of direct secretsdump.
+    Only returns True if:
+    1. A constrained delegation vulnerability exists targeting this host
+    2. We have working credentials for the delegated account
+
+    If we don't have credentials for the delegated account, the S4U path can't be used,
+    so we should still try secretsdump instead of skipping it.
+
+    Args:
+        state: The shared red team state
+        target_ip: The target IP to check
+
+    Returns:
+        True only if delegation exists AND we have credentials to exploit it
     """
     # Snapshot to avoid "dict changed size during iteration" from concurrent access
     for vuln in list(state.discovered_vulnerabilities.values()):
         if vuln.vuln_type != "constrained_delegation":
             continue
+
         # Defensive: ensure vuln.details is a dict before calling .get()
         details = vuln.details if isinstance(vuln.details, dict) else {}
+
         # Check if target matches the vulnerability's target
+        target_matches = False
         vuln_target_ip = details.get("target_ip", "")
         if vuln_target_ip == target_ip:
+            target_matches = True
+        else:
+            # Also check hostname in target_spn
+            target_spn = details.get("target_spn", "")
+            if target_spn:
+                # Extract hostname from SPN (e.g., cifs/dc01.contoso.local -> dc01.contoso.local)
+                spn_host = target_spn.split("/", 1)[1] if "/" in target_spn else ""
+                for host in state.all_hosts:
+                    if (
+                        host.ip == target_ip
+                        and host.hostname
+                        and spn_host.lower() in host.hostname.lower()
+                    ):
+                        target_matches = True
+                        break
+
+        if not target_matches:
+            continue
+
+        # Target matches - now check if we have credentials for the delegated account
+        account = details.get("account_name") or details.get("account", "")
+        if not account:
+            # No account info in vulnerability - can't determine exploitability
+            # Be conservative and don't skip secretsdump
+            continue
+
+        # Check if we have working credentials for this account
+        account_lower = account.lower().rstrip("$")
+        has_working_creds = any(
+            cred.username.lower() == account_lower and cred.password
+            for cred in state.all_credentials
+        )
+
+        if has_working_creds:
+            # We have credentials - S4U path is viable, skip secretsdump
             return True
-        # Also check hostname in target_spn
-        target_spn = details.get("target_spn", "")
-        if target_spn:
-            # Extract hostname from SPN (e.g., cifs/dc01.contoso.local -> dc01.contoso.local)
-            spn_host = target_spn.split("/", 1)[1] if "/" in target_spn else ""
-            for host in state.all_hosts:
-                if (
-                    host.ip == target_ip
-                    and host.hostname
-                    and spn_host.lower() in host.hostname.lower()
-                ):
-                    return True
+
+        # No credentials for delegated account - S4U can't be used
+        # Continue checking other vulns (there may be another exploitable one)
+
     return False
 
 
@@ -2199,16 +2243,19 @@ async def _auto_credential_access(
                     )
 
                 # For DC hosts: only try secretsdump if credential is privileged OR
-                # there's no constrained delegation path (S4U) available
+                # there's no EXPLOITABLE constrained delegation path (S4U) available.
+                # NOTE: We only skip secretsdump if we have working credentials for the
+                # delegated account. If the account is locked out or we don't have creds,
+                # we should still try secretsdump as a fallback.
                 for dc_ip in dc_hosts_in_domain:
-                    has_s4u_path = _has_constrained_delegation_for_target(state, dc_ip)
+                    has_s4u_path = _has_exploitable_constrained_delegation_for_target(state, dc_ip)
                     is_privileged = _is_likely_privileged_credential(cred.username, cred.source)
 
                     if has_s4u_path and not is_privileged:
-                        # Skip secretsdump - let the S4U attack path handle this DC
+                        # Skip secretsdump - S4U path is viable (we have creds for delegated account)
                         logger.info(
                             f"Skipping secretsdump on DC {dc_ip} for {cred.username}: "
-                            f"constrained delegation path exists, use S4U instead"
+                            f"exploitable constrained delegation path exists, use S4U instead"
                         )
                         continue
 
@@ -2293,9 +2340,12 @@ async def _auto_credential_access(
                                 techniques=["kerberoast", "secretsdump"],
                             )
 
-                        # For DC hosts: only try if privileged or no S4U path
+                        # For DC hosts: only try if privileged or no EXPLOITABLE S4U path
+                        # (requires credentials for the delegated account to be viable)
                         for dc_ip in dc_hosts_in_domain:
-                            has_s4u_path = _has_constrained_delegation_for_target(state, dc_ip)
+                            has_s4u_path = _has_exploitable_constrained_delegation_for_target(
+                                state, dc_ip
+                            )
                             is_privileged = _is_likely_privileged_credential(
                                 hash_obj.username, hash_obj.source
                             )
@@ -2303,7 +2353,7 @@ async def _auto_credential_access(
                             if has_s4u_path and not is_privileged:
                                 logger.info(
                                     f"Skipping secretsdump on DC {dc_ip} for {hash_obj.username} (hash): "
-                                    f"constrained delegation path exists, use S4U instead"
+                                    f"exploitable constrained delegation path exists, use S4U instead"
                                 )
                                 continue
 

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -395,21 +395,15 @@ async def _run_nmap_on_worker(targets: list[str], namespace: str) -> tuple[str, 
                             continue
 
                     # Fallback: parse NetBIOS name from nbstat output
+                    # NOTE: We only use the NetBIOS hostname, not the domain group name.
+                    # Constructing FQDNs like "{netbios}.{domain}.local" is wrong because
+                    # we don't know the actual domain suffix (e.g., "north" could be
+                    # "north.sevenkingdoms.local", not "north.local"). The actual FQDN
+                    # will be discovered via DNS/LDAP enumeration.
                     nb_match = re.search(r"nbstat:\s*NetBIOS name:\s*([^,]+)", nb_stdout)
                     if nb_match:
                         netbios_name = nb_match.group(1).strip()
-                        # Try to find domain from Names section
-                        # Format: "|     DOMAIN<00>  Flags: <group>" (nmap nbstat output)
-                        domain_match = re.search(
-                            r"^\|?\s+([A-Z0-9_-]+)<00>\s+Flags:.*<group>",
-                            nb_stdout,
-                            re.MULTILINE,
-                        )
-                        if domain_match:
-                            domain = domain_match.group(1).strip().lower()
-                            host.hostname = f"{netbios_name.lower()}.{domain}.local"
-                        else:
-                            host.hostname = netbios_name.lower()
+                        host.hostname = netbios_name.lower()
                         logger.info(
                             f"[DIRECT NMAP] Resolved NetBIOS name for {host.ip}: {host.hostname}"
                         )

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -1913,7 +1913,8 @@ def _has_constrained_delegation_for_target(state: SharedRedTeamState, target_ip:
 
     If true, we should use the S4U attack path instead of direct secretsdump.
     """
-    for vuln in state.discovered_vulnerabilities.values():
+    # Snapshot to avoid "dict changed size during iteration" from concurrent access
+    for vuln in list(state.discovered_vulnerabilities.values()):
         if vuln.vuln_type != "constrained_delegation":
             continue
         # Defensive: ensure vuln.details is a dict before calling .get()
@@ -2916,7 +2917,8 @@ async def _auto_local_admin_secretsdump(
 
             # Also check for BloodHound AdminTo relationships
             # These are stored in discovered_vulnerabilities with local_admin type
-            for vuln_id, vuln in state.discovered_vulnerabilities.items():
+            # Snapshot to avoid "dict changed size during iteration" from concurrent access
+            for vuln_id, vuln in list(state.discovered_vulnerabilities.items()):
                 if vuln.vuln_type not in ("local_admin", "AdminTo", "CanRDP"):
                     continue
 
@@ -3528,7 +3530,8 @@ async def _auto_acl_chain_follow(
 def _get_running_crack_tasks(dispatcher: RedTeamDispatcher) -> list[str]:
     """Get task IDs for crack tasks that are still pending (running)."""
     crack_task_ids = []
-    for task_id, task_info in dispatcher.shared_state.pending_tasks.items():
+    # Snapshot to avoid "dict changed size during iteration" from concurrent access
+    for task_id, task_info in list(dispatcher.shared_state.pending_tasks.items()):
         if task_info.task_type == "crack":
             crack_task_ids.append(task_id)
     return crack_task_ids

--- a/src/ares/core/task_queue.py
+++ b/src/ares/core/task_queue.py
@@ -15,6 +15,11 @@ from typing import Any
 from loguru import logger
 from pydantic import BaseModel
 
+from ares.core.circuit_breaker import (
+    CircuitBreakerError,
+    get_error_debouncer,
+    get_redis_circuit,
+)
 from ares.core.config import get_agent_heartbeat_timeout, get_redis_url
 from ares.core.redis_client import (
     create_redis_client,
@@ -108,11 +113,15 @@ class RedisTaskQueue:
     RESULT_TTL = 86400  # 24 hours
     HEARTBEAT_TTL = 60  # 60 seconds
 
-    def __init__(self, redis_url: str | None = None):
+    def __init__(self, redis_url: str | None = None, use_circuit_breaker: bool = True):
         self.redis_url = redis_url or get_redis_url()
         self._client = None
         self._connected = False
         self._heartbeat_ttl = max(self.HEARTBEAT_TTL, get_agent_heartbeat_timeout() * 2)
+        self._use_circuit_breaker = use_circuit_breaker
+        # Shared circuit breaker and debouncer across all task queue instances
+        self._circuit = get_redis_circuit() if use_circuit_breaker else None
+        self._debouncer = get_error_debouncer() if use_circuit_breaker else None
 
     @property
     def redis(self):
@@ -129,9 +138,17 @@ class RedisTaskQueue:
         Uses socket_timeout=None to allow blocking operations (BRPOP) to wait
         for extended periods without hitting socket timeout. Timeout control
         is handled at the application level via asyncio.wait_for.
+
+        Circuit breaker: If the circuit is open, fails fast without attempting
+        connection. This prevents thundering herd when Redis is unavailable.
         """
         if self._connected:
             return
+
+        # Check circuit breaker FIRST - fail fast if Redis is known to be down
+        if self._circuit and not self._circuit.allow_request_sync():
+            remaining = self._circuit._get_remaining_open_time()
+            raise CircuitBreakerError(self._circuit.name, remaining)
 
         # Use direct connection when in a non-main thread to avoid
         # SentinelConnectionPool's async state being shared across event loops
@@ -151,13 +168,34 @@ class RedisTaskQueue:
             )
             await self._client.ping()
             self._connected = True
+
+            # Record success to close circuit if it was half-open
+            if self._circuit:
+                self._circuit.record_success_sync()
+
             if get_redis_sentinel_config():
                 conn_type = "direct" if direct_connection else "via Sentinel"
                 logger.info(f"TaskQueue connected to Redis {conn_type} (socket_timeout=None)")
             else:
                 logger.info(f"TaskQueue connected to Redis at {self.redis_url}")
 
+        except CircuitBreakerError:
+            raise  # Don't wrap circuit breaker errors
+
         except Exception as e:
+            # Record failure to potentially open circuit
+            if self._circuit and is_connection_error(e):
+                self._circuit.record_failure_sync(e)
+                # Debounce the error log
+                if self._debouncer:
+                    self._debouncer.log_error_sync(
+                        "redis_connect",
+                        f"Redis connect failed: {e}",
+                        level="warning",
+                    )
+                    # Don't raise the original error message if debounced
+                    # Just raise a clean circuit breaker aware error
+                    raise RuntimeError(f"Failed to connect to Redis: {e}") from e
             raise RuntimeError(f"Failed to connect to Redis: {e}") from e
 
     async def disconnect(self) -> None:
@@ -217,6 +255,71 @@ class RedisTaskQueue:
             # The client will be recreated on next connect()
             self._client = None
         logger.warning(f"Redis connection error, will retry: {error}")
+
+    async def _with_circuit_breaker(
+        self,
+        operation_name: str,
+        operation_func,
+        *,
+        suppress_open_error: bool = False,
+    ):
+        """Execute a Redis operation with circuit breaker protection.
+
+        When the circuit is open, operations fail-fast instead of trying to
+        connect to unavailable Redis. This prevents thundering herd when
+        multiple background tasks all discover Redis is down simultaneously.
+
+        IMPORTANT: This method handles connection AND operation failures.
+        Pass a callable (lambda or function) that will be called AFTER
+        the circuit check, not a coroutine.
+
+        Args:
+            operation_name: Name for logging (e.g., "check_results_batch")
+            operation_func: Async callable that performs the operation
+                           (called AFTER circuit check, so connect() is protected)
+            suppress_open_error: If True, return None instead of raising when open
+
+        Returns:
+            Result of the operation, or None if circuit is open and suppress_open_error
+
+        Raises:
+            CircuitBreakerError: If circuit is open and not suppressed
+            Exception: Any exception from the Redis operation
+        """
+        if not self._circuit:
+            # Circuit breaker disabled - execute directly
+            return await operation_func()
+
+        # Check if circuit allows request BEFORE trying to connect
+        if not self._circuit.allow_request_sync():
+            if suppress_open_error:
+                # Log with debouncing to reduce spam (sync version for thread safety)
+                if self._debouncer:
+                    self._debouncer.log_error_sync(
+                        f"circuit_open_{operation_name}",
+                        f"Circuit breaker open, skipping {operation_name}",
+                        level="debug",
+                    )
+                return None
+            remaining = self._circuit._get_remaining_open_time()
+            raise CircuitBreakerError(self._circuit.name, remaining)
+
+        try:
+            # Now execute the operation (which may include connect())
+            result = await operation_func()
+            self._circuit.record_success_sync()
+            return result
+        except Exception as e:
+            if is_connection_error(e):
+                self._circuit.record_failure_sync(e)
+                # Use debouncer for connection errors (sync version)
+                if self._debouncer:
+                    self._debouncer.log_error_sync(
+                        f"redis_error_{operation_name}",
+                        f"Redis {operation_name} failed: {e}",
+                        level="warning",
+                    )
+            raise
 
     def _task_queue_key(self, role: str) -> str:
         """Get task queue key for a role."""
@@ -288,12 +391,26 @@ class RedisTaskQueue:
         target_fqdn = None
         target_user = None
 
-        # Check explicit IP fields first
-        for field in ("target_ip", "dc_ip", "ip"):
+        # Check explicit IP fields first (NOT dc_ip - that's for auth, not target)
+        # dc_ip is the domain controller used for authentication, not the attack target
+        for field in ("target_ip", "ip"):
             val = payload.get(field)
             if val and IP_PATTERN.match(val):
                 target_ip = val
                 break
+
+        # Check target_ips list (common in recon/credential_access payloads)
+        if not target_ip:
+            target_ips = payload.get("target_ips", [])
+            if target_ips and isinstance(target_ips, list) and target_ips[0]:
+                first_target = target_ips[0]
+                if IP_PATTERN.match(first_target):
+                    target_ip = first_target
+                elif is_likely_fqdn(first_target):
+                    target_fqdn = first_target
+                elif first_target:
+                    # NetBIOS hostname - set as FQDN for span tracking
+                    target_fqdn = first_target
 
         # Check target/host fields - distinguish FQDN from username
         for field in ("target", "host", "hostname"):
@@ -303,12 +420,13 @@ class RedisTaskQueue:
                     if not target_ip:
                         target_ip = val
                 elif "." in val and is_likely_fqdn(val):
-                    target_fqdn = val
+                    if not target_fqdn:
+                        target_fqdn = val
                 elif "." in val:
                     # Has dot but not FQDN -> likely username (e.g., "sansa.stark")
                     target_user = val
                 # Plain hostname without dots - set as FQDN for backwards compat
-                elif val:
+                elif val and not target_fqdn:
                     target_fqdn = val
                 break
 
@@ -451,6 +569,9 @@ class RedisTaskQueue:
         N * 30s during connectivity issues. Pipeline batching reduces this to
         a single timeout window regardless of N.
 
+        Circuit breaker protection: When Redis is unavailable, the circuit opens
+        and subsequent calls fail-fast instead of waiting for timeout.
+
         Args:
             task_ids: List of task IDs to check
 
@@ -460,18 +581,30 @@ class RedisTaskQueue:
         if not task_ids:
             return {}
 
-        if not self._connected:
-            await self.connect()
-
-        # Use pipeline for single round-trip
-        pipe = self._client.pipeline()
-        for task_id in task_ids:
-            result_key = self._result_queue_key(task_id)
-            pipe.rpop(result_key)
+        async def _execute_batch():
+            # Connect inside the circuit breaker so failures are tracked
+            if not self._connected:
+                await self.connect()
+            # Use pipeline for single round-trip
+            pipe = self._client.pipeline()
+            for task_id in task_ids:
+                result_key = self._result_queue_key(task_id)
+                pipe.rpop(result_key)
+            return await pipe.execute()
 
         results: dict[str, TaskResult | None] = {}
         try:
-            raw_results = await pipe.execute()
+            # Wrap entire operation (including connect) with circuit breaker
+            raw_results = await self._with_circuit_breaker(
+                "check_results_batch",
+                _execute_batch,  # Pass callable, not coroutine
+                suppress_open_error=True,
+            )
+
+            if raw_results is None:
+                # Circuit is open - return empty results
+                return dict.fromkeys(task_ids)
+
             for task_id, data in zip(task_ids, raw_results, strict=False):
                 if data is None:
                     results[task_id] = None
@@ -481,6 +614,11 @@ class RedisTaskQueue:
                     except Exception as e:
                         logger.warning(f"Failed to parse result for {task_id}: {e}")
                         results[task_id] = None
+
+        except CircuitBreakerError:
+            # Circuit is open - return empty results (already logged by circuit)
+            return dict.fromkeys(task_ids)
+
         except Exception as e:
             # Handle connection errors to force reconnection on next call
             if is_connection_error(e):
@@ -488,7 +626,9 @@ class RedisTaskQueue:
                 # Force fresh DNS resolution on reconnect (handles Sentinel pod restarts)
                 invalidate_sentinel_client()
             # On pipeline failure, return empty results (caller will retry)
-            logger.warning(f"Pipeline check_results_batch failed: {e}")
+            # Note: Circuit breaker already logged this if it's a connection error
+            if not self._circuit or not is_connection_error(e):
+                logger.warning(f"Pipeline check_results_batch failed: {e}")
             return dict.fromkeys(task_ids)
 
         return results
@@ -701,21 +841,34 @@ class RedisTaskQueue:
         """
         Get agent heartbeat data.
 
+        Circuit breaker protection: When Redis is unavailable, returns None
+        instead of blocking on timeout.
+
         Raises:
             Exception: Re-raises connection errors after marking connection as failed
         """
-        if not self._connected:
-            await self.connect()
-
         heartbeat_key = self._heartbeat_key(agent_name)
 
+        async def _get_heartbeat():
+            if not self._connected:
+                await self.connect()
+            return await self._client.get(heartbeat_key)
+
         try:
-            data = await self._client.get(heartbeat_key)
+            data = await self._with_circuit_breaker(
+                "get_heartbeat",
+                _get_heartbeat,  # Pass callable, not coroutine
+                suppress_open_error=True,
+            )
 
             if data is None:
                 return None
 
             return json.loads(data)
+
+        except CircuitBreakerError:
+            # Circuit is open - return None (agent status unknown)
+            return None
 
         except Exception as e:
             if is_connection_error(e):
@@ -1058,6 +1211,9 @@ class RedisTaskQueue:
         """
         Poll for pending discoveries (non-blocking).
 
+        Circuit breaker protection: When Redis is unavailable, returns empty
+        list instead of blocking on timeout.
+
         Args:
             operation_id: The operation ID
             max_items: Maximum discoveries to retrieve per poll
@@ -1065,18 +1221,29 @@ class RedisTaskQueue:
         Returns:
             List of discovery dicts
         """
-        if not self._connected:
-            await self.connect()
-
         queue_key = self._discovery_queue_key(operation_id)
         discoveries = []
 
-        try:
+        async def _execute_poll():
+            # Connect inside the circuit breaker so failures are tracked
+            if not self._connected:
+                await self.connect()
             # Use pipeline for efficiency
             pipe = self._client.pipeline()
             for _ in range(max_items):
                 pipe.rpop(queue_key)
-            results = await pipe.execute()
+            return await pipe.execute()
+
+        try:
+            results = await self._with_circuit_breaker(
+                "poll_discoveries",
+                _execute_poll,  # Pass callable, not coroutine
+                suppress_open_error=True,
+            )
+
+            if results is None:
+                # Circuit is open - return empty list
+                return []
 
             for data in results:
                 if data is None:
@@ -1086,12 +1253,33 @@ class RedisTaskQueue:
                 except json.JSONDecodeError:
                     logger.warning(f"Invalid discovery JSON: {data}")
 
+        except CircuitBreakerError:
+            # Circuit is open - return empty list
+            return []
+
         except Exception as e:
             if is_connection_error(e):
                 self._handle_connection_error(e)
-            logger.warning(f"Failed to poll discoveries: {e}")
+            # Note: Circuit breaker already logged this if it's a connection error
+            if not self._circuit or not is_connection_error(e):
+                logger.warning(f"Failed to poll discoveries: {e}")
 
         return discoveries
+
+    def get_circuit_breaker_status(self) -> dict[str, Any] | None:
+        """Get circuit breaker status for monitoring.
+
+        Returns:
+            Dict with circuit breaker state, or None if disabled
+        """
+        if not self._circuit:
+            return None
+        return self._circuit.get_status()
+
+    async def flush_error_debouncer(self) -> None:
+        """Flush pending debounced errors (call on shutdown)."""
+        if self._debouncer:
+            await self._debouncer.flush()
 
 
 __all__ = [

--- a/src/ares/core/tracing.py
+++ b/src/ares/core/tracing.py
@@ -232,12 +232,16 @@ TOOL_TO_TECHNIQUE: dict[str, str] = {
     "nmap_scan": "T1046",  # Network Service Discovery
     "portscan": "T1046",
     "ping_sweep": "T1018",  # Remote System Discovery
+    "smb_sweep": "T1046",  # Network Service Scanning
+    "resolve_domain_controllers": "T1018",  # Remote System Discovery
     "ldap_domain_dump": "T1087.002",  # Domain Account Discovery
     "ldap_search": "T1087.002",
     "ldap_search_descriptions": "T1087.002",
     "bloodhound_collection": "T1087.002",
+    "run_bloodhound": "T1087.002",  # Domain Account Discovery (also T1482)
     "sharphound": "T1087.002",
     "get_domain_info": "T1087.002",
+    "enumerate_users": "T1087.002",  # Domain Account Discovery
     "enum_domain_trusts": "T1482",  # Domain Trust Discovery
     "enumerate_forest": "T1482",
     "enum_constrained_delegation": "T1087.002",
@@ -309,6 +313,10 @@ TOOL_TO_TECHNIQUE: dict[str, str] = {
     "forge_golden_ticket": "T1558.001",  # Golden Ticket (alias)  # nosec B105
     "forge_silver_ticket": "T1558.002",  # Silver Ticket
     "create_machine_account": "T1136.002",
+    # Reporting / Documentation tools
+    "record_credential": "T1087.002",  # Account Discovery (documenting discovered credentials)
+    "record_weakness": "T1518.001",  # Software Discovery: Security Software
+    "record_timeline_event": "T1087",  # Account Discovery (general)
 }
 
 # Map tool categories to tactics for fallback
@@ -331,6 +339,7 @@ TOOL_CATEGORY_TO_TACTIC: dict[str, str] = {
     "LateralMovementTools": "lateral-movement",
     "CoercionTools": "credential-access",
     "CoercionNetworkTools": "credential-access",
+    "ReportingTools": "discovery",
 }
 
 # Map tool names to their category (toolset class name)
@@ -340,12 +349,16 @@ TOOL_TO_CATEGORY: dict[str, str] = {
     "nmap_scan": "NetworkEnumerationTools",
     "portscan": "NetworkEnumerationTools",
     "ping_sweep": "NetworkEnumerationTools",
+    "smb_sweep": "NetworkEnumerationTools",
+    "resolve_domain_controllers": "NetworkEnumerationTools",
     "ldap_domain_dump": "NetworkEnumerationTools",
     "ldap_search": "NetworkEnumerationTools",
     "ldap_search_descriptions": "NetworkEnumerationTools",
     "bloodhound_collection": "NetworkEnumerationTools",
+    "run_bloodhound": "BloodHoundTools",
     "sharphound": "NetworkEnumerationTools",
     "get_domain_info": "NetworkEnumerationTools",
+    "enumerate_users": "NetworkEnumerationTools",
     "enum_domain_trusts": "NetworkEnumerationTools",
     "enumerate_forest": "NetworkEnumerationTools",
     "enum_constrained_delegation": "NetworkEnumerationTools",
@@ -420,6 +433,10 @@ TOOL_TO_CATEGORY: dict[str, str] = {
     "forge_golden_ticket": "GoldenTicketTools",  # nosec B105
     "forge_silver_ticket": "GoldenTicketTools",
     "create_machine_account": "GoldenTicketTools",
+    # ReportingTools - Documentation and findings recording
+    "record_credential": "ReportingTools",
+    "record_weakness": "ReportingTools",
+    "record_timeline_event": "ReportingTools",
 }
 
 # =============================================================================
@@ -510,7 +527,7 @@ def get_tool_mitre_info(tool_name: str) -> tuple[str | None, str | None]:
 
     if technique_id:
         # Derive tactic from technique ID prefix patterns
-        if technique_id.startswith(("T1087", "T1018", "T1046", "T1135", "T1482")):
+        if technique_id.startswith(("T1087", "T1018", "T1046", "T1135", "T1482", "T1518")):
             tactic = "discovery"
         elif technique_id.startswith(("T1003", "T1558", "T1187", "T1557", "T1552", "T1110")):
             tactic = "credential-access"

--- a/src/ares/core/worker/_worker.py
+++ b/src/ares/core/worker/_worker.py
@@ -337,6 +337,7 @@ class RedisWorkerAgent:
 
         # Serialize discovered vulnerabilities (delegation, ADCS, etc.)
         if self.shared_state.discovered_vulnerabilities:
+            # Snapshot to avoid "dict changed size during iteration" from threaded consumer
             discoveries["discovered_vulnerabilities"] = [
                 {
                     "vuln_id": v.vuln_id,
@@ -347,7 +348,7 @@ class RedisWorkerAgent:
                     "priority": v.priority,
                     "recommended_agent": v.recommended_agent,
                 }
-                for v in self.shared_state.discovered_vulnerabilities.values()
+                for v in list(self.shared_state.discovered_vulnerabilities.values())
             ]
 
         return discoveries

--- a/src/ares/core/worker/prompts.py
+++ b/src/ares/core/worker/prompts.py
@@ -95,9 +95,10 @@ def format_state_context(
 
     # Pending vulns - compact
     if hasattr(state, "discovered_vulnerabilities") and state.discovered_vulnerabilities:
+        # Snapshot to avoid "dict changed size during iteration" from concurrent access
         unexploited = [
             v
-            for v in state.discovered_vulnerabilities.values()
+            for v in list(state.discovered_vulnerabilities.values())
             if v.vuln_id not in state.exploited_vulnerabilities
         ]
         if unexploited:

--- a/src/ares/main.py
+++ b/src/ares/main.py
@@ -511,6 +511,14 @@ async def main(
                         set_target_domains(target_domains)
                         logger.info(f"Evidence scope set to domains: {target_domains}")
 
+                    # Extract target deployment for Loki query scoping
+                    # This ensures blue team queries filter by deployment label,
+                    # avoiding noise from other environments in shared Grafana
+                    target_deployment = ""
+                    if state.target and state.target.environment:
+                        target_deployment = state.target.environment
+                        logger.info(f"Target deployment for Loki scoping: {target_deployment}")
+
                     attack_context = {
                         "operation_id": operation_id,
                         "playbook": playbook,
@@ -520,6 +528,7 @@ async def main(
                         "priority_queries": playbook.priority_queries[:10],
                         "detection_targets": playbook.detection_targets[:20],
                         "target_domains": list(target_domains),
+                        "deployment": target_deployment,
                     }
                     logger.success(f"Loaded red team operation: {operation_id}")
                     logger.info(

--- a/src/ares/templates/redteam/agents/orchestrator.md.jinja
+++ b/src/ares/templates/redteam/agents/orchestrator.md.jinja
@@ -62,7 +62,12 @@ Your role is to **delegate tasks to specialized worker agents** and coordinate t
    - Use `dispatch_esc8_attack(...)` for ESC8 - COERCION handles both relay and coercion
 
 6. **Queue Vulnerabilities** (for priority-based exploitation)
-   - `queue_vulnerability_for_exploitation(vuln_type="ADCS_ESC1", target="CA-NAME", ...)`
+   - `target` is ALWAYS a hostname or IP (like Metasploit's RHOSTS). NEVER use DOMAIN\User format.
+   - Account info goes in `details` JSON (like Metasploit's SMBUser/SMBDomain).
+   - Examples:
+     - `queue_vulnerability_for_exploitation(vuln_type="ADCS_ESC1", target="ca01.contoso.local", details='{"template": "VulnTemplate", "ca": "contoso-CA"}')`
+     - `queue_vulnerability_for_exploitation(vuln_type="domain_admin_hash", target="dc01.contoso.local", details='{"account": "Administrator", "domain": "contoso.local", "hash": "aad3b..."}')`
+     - `queue_vulnerability_for_exploitation(vuln_type="constrained_delegation", target="dc01.contoso.local", details='{"account_name": "svc_sql", "target_spn": "cifs/dc01.contoso.local"}')`
    - Automatically dispatched to PRIVESC worker
 
 5. **Monitor Progress**

--- a/src/ares/tools/red/orchestrator.py
+++ b/src/ares/tools/red/orchestrator.py
@@ -1586,8 +1586,15 @@ class OrchestratorTools(Toolset):
             vuln_type: Type of vulnerability (ADCS_ESC1, ADCS_ESC4, ADCS_ESC8,
                       krbtgt_hash, domain_admin_hash, acl_abuse,
                       unconstrained_delegation, constrained_delegation, etc.)
-            target: Target to exploit (CA name, server, user, etc.)
-            details: JSON string with vulnerability-specific details
+            target: Target HOST to exploit - must be hostname or IP address.
+                    NEVER use DOMAIN\\User format here. Account info goes in details.
+                    Examples: "dc01.contoso.local", "192.168.58.10", "ca01.contoso.local"
+            details: JSON string with vulnerability-specific details including account info.
+                    Examples by vuln_type:
+                    - domain_admin_hash: {"account": "Administrator", "domain": "contoso.local", "hash": "aad3b..."}
+                    - krbtgt_hash: {"account": "krbtgt", "domain": "contoso.local", "hash": "aad3b..."}
+                    - constrained_delegation: {"account_name": "svc_sql", "target_spn": "cifs/dc01.contoso.local"}
+                    - ADCS_ESC1: {"template": "VulnTemplate", "ca": "contoso-CA"}
 
         Returns:
             Confirmation with vulnerability ID and priority

--- a/src/ares/tools/red/reconnaissance.py
+++ b/src/ares/tools/red/reconnaissance.py
@@ -193,12 +193,74 @@ class NetworkEnumerationTools(Toolset):
         if not output:
             return []
         creds: list[tuple[str, str]] = []
+
+        # Check if output contains LDAP entries (dn: lines)
+        # LDAP entries need special handling because password can appear before username
+        if "\ndn:" in output or output.strip().lower().startswith("dn:"):
+            creds.extend(self._extract_passwords_from_ldap_entries(output))
+
+        # Also process line-by-line for non-LDAP formats (netexec, etc.)
+        creds.extend(self._extract_passwords_line_by_line(output))
+
+        # Deduplicate while preserving order
+        seen: set[tuple[str, str]] = set()
+        unique_creds: list[tuple[str, str]] = []
+        for cred in creds:
+            key = (cred[0].lower(), cred[1])
+            if key not in seen:
+                seen.add(key)
+                unique_creds.append(cred)
+        return unique_creds
+
+    def _extract_passwords_from_ldap_entries(self, output: str) -> list[tuple[str, str]]:
+        """Extract credentials from LDAP-formatted output.
+
+        LDAP entries start with 'dn:' and can have password (in description)
+        appear before sAMAccountName. We must parse each entry as a complete
+        unit to correctly associate passwords with usernames.
+        """
+        creds: list[tuple[str, str]] = []
+
+        # Split into LDAP entries (each starts with dn:)
+        entries = re.split(r"(?=^dn:)", output, flags=re.MULTILINE | re.IGNORECASE)
+
+        for entry in entries:
+            if not entry.strip():
+                continue
+
+            # Extract username from sAMAccountName
+            username = ""
+            sam_match = re.search(r"samaccountname:\s*([A-Za-z0-9_.-]+)", entry, re.IGNORECASE)
+            if sam_match:
+                username = sam_match.group(1).strip()
+
+            # Extract password from description or other fields
+            password = ""  # nosec B105 - initialization, not hardcoded password
+            pass_match = re.search(r"Password\s*:\s*([^\s()]+)", entry, re.IGNORECASE)
+            if pass_match:
+                password = pass_match.group(1).strip().rstrip(".,;:()")
+
+            if username and password:
+                creds.append((username, password))
+
+        return creds
+
+    def _extract_passwords_line_by_line(self, output: str) -> list[tuple[str, str]]:
+        """Extract credentials from line-based output (netexec, etc.)."""
+        creds: list[tuple[str, str]] = []
         current_user = ""
+
         for line in output.splitlines():
             stripped = line.strip()
             if not stripped:
                 continue
 
+            # Skip LDAP entry markers (handled by _extract_passwords_from_ldap_entries)
+            if stripped.lower().startswith("dn:"):
+                current_user = ""
+                continue
+
+            # Track current user from various patterns
             user_match = re.search(r"user:\[([^\]]+)\]", stripped, re.IGNORECASE)
             if user_match:
                 current_user = user_match.group(1).strip()
@@ -217,9 +279,9 @@ class NetworkEnumerationTools(Toolset):
             pass_match = re.search(r"Password\s*:\s*([^\s()]+)", stripped, re.IGNORECASE)
             if not pass_match:
                 continue
-            # Only strip clearly trailing punctuation, not ! which is common in passwords
             password = pass_match.group(1).strip().rstrip(".,;:()")
 
+            # Try to extract username from same line first
             username = ""
             account_inline = re.search(r"Account:\s*([A-Za-z0-9_.-]+)", stripped)
             if account_inline:
@@ -231,9 +293,6 @@ class NetworkEnumerationTools(Toolset):
                     username = user_inline.group(1).strip()
 
             if not username:
-                username = current_user
-
-            if not username:
                 netexec_match = re.match(
                     r"^SMB\s+\d+\.\d+\.\d+\.\d+\s+\d+\s+\S+\s+([A-Za-z0-9._-]+)\s+\d{4}-\d{2}-\d{2}",
                     stripped,
@@ -241,8 +300,14 @@ class NetworkEnumerationTools(Toolset):
                 if netexec_match:
                     username = netexec_match.group(1).strip()
 
+            # Only fall back to current_user for non-LDAP lines
+            # (LDAP entries are handled by _extract_passwords_from_ldap_entries)
+            if not username and current_user:
+                username = current_user
+
             if username and password:
                 creds.append((username, password))
+
         return creds
 
     def _add_credential(
@@ -413,11 +478,46 @@ class NetworkEnumerationTools(Toolset):
 
         def _parse_nmap_hosts(output: str) -> list[Host]:
             hosts: list[Host] = []
+            # Track domains discovered from LDAP banners in this scan
+            discovered_domains: set[str] = set()
             current_ip = ""
             current_hostname = ""
             current_os = ""
             current_domain = ""
             current_services: list[str] = []
+
+            def _fix_truncated_domain(hostname: str) -> str:
+                """Fix truncated domain suffixes using known domains."""
+                if not hostname or "." not in hostname:
+                    return hostname
+
+                parts = hostname.lower().split(".", 1)
+                if len(parts) != 2:
+                    return hostname
+
+                short_name, domain_suffix = parts
+
+                # Build list of known domains from state and this scan's discoveries
+                known_domains = {
+                    d.lower() for d in getattr(self.state, "all_domains", []) if self.state
+                }
+                known_domains.update(discovered_domains)
+
+                if domain_suffix in known_domains:
+                    return hostname  # Domain is valid
+
+                # Try to find a known domain that this could be a truncation of
+                # e.g., "north.local" might be truncated "north.sevenkingdoms.local"
+                domain_parts = domain_suffix.split(".")
+                if domain_parts:
+                    first_label = domain_parts[0]  # e.g., "north"
+                    for known in known_domains:
+                        if known.startswith(first_label + ".") and known != domain_suffix:
+                            corrected = f"{short_name}.{known}"
+                            logger.debug(f"Corrected truncated hostname: {hostname} -> {corrected}")
+                            return corrected
+
+                return hostname
 
             def _commit_current() -> None:
                 nonlocal current_hostname
@@ -427,6 +527,12 @@ class NetworkEnumerationTools(Toolset):
                 hostname_to_use = current_hostname
                 if current_hostname and current_domain and "." not in current_hostname:
                     hostname_to_use = f"{current_hostname.lower()}.{current_domain.lower()}"
+                    # Track the domain from LDAP for fixing other hosts
+                    discovered_domains.add(current_domain.lower())
+
+                # Try to fix truncated domain with currently known domains
+                hostname_to_use = _fix_truncated_domain(hostname_to_use)
+
                 # Detect DC based on services (LDAP + Kerberos = domain controller)
                 services_lower = [s.lower() for s in current_services]
                 has_ldap = any("ldap" in s for s in services_lower)
@@ -479,6 +585,8 @@ class NetworkEnumerationTools(Toolset):
                     domain_match = re.search(r"\(Domain:\s*([^,)]+)", line)
                     if domain_match and not current_domain:
                         current_domain = domain_match.group(1).strip()
+                        # Track discovered domains for fixing truncated hostnames
+                        discovered_domains.add(current_domain.lower())
                     # Parse Service Info line for Host and OS
                     # Format: "Service Info: Host: KINGSLANDING; OS: Windows; CPE: ..."
                     if "Service Info:" in line:
@@ -492,6 +600,16 @@ class NetworkEnumerationTools(Toolset):
                             current_os = os_match.group(1).strip()
 
             _commit_current()
+
+            # Second pass: fix any truncated hostnames now that we have all discovered domains
+            # This handles hosts parsed before their correct domain was discovered from LDAP
+            for host in hosts:
+                if host.hostname and "." in host.hostname:
+                    fixed = _fix_truncated_domain(host.hostname)
+                    if fixed != host.hostname:
+                        logger.debug(f"Second pass fix: {host.hostname} -> {fixed}")
+                        host.hostname = fixed
+
             return hosts
 
         def _hosts_to_dicts(hosts: list[Host]) -> list[dict[str, Any]]:

--- a/src/ares/tools/red/reconnaissance.py
+++ b/src/ares/tools/red/reconnaissance.py
@@ -663,9 +663,24 @@ class NetworkEnumerationTools(Toolset):
                                     re.MULTILINE,
                                 )
                                 if domain_match:
-                                    domain = domain_match.group(1).strip().lower()
-                                    # Build FQDN: hostname.domain.local (assume .local TLD)
-                                    host.hostname = f"{netbios_name.lower()}.{domain}.local"
+                                    netbios_domain = domain_match.group(1).strip().lower()
+                                    # Resolve NetBIOS domain to FQDN using state if available
+                                    # e.g., "NORTH" -> "north.sevenkingdoms.local"
+                                    if self.state and hasattr(
+                                        self.state, "_resolve_netbios_to_fqdn"
+                                    ):
+                                        fqdn_domain = self.state._resolve_netbios_to_fqdn(
+                                            netbios_domain
+                                        )
+                                        # Only use resolved domain if it's an FQDN (contains dot)
+                                        # Otherwise just use short name without wrong assumptions
+                                        if "." in fqdn_domain:
+                                            host.hostname = f"{netbios_name.lower()}.{fqdn_domain}"
+                                        else:
+                                            host.hostname = netbios_name.lower()
+                                    else:
+                                        # Fallback: just use NetBIOS name without domain assumption
+                                        host.hostname = netbios_name.lower()
                                 else:
                                     host.hostname = netbios_name.lower()
                                 logger.info(

--- a/tests/core/dispatcher/test_deferred_queue.py
+++ b/tests/core/dispatcher/test_deferred_queue.py
@@ -461,6 +461,54 @@ class TestDeferredQueueMixin:
         assert await fake_redis.zcard(self._queue_key(dispatcher, "lateral")) == 0
         assert await fake_redis.zcard(self._queue_key(dispatcher, "exploit")) == 0
 
+    @pytest.mark.asyncio
+    async def test_get_deferred_for_starved_roles(self, dispatcher, fake_redis):
+        """Should return one task per starved role (roles with 0 pending tasks)."""
+        from ares.core.models import TaskInfo, TaskStatus
+
+        # Add tasks for multiple roles
+        await dispatcher._enqueue_deferred_task(
+            task_type="credential_access",
+            target_role="credential",
+            payload={"target": "dc01.contoso.local"},
+            source_agent="orchestrator",
+            priority=4,
+        )
+        await dispatcher._enqueue_deferred_task(
+            task_type="lateral",
+            target_role="lateral",
+            payload={"target": "192.168.58.10"},
+            source_agent="orchestrator",
+            priority=5,
+        )
+        await dispatcher._enqueue_deferred_task(
+            task_type="recon",
+            target_role="recon",
+            payload={"target": "192.168.58.0/24"},
+            source_agent="orchestrator",
+            priority=6,
+        )
+
+        # Simulate lateral role having 1 pending task (not starved)
+        dispatcher._shared_state.pending_tasks["task-1"] = TaskInfo(
+            task_id="task-1",
+            task_type="lateral",
+            assigned_agent="lateral",
+            params={},
+            status=TaskStatus.IN_PROGRESS,
+        )
+
+        # Get deferred tasks for starved roles (credential, recon are starved)
+        tasks = await dispatcher._get_deferred_for_starved_roles()
+
+        # Should get 2 tasks (credential and recon), not lateral
+        assert len(tasks) == 2
+        target_roles = {t.target_role for t in tasks}
+        assert target_roles == {"credential", "recon"}
+
+        # Lateral task should remain in queue
+        assert await fake_redis.zcard(self._queue_key(dispatcher, "lateral")) == 1
+
 
 class TestGlobalQueueLimits:
     """Tests for global deferred queue limits (get_max_deferred_total())."""

--- a/tests/core/orchestrator/test_orchestrator.py
+++ b/tests/core/orchestrator/test_orchestrator.py
@@ -1080,7 +1080,10 @@ class TestDirectNmapNetBIOSEnrichment:
 
         assert len(hosts) == 1
         assert hosts[0].ip == "192.168.58.11"
-        assert hosts[0].hostname == "sql01.contoso.local"
+        # Only NetBIOS name - we don't construct fake FQDNs like "sql01.contoso.local"
+        # because we don't know the actual domain suffix. The FQDN will be discovered
+        # via DNS/LDAP enumeration.
+        assert hosts[0].hostname == "sql01"
 
     @pytest.mark.asyncio
     async def test_netbios_enrichment_skips_aws_hostnames(self, monkeypatch):

--- a/tests/core/test_circuit_breaker.py
+++ b/tests/core/test_circuit_breaker.py
@@ -1,0 +1,466 @@
+"""Unit tests for circuit breaker and error debouncing.
+
+Tests the Redis circuit breaker pattern that prevents thundering herd
+during Redis outages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from ares.core.circuit_breaker import (
+    CircuitBreakerError,
+    CircuitBreakerListener,
+    CircuitState,
+    DebouncedErrorLogger,
+    LoggingCircuitListener,
+    RedisCircuitBreaker,
+    RedisHealthMonitor,
+    reset_circuit_breaker_state,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_globals():
+    """Reset global circuit breaker state between tests."""
+    reset_circuit_breaker_state()
+    yield
+    reset_circuit_breaker_state()
+
+
+# ============================================================================
+# RedisCircuitBreaker Tests
+# ============================================================================
+
+
+class TestRedisCircuitBreaker:
+    """Tests for RedisCircuitBreaker."""
+
+    async def test_initial_state_is_closed(self):
+        """Circuit starts in closed state."""
+        circuit = RedisCircuitBreaker("test")
+        assert circuit.state == CircuitState.CLOSED
+        assert circuit.is_closed
+        assert not circuit.is_open
+        assert circuit.failure_count == 0
+
+    async def test_allows_request_when_closed(self):
+        """Closed circuit allows requests."""
+        circuit = RedisCircuitBreaker("test")
+        assert await circuit.allow_request()
+
+    async def test_opens_after_fail_max_failures(self):
+        """Circuit opens after reaching failure threshold."""
+        circuit = RedisCircuitBreaker("test", fail_max=3)
+
+        # Record failures up to threshold
+        for i in range(3):
+            await circuit.record_failure(Exception(f"error {i}"))
+
+        assert circuit.state == CircuitState.OPEN
+        assert circuit.is_open
+        assert not circuit.is_closed
+
+    async def test_rejects_request_when_open(self):
+        """Open circuit rejects requests."""
+        circuit = RedisCircuitBreaker("test", fail_max=1)
+        await circuit.record_failure(Exception("error"))
+
+        assert circuit.is_open
+        assert not await circuit.allow_request()
+
+    async def test_transitions_to_half_open_after_timeout(self):
+        """Circuit transitions to half-open after reset timeout."""
+        circuit = RedisCircuitBreaker("test", fail_max=1, reset_timeout=0.1)
+        await circuit.record_failure(Exception("error"))
+
+        assert circuit.is_open
+
+        # Wait for timeout
+        await asyncio.sleep(0.15)
+
+        # Check state transitions to half-open
+        assert await circuit.allow_request()
+        assert circuit.state == CircuitState.HALF_OPEN
+
+    async def test_closes_on_success_in_half_open(self):
+        """Successful request in half-open closes circuit."""
+        circuit = RedisCircuitBreaker("test", fail_max=1, reset_timeout=0.1)
+        await circuit.record_failure(Exception("error"))
+
+        await asyncio.sleep(0.15)
+        await circuit.allow_request()  # Transition to half-open
+
+        # Record success
+        await circuit.record_success()
+
+        assert circuit.state == CircuitState.CLOSED
+        assert circuit.failure_count == 0
+
+    async def test_reopens_on_failure_in_half_open(self):
+        """Failure in half-open reopens circuit."""
+        circuit = RedisCircuitBreaker("test", fail_max=1, reset_timeout=0.1)
+        await circuit.record_failure(Exception("error"))
+
+        await asyncio.sleep(0.15)
+        await circuit.allow_request()  # Transition to half-open
+
+        # Record another failure
+        await circuit.record_failure(Exception("still broken"))
+
+        assert circuit.state == CircuitState.OPEN
+
+    async def test_success_resets_failure_count_when_closed(self):
+        """Success resets failure count in closed state."""
+        circuit = RedisCircuitBreaker("test", fail_max=5)
+
+        # Record some failures
+        await circuit.record_failure(Exception("error 1"))
+        await circuit.record_failure(Exception("error 2"))
+        assert circuit.failure_count == 2
+
+        # Record success
+        await circuit.record_success()
+        assert circuit.failure_count == 0
+        assert circuit.is_closed
+
+    async def test_protect_context_manager_success(self):
+        """Protect context manager records success on normal exit."""
+        circuit = RedisCircuitBreaker("test")
+
+        async with circuit.protect():
+            pass  # Successful operation
+
+        assert circuit.failure_count == 0
+
+    async def test_protect_context_manager_failure(self):
+        """Protect context manager records failure on exception."""
+        circuit = RedisCircuitBreaker("test", fail_max=1)
+
+        with pytest.raises(ValueError, match="test error"):
+            async with circuit.protect():
+                raise ValueError("test error")
+
+        assert circuit.is_open
+
+    async def test_protect_raises_when_open(self):
+        """Protect raises CircuitBreakerError when circuit is open."""
+        circuit = RedisCircuitBreaker("test", fail_max=1, reset_timeout=30)
+        await circuit.record_failure(Exception("error"))
+
+        with pytest.raises(CircuitBreakerError) as exc_info:
+            async with circuit.protect():
+                pass
+
+        assert exc_info.value.circuit_name == "test"
+        assert exc_info.value.remaining_time > 0
+
+    async def test_get_status(self):
+        """Get status returns current circuit state."""
+        circuit = RedisCircuitBreaker("test", fail_max=5, reset_timeout=30)
+
+        status = circuit.get_status()
+        assert status["name"] == "test"
+        assert status["state"] == "closed"
+        assert status["failure_count"] == 0
+        assert status["fail_max"] == 5
+        assert status["reset_timeout"] == 30
+
+    async def test_listener_notified_on_state_change(self):
+        """Listeners are notified on state changes."""
+
+        class TestListener(CircuitBreakerListener):
+            def __init__(self):
+                self.changes = []
+
+            def on_state_change_sync(self, circuit_name, old_state, new_state):
+                self.changes.append((circuit_name, old_state, new_state))
+
+        circuit = RedisCircuitBreaker("test", fail_max=1, reset_timeout=0.1)
+        listener = TestListener()
+        circuit.add_listener(listener)
+
+        # Trigger CLOSED -> OPEN
+        await circuit.record_failure(Exception("error"))
+        assert len(listener.changes) == 1
+        assert listener.changes[0] == ("test", CircuitState.CLOSED, CircuitState.OPEN)
+
+        # Wait for OPEN -> HALF_OPEN
+        await asyncio.sleep(0.15)
+        await circuit.allow_request()
+        assert len(listener.changes) == 2
+        assert listener.changes[1] == ("test", CircuitState.OPEN, CircuitState.HALF_OPEN)
+
+        # Trigger HALF_OPEN -> CLOSED
+        await circuit.record_success()
+        assert len(listener.changes) == 3
+        assert listener.changes[2] == ("test", CircuitState.HALF_OPEN, CircuitState.CLOSED)
+
+
+# ============================================================================
+# DebouncedErrorLogger Tests
+# ============================================================================
+
+
+class TestDebouncedErrorLogger:
+    """Tests for DebouncedErrorLogger."""
+
+    async def test_logs_first_error(self):
+        """First error is always logged."""
+        debouncer = DebouncedErrorLogger(window_sec=10)
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            logged = await debouncer.log_error("test_key", "Test error message")
+
+        assert logged
+        mock_logger.warning.assert_called_once()
+
+    async def test_suppresses_duplicate_within_window(self):
+        """Duplicate errors within window are suppressed."""
+        debouncer = DebouncedErrorLogger(window_sec=10)
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            # First error logs
+            await debouncer.log_error("test_key", "Error 1")
+            # Second error suppressed
+            logged = await debouncer.log_error("test_key", "Error 2")
+
+        assert not logged
+        mock_logger.warning.assert_called_once()
+
+    async def test_logs_after_window_expires(self):
+        """Error is logged after window expires."""
+        debouncer = DebouncedErrorLogger(window_sec=0.1)
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            await debouncer.log_error("test_key", "Error 1")
+            await asyncio.sleep(0.15)
+            logged = await debouncer.log_error("test_key", "Error 2")
+
+        assert logged
+        assert mock_logger.warning.call_count == 2
+
+    async def test_includes_suppression_count(self):
+        """Logged message includes count of suppressed errors."""
+        debouncer = DebouncedErrorLogger(window_sec=0.1)
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            await debouncer.log_error("test_key", "Error 1")
+            await debouncer.log_error("test_key", "Error 2")
+            await debouncer.log_error("test_key", "Error 3")
+            await asyncio.sleep(0.15)
+            await debouncer.log_error("test_key", "Error 4")
+
+        # Last call should include suppression count
+        last_call = mock_logger.warning.call_args[0][0]
+        assert "suppressed 2 similar" in last_call
+
+    async def test_different_keys_logged_independently(self):
+        """Different error keys are logged independently."""
+        debouncer = DebouncedErrorLogger(window_sec=10)
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            await debouncer.log_error("key1", "Error type 1")
+            await debouncer.log_error("key2", "Error type 2")
+
+        assert mock_logger.warning.call_count == 2
+
+    async def test_flush_logs_pending_counts(self):
+        """Flush logs any pending suppression counts."""
+        debouncer = DebouncedErrorLogger(window_sec=10)
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            await debouncer.log_error("test_key", "Error 1")
+            await debouncer.log_error("test_key", "Error 2")
+            await debouncer.log_error("test_key", "Error 3")
+            await debouncer.flush()
+
+        # Should log info about suppressed errors
+        mock_logger.info.assert_called()
+        info_call = mock_logger.info.call_args[0][0]
+        assert "Suppressed 2" in info_call
+
+    async def test_respects_log_level(self):
+        """Uses specified log level."""
+        debouncer = DebouncedErrorLogger(window_sec=10)
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            await debouncer.log_error("test_key", "Error", level="error")
+
+        mock_logger.error.assert_called_once()
+
+
+# ============================================================================
+# RedisHealthMonitor Tests
+# ============================================================================
+
+
+class TestRedisHealthMonitor:
+    """Tests for RedisHealthMonitor."""
+
+    async def test_starts_healthy(self):
+        """Monitor starts in healthy state."""
+        monitor = RedisHealthMonitor()
+        assert monitor.is_healthy
+
+    async def test_mark_unhealthy(self):
+        """Marking unhealthy clears healthy flag."""
+        monitor = RedisHealthMonitor()
+        monitor.mark_unhealthy()
+        assert not monitor.is_healthy
+
+    async def test_mark_healthy_after_unhealthy(self):
+        """Marking healthy sets healthy flag."""
+        monitor = RedisHealthMonitor()
+        monitor.mark_unhealthy()
+        monitor.mark_healthy()
+        assert monitor.is_healthy
+
+    async def test_wait_for_healthy_immediate(self):
+        """Wait returns immediately when healthy."""
+        monitor = RedisHealthMonitor()
+        result = await monitor.wait_for_healthy(timeout=0.1)
+        assert result
+
+    async def test_wait_for_healthy_timeout(self):
+        """Wait times out when unhealthy."""
+        monitor = RedisHealthMonitor()
+        monitor.mark_unhealthy()
+        result = await monitor.wait_for_healthy(timeout=0.1)
+        assert not result
+
+    async def test_wait_for_healthy_becomes_healthy(self):
+        """Wait returns when health is restored."""
+        monitor = RedisHealthMonitor()
+        monitor.mark_unhealthy()
+
+        async def restore_health():
+            await asyncio.sleep(0.05)
+            monitor.mark_healthy()
+
+        task = asyncio.create_task(restore_health())
+        result = await monitor.wait_for_healthy(timeout=1.0)
+        await task  # Ensure task completes
+        assert result
+
+    async def test_circuit_breaker_affects_health(self):
+        """Open circuit breaker makes monitor report unhealthy."""
+        circuit = RedisCircuitBreaker("test", fail_max=1)
+        monitor = RedisHealthMonitor(circuit)
+
+        assert monitor.is_healthy
+
+        await circuit.record_failure(Exception("error"))
+        assert not monitor.is_healthy
+
+    async def test_get_status(self):
+        """Get status returns current health state."""
+        circuit = RedisCircuitBreaker("test")
+        monitor = RedisHealthMonitor(circuit)
+
+        status = monitor.get_status()
+        assert status["is_healthy"]
+        assert status["consecutive_failures"] == 0
+        assert status["circuit_state"] == "closed"
+
+
+# ============================================================================
+# LoggingCircuitListener Tests
+# ============================================================================
+
+
+class TestLoggingCircuitListener:
+    """Tests for LoggingCircuitListener."""
+
+    async def test_logs_open_state(self):
+        """Logs error when circuit opens."""
+        listener = LoggingCircuitListener()
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            listener.on_state_change_sync("test", CircuitState.CLOSED, CircuitState.OPEN)
+
+        mock_logger.error.assert_called_once()
+        assert "OPENED" in mock_logger.error.call_args[0][0]
+
+    async def test_logs_closed_state(self):
+        """Logs info when circuit closes."""
+        listener = LoggingCircuitListener()
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            listener.on_state_change_sync("test", CircuitState.HALF_OPEN, CircuitState.CLOSED)
+
+        mock_logger.info.assert_called_once()
+        assert "CLOSED" in mock_logger.info.call_args[0][0]
+
+    async def test_logs_half_open_state(self):
+        """Logs info when circuit enters half-open."""
+        listener = LoggingCircuitListener()
+
+        with patch("ares.core.circuit_breaker.logger") as mock_logger:
+            listener.on_state_change_sync("test", CircuitState.OPEN, CircuitState.HALF_OPEN)
+
+        mock_logger.info.assert_called_once()
+        assert "recovery" in mock_logger.info.call_args[0][0].lower()
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestCircuitBreakerIntegration:
+    """Integration tests for circuit breaker with Redis operations."""
+
+    async def test_multiple_concurrent_failures_open_circuit_once(self):
+        """Multiple concurrent failures only open circuit once."""
+        circuit = RedisCircuitBreaker("test", fail_max=3)
+
+        # Simulate multiple concurrent failures (thundering herd)
+        failures = [circuit.record_failure(Exception(f"error {i}")) for i in range(5)]
+        await asyncio.gather(*failures)
+
+        # Circuit should be open
+        assert circuit.is_open
+        # Failure count should be 5 (all recorded)
+        assert circuit.failure_count == 5
+
+    async def test_circuit_prevents_further_requests(self):
+        """Open circuit prevents further request attempts."""
+        circuit = RedisCircuitBreaker("test", fail_max=1, reset_timeout=30)
+
+        # Open circuit
+        await circuit.record_failure(Exception("error"))
+
+        # Try multiple requests - all should be rejected
+        results = await asyncio.gather(*[circuit.allow_request() for _ in range(10)])
+
+        assert all(not r for r in results)
+
+    async def test_shared_circuit_across_tasks(self):
+        """Multiple tasks share the same circuit state."""
+        circuit = RedisCircuitBreaker("test", fail_max=2)
+
+        async def task_that_fails():
+            try:
+                async with circuit.protect():
+                    raise ConnectionError("Redis down")
+            except ConnectionError:
+                pass
+
+        # Two tasks fail
+        await asyncio.gather(task_that_fails(), task_that_fails())
+
+        # Circuit should now be open
+        assert circuit.is_open
+
+        # Third task should be rejected immediately
+        with pytest.raises(CircuitBreakerError):
+            async with circuit.protect():
+                pass

--- a/tests/core/test_dict_iteration_safety.py
+++ b/tests/core/test_dict_iteration_safety.py
@@ -806,27 +806,42 @@ class TestOrchestratorVulnerabilityIterationSafety:
     """Tests for orchestrator vulnerability iteration safety."""
 
     @pytest.mark.asyncio
-    async def test_has_constrained_delegation_for_target_with_concurrent_modification(
+    async def test_has_exploitable_constrained_delegation_with_concurrent_modification(
         self, state_with_vulnerabilities: SharedRedTeamState
     ):
-        """Test _has_constrained_delegation_for_target handles concurrent modification."""
-        from ares.core.models import VulnerabilityInfo
-        from ares.core.orchestrator._orchestrator import _has_constrained_delegation_for_target
+        """Test _has_exploitable_constrained_delegation_for_target handles concurrent modification."""
+        from ares.core.models import Credential, VulnerabilityInfo
+        from ares.core.orchestrator._orchestrator import (
+            _has_exploitable_constrained_delegation_for_target,
+        )
 
-        # Add a constrained delegation vulnerability with target_ip
+        # Add a credential for the delegated account (required for exploitability)
+        cred = Credential(
+            username="svc_sql",
+            password="P@ssw0rd!",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="test",
+        )
+        state_with_vulnerabilities.add_credential(cred, source_agent="test")
+
+        # Add a constrained delegation vulnerability with target_ip and account_name
         vuln = VulnerabilityInfo(
             vuln_id="cd_vuln_test",
             vuln_type="constrained_delegation",
             target="192.168.58.50",
-            details={"target_ip": "192.168.58.50", "target_spn": "cifs/dc01.contoso.local"},
+            details={
+                "target_ip": "192.168.58.50",
+                "target_spn": "cifs/dc01.contoso.local",
+                "account_name": "svc_sql",
+            },
             discovered_by="recon",
         )
         state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln
 
         async def check_delegation():
-            """Repeatedly call _has_constrained_delegation_for_target."""
+            """Repeatedly call _has_exploitable_constrained_delegation_for_target."""
             for _ in range(20):
-                result = _has_constrained_delegation_for_target(
+                result = _has_exploitable_constrained_delegation_for_target(
                     state_with_vulnerabilities, "192.168.58.50"
                 )
                 assert isinstance(result, bool)
@@ -840,7 +855,7 @@ class TestOrchestratorVulnerabilityIterationSafety:
                     vuln_id=f"cd_concurrent_vuln_{i}",
                     vuln_type="constrained_delegation",
                     target=f"192.168.58.{i}",
-                    details={"target_ip": f"192.168.58.{i}"},
+                    details={"target_ip": f"192.168.58.{i}", "account_name": "svc_sql"},
                     discovered_by="recon",
                 )
                 state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln

--- a/tests/core/test_dict_iteration_safety.py
+++ b/tests/core/test_dict_iteration_safety.py
@@ -561,5 +561,339 @@ class TestConcurrentDictModificationStress:
         )
 
 
+# ============================================================================
+# Discovered Vulnerabilities Dict Tests
+# ============================================================================
+
+
+@pytest.fixture
+def state_with_vulnerabilities() -> SharedRedTeamState:
+    """Create a state with discovered vulnerabilities for testing."""
+    from ares.core.models import VulnerabilityInfo
+
+    state = SharedRedTeamState(
+        operation_id="test-op-vuln-safety",
+        target=Target(ip="192.168.58.10", hostname="dc01.contoso.local", domain="contoso.local"),
+    )
+
+    # Add multiple vulnerabilities
+    for i in range(10):
+        vuln = VulnerabilityInfo(
+            vuln_id=f"vuln_{i:03d}",
+            vuln_type="constrained_delegation" if i % 2 == 0 else "local_admin",
+            target=f"192.168.58.{10 + i}",
+            details={"account_name": f"svc_{i}", "domain": "contoso.local"},
+            discovered_by="recon",
+        )
+        state.discovered_vulnerabilities[vuln.vuln_id] = vuln
+
+    return state
+
+
+class TestDiscoveredVulnerabilitiesDictSafety:
+    """Tests for dict iteration safety with discovered_vulnerabilities."""
+
+    @pytest.mark.asyncio
+    async def test_add_vulnerability_with_concurrent_modification(
+        self, state_with_vulnerabilities: SharedRedTeamState
+    ):
+        """Test add_vulnerability dedup check handles concurrent dict modification."""
+        from ares.core.models import VulnerabilityInfo
+
+        async def add_vulns():
+            """Add multiple vulnerabilities concurrently."""
+            for i in range(20, 30):
+                vuln = VulnerabilityInfo(
+                    vuln_id=f"new_vuln_{i}",
+                    vuln_type="mssql_linked_server",
+                    target=f"192.168.58.{i}",
+                    details={},
+                    discovered_by="recon",
+                )
+                # This iterates discovered_vulnerabilities.values() for dedup
+                state_with_vulnerabilities.add_vulnerability(vuln)
+                await asyncio.sleep(0)
+
+        async def modify_dict():
+            """Modify dict during iteration."""
+            for i in range(30, 40):
+                await asyncio.sleep(0)
+                vuln = VulnerabilityInfo(
+                    vuln_id=f"concurrent_vuln_{i}",
+                    vuln_type="esc1",
+                    target=f"192.168.58.{i}",
+                    details={},
+                    discovered_by="lateral",
+                )
+                state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln
+
+        # Should complete without RuntimeError
+        await asyncio.gather(add_vulns(), modify_dict())
+
+        # Verify vulns were added
+        assert len(state_with_vulnerabilities.discovered_vulnerabilities) >= 20
+
+    @pytest.mark.asyncio
+    async def test_get_unexploited_vulnerabilities_with_concurrent_modification(
+        self, state_with_vulnerabilities: SharedRedTeamState
+    ):
+        """Test get_unexploited_vulnerabilities handles concurrent dict modification."""
+        from ares.core.models import VulnerabilityInfo
+
+        async def get_unexploited():
+            """Repeatedly call get_unexploited_vulnerabilities."""
+            for _ in range(20):
+                vulns = state_with_vulnerabilities.get_unexploited_vulnerabilities()
+                assert isinstance(vulns, list)
+                await asyncio.sleep(0)
+
+        async def modify_dict():
+            """Add/remove vulnerabilities during iteration."""
+            for i in range(50, 60):
+                await asyncio.sleep(0)
+                vuln_id = f"temp_vuln_{i}"
+                vuln = VulnerabilityInfo(
+                    vuln_id=vuln_id,
+                    vuln_type="dcsync",
+                    target=f"192.168.58.{i}",
+                    details={},
+                    discovered_by="privesc",
+                )
+                state_with_vulnerabilities.discovered_vulnerabilities[vuln_id] = vuln
+                await asyncio.sleep(0)
+                if vuln_id in state_with_vulnerabilities.discovered_vulnerabilities:
+                    del state_with_vulnerabilities.discovered_vulnerabilities[vuln_id]
+
+        # Should complete without RuntimeError
+        await asyncio.gather(get_unexploited(), modify_dict())
+
+    @pytest.mark.asyncio
+    async def test_check_golden_ticket_capability_with_concurrent_modification(
+        self, state_with_vulnerabilities: SharedRedTeamState
+    ):
+        """Test check_golden_ticket_capability handles concurrent dict modification."""
+        from ares.core.models import Host, VulnerabilityInfo
+
+        # Add a DC host
+        dc_host = Host(
+            ip="192.168.58.10",
+            hostname="dc01.contoso.local",
+            is_dc=True,
+            services=["ldap", "kerberos"],
+        )
+        state_with_vulnerabilities.all_hosts.append(dc_host)
+
+        # Add a local_admin vuln for the DC
+        vuln = VulnerabilityInfo(
+            vuln_id="local_admin_dc",
+            vuln_type="local_admin",
+            target="192.168.58.10",
+            details={"username": "testuser", "domain": "contoso.local"},
+            discovered_by="bloodhound",
+        )
+        state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln
+
+        async def check_golden_ticket():
+            """Repeatedly call check_golden_ticket_capability."""
+            for _ in range(20):
+                result = state_with_vulnerabilities.check_golden_ticket_capability(
+                    "testuser", "contoso.local"
+                )
+                assert isinstance(result, list)
+                await asyncio.sleep(0)
+
+        async def modify_dict():
+            """Add vulnerabilities during iteration."""
+            for i in range(60, 70):
+                await asyncio.sleep(0)
+                vuln = VulnerabilityInfo(
+                    vuln_id=f"golden_test_vuln_{i}",
+                    vuln_type="local_admin",
+                    target=f"192.168.58.{i}",
+                    details={"username": f"user_{i}", "domain": "contoso.local"},
+                    discovered_by="recon",
+                )
+                state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln
+
+        # Should complete without RuntimeError
+        await asyncio.gather(check_golden_ticket(), modify_dict())
+
+    @pytest.mark.asyncio
+    async def test_weaknesses_property_with_concurrent_modification(
+        self, state_with_vulnerabilities: SharedRedTeamState
+    ):
+        """Test weaknesses property handles concurrent dict modification."""
+        from ares.core.models import VulnerabilityInfo
+
+        async def read_weaknesses():
+            """Repeatedly access weaknesses property."""
+            for _ in range(20):
+                weaknesses = state_with_vulnerabilities.weaknesses
+                assert isinstance(weaknesses, list)
+                await asyncio.sleep(0)
+
+        async def modify_dict():
+            """Add vulnerabilities during iteration."""
+            for i in range(70, 80):
+                await asyncio.sleep(0)
+                vuln = VulnerabilityInfo(
+                    vuln_id=f"weakness_test_vuln_{i}",
+                    vuln_type="unconstrained_delegation",
+                    target=f"192.168.58.{i}",
+                    details={},
+                    discovered_by="recon",
+                )
+                state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln
+
+        # Should complete without RuntimeError
+        await asyncio.gather(read_weaknesses(), modify_dict())
+
+    @pytest.mark.asyncio
+    async def test_discovered_vulnerabilities_rapid_stress(
+        self, state_with_vulnerabilities: SharedRedTeamState
+    ):
+        """Stress test rapid concurrent modifications to discovered_vulnerabilities."""
+        from ares.core.models import VulnerabilityInfo
+
+        async def reader():
+            """Continuously iterate over vulnerabilities."""
+            for _ in range(50):
+                try:
+                    # Simulate snapshot iteration like the fixed code
+                    vulns = [
+                        v
+                        for v in list(
+                            state_with_vulnerabilities.discovered_vulnerabilities.values()
+                        )
+                        if v.vuln_type == "constrained_delegation"
+                    ]
+                    assert isinstance(vulns, list)
+                except RuntimeError as e:
+                    if "dictionary changed size" in str(e):
+                        pytest.fail(
+                            "Dict changed size during iteration - "
+                            "discovered_vulnerabilities fix not applied?"
+                        )
+                    raise
+                await asyncio.sleep(0)
+
+        async def writer():
+            """Continuously add/remove vulnerabilities."""
+            for i in range(50):
+                vuln_id = f"stress_vuln_{i}"
+                vuln = VulnerabilityInfo(
+                    vuln_id=vuln_id,
+                    vuln_type="constrained_delegation",
+                    target=f"192.168.58.{100 + i}",
+                    details={},
+                    discovered_by="stress_test",
+                )
+                state_with_vulnerabilities.discovered_vulnerabilities[vuln_id] = vuln
+                await asyncio.sleep(0)
+                if vuln_id in state_with_vulnerabilities.discovered_vulnerabilities:
+                    del state_with_vulnerabilities.discovered_vulnerabilities[vuln_id]
+
+        # Run readers and writers concurrently
+        await asyncio.gather(
+            reader(),
+            reader(),
+            writer(),
+            writer(),
+        )
+
+
+class TestOrchestratorVulnerabilityIterationSafety:
+    """Tests for orchestrator vulnerability iteration safety."""
+
+    @pytest.mark.asyncio
+    async def test_has_constrained_delegation_for_target_with_concurrent_modification(
+        self, state_with_vulnerabilities: SharedRedTeamState
+    ):
+        """Test _has_constrained_delegation_for_target handles concurrent modification."""
+        from ares.core.models import VulnerabilityInfo
+        from ares.core.orchestrator._orchestrator import _has_constrained_delegation_for_target
+
+        # Add a constrained delegation vulnerability with target_ip
+        vuln = VulnerabilityInfo(
+            vuln_id="cd_vuln_test",
+            vuln_type="constrained_delegation",
+            target="192.168.58.50",
+            details={"target_ip": "192.168.58.50", "target_spn": "cifs/dc01.contoso.local"},
+            discovered_by="recon",
+        )
+        state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln
+
+        async def check_delegation():
+            """Repeatedly call _has_constrained_delegation_for_target."""
+            for _ in range(20):
+                result = _has_constrained_delegation_for_target(
+                    state_with_vulnerabilities, "192.168.58.50"
+                )
+                assert isinstance(result, bool)
+                await asyncio.sleep(0)
+
+        async def modify_dict():
+            """Add vulnerabilities during iteration."""
+            for i in range(80, 90):
+                await asyncio.sleep(0)
+                vuln = VulnerabilityInfo(
+                    vuln_id=f"cd_concurrent_vuln_{i}",
+                    vuln_type="constrained_delegation",
+                    target=f"192.168.58.{i}",
+                    details={"target_ip": f"192.168.58.{i}"},
+                    discovered_by="recon",
+                )
+                state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln
+
+        # Should complete without RuntimeError
+        await asyncio.gather(check_delegation(), modify_dict())
+
+
+class TestPublishingVulnerabilityIterationSafety:
+    """Tests for publishing mixin vulnerability iteration safety."""
+
+    @pytest.mark.asyncio
+    async def test_auto_queue_mssql_with_concurrent_modification(
+        self, state_with_vulnerabilities: SharedRedTeamState
+    ):
+        """Test _auto_queue_mssql_from_host handles concurrent modification."""
+        from ares.core.models import Host, VulnerabilityInfo
+
+        # Simulate the iteration pattern in _auto_queue_mssql_from_host
+        host = Host(
+            ip="192.168.58.99",
+            hostname="sql01.contoso.local",
+            services=["mssql", "1433"],
+        )
+
+        async def check_mssql_dedup():
+            """Simulate the MSSQL dedup check."""
+            for _ in range(20):
+                # This is what the fixed code does - snapshot iteration
+                existing_vulns = list(
+                    state_with_vulnerabilities.discovered_vulnerabilities.values()
+                )
+                for vuln in existing_vulns:
+                    if vuln.target == host.ip and vuln.vuln_type.startswith("mssql_"):
+                        pass  # Found duplicate
+                await asyncio.sleep(0)
+
+        async def modify_dict():
+            """Add MSSQL vulnerabilities during iteration."""
+            for i in range(90, 100):
+                await asyncio.sleep(0)
+                vuln = VulnerabilityInfo(
+                    vuln_id=f"mssql_vuln_{i}",
+                    vuln_type="mssql_linked_server",
+                    target=f"192.168.58.{i}",
+                    details={},
+                    discovered_by="recon",
+                )
+                state_with_vulnerabilities.discovered_vulnerabilities[vuln.vuln_id] = vuln
+
+        # Should complete without RuntimeError
+        await asyncio.gather(check_mssql_dedup(), modify_dict())
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -2226,3 +2226,265 @@ class TestAttackChainConsistency:
         # da_hash_id should still be the first one
         assert state.da_hash_id == first_da_hash_id
         assert state.da_hash_id == hash1.id
+
+
+class TestResolveHostnameToFQDN:
+    """Tests for SharedRedTeamState.resolve_hostname_to_fqdn.
+
+    This method normalizes hostnames to canonical FQDNs at the span emission layer.
+    It handles NetBIOS names (WINTERFELL), short names (winterfell), and wrong
+    domain suffixes (winterfell.sevenkingdoms.local -> winterfell.north.sevenkingdoms.local).
+    """
+
+    def test_resolves_netbios_to_fqdn(self) -> None:
+        """Test that NetBIOS hostname is resolved to FQDN from all_hosts."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+            Host(ip="192.168.58.20", hostname="sql01.contoso.local"),
+        ]
+
+        # NetBIOS "DC01" should resolve to "dc01.contoso.local"
+        result = state.resolve_hostname_to_fqdn("DC01")
+        assert result == "dc01.contoso.local"
+
+    def test_resolves_lowercase_short_hostname(self) -> None:
+        """Test that lowercase short hostname is resolved to FQDN."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+        ]
+
+        # Lowercase "dc01" should resolve to "dc01.contoso.local"
+        result = state.resolve_hostname_to_fqdn("dc01")
+        assert result == "dc01.contoso.local"
+
+    def test_corrects_wrong_domain_suffix(self) -> None:
+        """Test that wrong domain suffix is corrected to canonical FQDN."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        # The canonical FQDN is in the child domain
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.child.contoso.local"),
+        ]
+
+        # Wrong domain suffix should be corrected
+        result = state.resolve_hostname_to_fqdn("dc01.contoso.local")
+        assert result == "dc01.child.contoso.local"
+
+    def test_preserves_exact_fqdn_match(self) -> None:
+        """Test that exact FQDN match is preserved."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+        ]
+
+        # Exact match should be preserved
+        result = state.resolve_hostname_to_fqdn("dc01.contoso.local")
+        assert result == "dc01.contoso.local"
+
+    def test_resolves_by_ip(self) -> None:
+        """Test that target_ip enables resolution even with ambiguous hostname."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+            Host(ip="192.168.58.20", hostname="dc01.fabrikam.local"),
+        ]
+
+        # With target_ip, should resolve to the correct domain
+        result = state.resolve_hostname_to_fqdn("DC01", target_ip="192.168.58.20")
+        assert result == "dc01.fabrikam.local"
+
+    def test_ip_takes_priority_over_hostname_match(self) -> None:
+        """Test that IP-based resolution takes priority over hostname matching."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+            Host(ip="192.168.58.20", hostname="dc01.fabrikam.local"),
+        ]
+
+        # Even with wrong FQDN, IP should resolve correctly
+        result = state.resolve_hostname_to_fqdn("dc01.contoso.local", target_ip="192.168.58.20")
+        assert result == "dc01.fabrikam.local"
+
+    def test_returns_none_when_no_match(self) -> None:
+        """Test that None is returned when no match exists."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+        ]
+
+        # Unknown hostname should return None
+        result = state.resolve_hostname_to_fqdn("sql01")
+        assert result is None
+
+    def test_returns_none_for_empty_hostname(self) -> None:
+        """Test that None is returned for empty hostname."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+        ]
+
+        result = state.resolve_hostname_to_fqdn("")
+        assert result is None
+
+    def test_skips_hosts_without_fqdn(self) -> None:
+        """Test that hosts without FQDN (no dots) are skipped."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01"),  # No FQDN
+            Host(ip="192.168.58.20", hostname="dc01.contoso.local"),
+        ]
+
+        # Should skip the first host and match the second
+        result = state.resolve_hostname_to_fqdn("dc01")
+        assert result == "dc01.contoso.local"
+
+    def test_case_insensitive_matching(self) -> None:
+        """Test that hostname matching is case-insensitive."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="DC01.CONTOSO.LOCAL"),
+        ]
+
+        # Lowercase input should match uppercase host
+        result = state.resolve_hostname_to_fqdn("dc01")
+        assert result == "dc01.contoso.local"
+
+    def test_handles_empty_hosts(self) -> None:
+        """Test that empty all_hosts returns None."""
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        result = state.resolve_hostname_to_fqdn("dc01")
+        assert result is None
+
+    def test_resolves_ip_only_no_hostname(self) -> None:
+        """Test that IP alone can resolve to FQDN when hostname is empty."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+        ]
+
+        # Empty hostname but valid IP should resolve
+        result = state.resolve_hostname_to_fqdn("", target_ip="192.168.58.10")
+        assert result == "dc01.contoso.local"
+
+    def test_child_domain_resolution(self) -> None:
+        """Test correct resolution in child domain scenarios."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+        state.all_hosts = [
+            # Parent domain DC
+            Host(ip="192.168.58.10", hostname="dc01.contoso.local"),
+            # Child domain DC
+            Host(ip="192.168.58.20", hostname="dc01.child.contoso.local"),
+        ]
+
+        # NetBIOS name should match first occurrence
+        result = state.resolve_hostname_to_fqdn("dc01")
+        assert result == "dc01.contoso.local"
+
+        # With IP, should resolve to child domain
+        result = state.resolve_hostname_to_fqdn("dc01", target_ip="192.168.58.20")
+        assert result == "dc01.child.contoso.local"
+
+
+class TestAddHostMerge:
+    """Tests for SharedRedTeamState.add_host merge behavior.
+
+    When adding a host with the same IP, the merge logic should:
+    - Prefer FQDN over short hostname
+    - Prefer more specific FQDN (more domain levels) over less specific
+    """
+
+    def test_upgrades_short_hostname_to_fqdn(self) -> None:
+        """Test that a short hostname is upgraded to FQDN on merge."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add host with short hostname first
+        state.add_host(Host(ip="192.168.58.10", hostname="dc01"))
+        assert state.all_hosts[0].hostname == "dc01"
+
+        # Add same host with FQDN - should upgrade
+        state.add_host(Host(ip="192.168.58.10", hostname="dc01.contoso.local"))
+        assert len(state.all_hosts) == 1
+        assert state.all_hosts[0].hostname == "dc01.contoso.local"
+
+    def test_prefers_more_specific_fqdn(self) -> None:
+        """Test that more specific FQDN is preferred over less specific.
+
+        This is the GOAD scenario: winterfell.sevenkingdoms.local should be
+        upgraded to winterfell.north.sevenkingdoms.local (more specific).
+        """
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add host with less specific FQDN first (wrong domain suffix)
+        state.add_host(Host(ip="10.1.2.240", hostname="winterfell.sevenkingdoms.local"))
+        assert state.all_hosts[0].hostname == "winterfell.sevenkingdoms.local"
+
+        # Add same host with more specific FQDN (correct child domain)
+        state.add_host(Host(ip="10.1.2.240", hostname="winterfell.north.sevenkingdoms.local"))
+        assert len(state.all_hosts) == 1
+        # Should upgrade to more specific FQDN
+        assert state.all_hosts[0].hostname == "winterfell.north.sevenkingdoms.local"
+
+    def test_does_not_downgrade_to_less_specific(self) -> None:
+        """Test that a less specific FQDN does NOT replace a more specific one."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add host with more specific FQDN first
+        state.add_host(Host(ip="10.1.2.240", hostname="winterfell.north.sevenkingdoms.local"))
+        assert state.all_hosts[0].hostname == "winterfell.north.sevenkingdoms.local"
+
+        # Add same host with less specific FQDN - should NOT downgrade
+        state.add_host(Host(ip="10.1.2.240", hostname="winterfell.sevenkingdoms.local"))
+        assert len(state.all_hosts) == 1
+        # Should keep the more specific FQDN
+        assert state.all_hosts[0].hostname == "winterfell.north.sevenkingdoms.local"
+
+    def test_requires_same_short_hostname_for_upgrade(self) -> None:
+        """Test that FQDN upgrade only happens when short hostnames match."""
+        from ares.core.models import Host, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add host with one FQDN
+        state.add_host(Host(ip="192.168.58.10", hostname="dc01.contoso.local"))
+
+        # Add same IP with completely different hostname - should NOT upgrade
+        # (This is technically the same IP but hostname doesn't match short name)
+        # Since they're different hosts conceptually, the merge preserves first
+        state.add_host(Host(ip="192.168.58.10", hostname="srv01.child.contoso.local"))
+        assert len(state.all_hosts) == 1
+        # Original hostname preserved since short names differ
+        assert state.all_hosts[0].hostname == "dc01.contoso.local"

--- a/tests/core/test_task_queue.py
+++ b/tests/core/test_task_queue.py
@@ -1553,5 +1553,130 @@ class TestTargetFallback:
         # In this case, the vulnerability should be skipped (not published)
 
 
+class TestSpanTargetExtraction:
+    """Tests for span target_ip extraction logic in submit_task.
+
+    Ensures dc_ip is NOT used as target_ip (they are semantically different:
+    dc_ip is for authentication, target_ip is the attack target).
+    """
+
+    @pytest.mark.asyncio
+    async def test_dc_ip_not_used_as_target_ip(self, task_queue, mock_redis_client):
+        """dc_ip should not be extracted as target_ip for span - they're semantically different."""
+        # This is a typical recon payload where dc_ip is set for auth
+        # but target_ips contains the actual targets
+        payload = {
+            "domain": "contoso.local",
+            "dc_ip": "192.168.58.10",  # DC for authentication
+            "target_ips": ["MEEREEN"],  # Actual target (NetBIOS hostname)
+            "username": "testuser",
+            "techniques": ["ldap_enum"],
+        }
+
+        # Patch the producer_span to capture what target_ip is passed
+        captured_kwargs: dict = {}
+
+        def mock_producer_span(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            # Return a context manager
+            from contextlib import nullcontext
+
+            return nullcontext()
+
+        with patch("ares.core.task_queue.producer_span", mock_producer_span):
+            await task_queue.submit_task(
+                task_type="recon",
+                target_role="recon",
+                payload=payload,
+            )
+
+        # dc_ip (192.168.58.10) should NOT be used as target_ip
+        # target_fqdn should be "MEEREEN" (from target_ips)
+        assert captured_kwargs.get("target_ip") is None
+        assert captured_kwargs.get("target_fqdn") == "MEEREEN"
+
+    @pytest.mark.asyncio
+    async def test_target_ips_list_ip_used_as_target_ip(self, task_queue, mock_redis_client):
+        """First IP from target_ips list should be used as target_ip."""
+        payload = {
+            "domain": "contoso.local",
+            "dc_ip": "192.168.58.10",  # DC for auth
+            "target_ips": ["192.168.58.100", "192.168.58.101"],  # Actual targets
+        }
+
+        captured_kwargs: dict = {}
+
+        def mock_producer_span(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            from contextlib import nullcontext
+
+            return nullcontext()
+
+        with patch("ares.core.task_queue.producer_span", mock_producer_span):
+            await task_queue.submit_task(
+                task_type="recon",
+                target_role="recon",
+                payload=payload,
+            )
+
+        # target_ip should be first element of target_ips, NOT dc_ip
+        assert captured_kwargs.get("target_ip") == "192.168.58.100"
+
+    @pytest.mark.asyncio
+    async def test_target_ips_list_fqdn_used_as_target_fqdn(self, task_queue, mock_redis_client):
+        """First FQDN from target_ips list should be used as target_fqdn."""
+        payload = {
+            "domain": "contoso.local",
+            "dc_ip": "192.168.58.10",  # DC for auth
+            "target_ips": ["sql01.contoso.local"],  # FQDN target
+        }
+
+        captured_kwargs: dict = {}
+
+        def mock_producer_span(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            from contextlib import nullcontext
+
+            return nullcontext()
+
+        with patch("ares.core.task_queue.producer_span", mock_producer_span):
+            await task_queue.submit_task(
+                task_type="credential_access",
+                target_role="credential_access",
+                payload=payload,
+            )
+
+        # target_fqdn should be the FQDN from target_ips
+        assert captured_kwargs.get("target_ip") is None
+        assert captured_kwargs.get("target_fqdn") == "sql01.contoso.local"
+
+    @pytest.mark.asyncio
+    async def test_explicit_target_ip_takes_priority(self, task_queue, mock_redis_client):
+        """Explicit target_ip field should take priority over target_ips."""
+        payload = {
+            "target_ip": "192.168.58.200",  # Explicit target
+            "dc_ip": "192.168.58.10",
+            "target_ips": ["192.168.58.100"],
+        }
+
+        captured_kwargs: dict = {}
+
+        def mock_producer_span(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            from contextlib import nullcontext
+
+            return nullcontext()
+
+        with patch("ares.core.task_queue.producer_span", mock_producer_span):
+            await task_queue.submit_task(
+                task_type="exploit",
+                target_role="privesc",
+                payload=payload,
+            )
+
+        # Explicit target_ip should be used
+        assert captured_kwargs.get("target_ip") == "192.168.58.200"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/test_tracing.py
+++ b/tests/core/test_tracing.py
@@ -209,6 +209,45 @@ class TestToolMitreInfo:
         assert technique_id == "T1046"
         assert tactic == "discovery"
 
+    def test_recon_agent_tools(self):
+        """Recon agent tools should have technique IDs."""
+        # enumerate_users - Account Discovery: Domain Account
+        technique_id, tactic = get_tool_mitre_info("enumerate_users")
+        assert technique_id == "T1087.002"
+        assert tactic == "discovery"
+
+        # run_bloodhound - Account Discovery: Domain Account
+        technique_id, tactic = get_tool_mitre_info("run_bloodhound")
+        assert technique_id == "T1087.002"
+        assert tactic == "discovery"
+
+        # resolve_domain_controllers - Remote System Discovery
+        technique_id, tactic = get_tool_mitre_info("resolve_domain_controllers")
+        assert technique_id == "T1018"
+        assert tactic == "discovery"
+
+        # smb_sweep - Network Service Scanning
+        technique_id, tactic = get_tool_mitre_info("smb_sweep")
+        assert technique_id == "T1046"
+        assert tactic == "discovery"
+
+    def test_reporting_tools(self):
+        """Reporting/documentation tools should have technique IDs."""
+        # record_credential - Account Discovery
+        technique_id, tactic = get_tool_mitre_info("record_credential")
+        assert technique_id == "T1087.002"
+        assert tactic == "discovery"
+
+        # record_weakness - Software Discovery
+        technique_id, tactic = get_tool_mitre_info("record_weakness")
+        assert technique_id == "T1518.001"
+        assert tactic == "discovery"
+
+        # record_timeline_event - Account Discovery
+        technique_id, tactic = get_tool_mitre_info("record_timeline_event")
+        assert technique_id == "T1087"
+        assert tactic == "discovery"
+
     def test_unknown_tool_returns_none(self):
         """Unknown tools should return None."""
         technique_id, tactic = get_tool_mitre_info("unknown_tool")
@@ -234,6 +273,19 @@ class TestToolCategory:
         """Network enumeration tools should return NetworkEnumerationTools."""
         assert get_tool_category("nmap_scan") == "NetworkEnumerationTools"
         assert get_tool_category("ldap_domain_dump") == "NetworkEnumerationTools"
+        assert get_tool_category("smb_sweep") == "NetworkEnumerationTools"
+        assert get_tool_category("resolve_domain_controllers") == "NetworkEnumerationTools"
+        assert get_tool_category("enumerate_users") == "NetworkEnumerationTools"
+
+    def test_bloodhound_category(self):
+        """BloodHound tools should return BloodHoundTools."""
+        assert get_tool_category("run_bloodhound") == "BloodHoundTools"
+
+    def test_reporting_category(self):
+        """Reporting tools should return ReportingTools."""
+        assert get_tool_category("record_credential") == "ReportingTools"
+        assert get_tool_category("record_weakness") == "ReportingTools"
+        assert get_tool_category("record_timeline_event") == "ReportingTools"
 
     def test_coercion_category(self):
         """Coercion tools should return CoercionTools."""

--- a/tests/tools/red/test_reconnaissance.py
+++ b/tests/tools/red/test_reconnaissance.py
@@ -245,9 +245,224 @@ Names:
     def test_fqdn_construction_from_netbios(self):
         """Test FQDN construction from NetBIOS name and domain."""
         netbios_name = "DC01"
-        domain = "CONTOSO"
+        domain = "contoso.local"  # Full domain from LDAP
 
-        # Logic from reconnaissance.py - assumes .local TLD
-        fqdn = f"{netbios_name.lower()}.{domain.lower()}.local"
+        # Logic from reconnaissance.py - uses full domain from LDAP
+        fqdn = f"{netbios_name.lower()}.{domain.lower()}"
 
         assert fqdn == "dc01.contoso.local"
+
+
+class TestTruncatedDomainCorrection:
+    """Tests for correcting truncated domain suffixes from DNS.
+
+    When nmap resolves hostnames via AD DNS, it may return truncated
+    domains like "ws01.child.local" instead of the full
+    "ws01.child.contoso.local". The code should detect
+    and correct these truncated domains using known domains from LDAP.
+    """
+
+    def test_truncated_domain_detection(self):
+        """Test that truncated domains can be detected."""
+        # child.local is truncated, child.contoso.local is correct
+        truncated = "child.local"
+        full_domain = "child.contoso.local"
+
+        # Check if truncated domain's first label matches known domain
+        first_label = truncated.split(".", maxsplit=1)[0]  # "child"
+        is_truncated = full_domain.startswith(first_label + ".")
+
+        assert is_truncated is True
+
+    def test_truncated_domain_correction_logic(self):
+        """Test the logic for correcting truncated hostnames."""
+        hostname = "ws01.child.local"
+        known_domains = {"child.contoso.local", "contoso.local", "fabrikam.local"}
+
+        # Extract domain suffix
+        parts = hostname.lower().split(".", 1)
+        short_name, domain_suffix = parts[0], parts[1]
+
+        # Check if domain_suffix is known
+        if domain_suffix not in known_domains:
+            # Find matching known domain
+            first_label = domain_suffix.split(".")[0]
+            for known in known_domains:
+                if known.startswith(first_label + ".") and known != domain_suffix:
+                    corrected = f"{short_name}.{known}"
+                    break
+            else:
+                corrected = hostname
+        else:
+            corrected = hostname
+
+        assert corrected == "ws01.child.contoso.local"
+
+    def test_valid_domain_not_corrected(self):
+        """Test that valid domains are not incorrectly corrected."""
+        hostname = "dc01.contoso.local"
+        known_domains = {"child.contoso.local", "contoso.local", "fabrikam.local"}
+
+        parts = hostname.lower().split(".", 1)
+        domain_suffix = parts[1]
+
+        # contoso.local IS a known domain, so no correction needed
+        assert domain_suffix in known_domains
+
+    def test_no_match_returns_original(self):
+        """Test that hostnames with unknown domains are not changed."""
+        hostname = "unknown.mystery.local"
+        known_domains = {"child.contoso.local", "contoso.local"}
+
+        parts = hostname.lower().split(".", 1)
+        _, domain_suffix = parts[0], parts[1]
+
+        # No known domain starts with "mystery."
+        first_label = domain_suffix.split(".")[0]
+        matches = [k for k in known_domains if k.startswith(first_label + ".")]
+
+        assert len(matches) == 0  # No match found
+
+    def test_child_domain_from_ldap_enables_correction(self):
+        """Test that domains discovered from LDAP enable hostname correction.
+
+        When nmap scans a child domain DC, the LDAP banner provides the
+        correct child domain (e.g., "child.contoso.local"). This
+        should be used to correct truncated hostnames for other hosts
+        in the same scan.
+        """
+        # Simulate discovering domain from LDAP banner
+        ldap_domain = "child.contoso.local"
+        discovered_domains = set()
+        discovered_domains.add(ldap_domain.lower())
+
+        # Now a truncated hostname can be corrected
+        hostname = "ws01.child.local"
+        parts = hostname.lower().split(".", 1)
+        short_name, domain_suffix = parts[0], parts[1]
+
+        first_label = domain_suffix.split(".")[0]
+        corrected = None
+        for known in discovered_domains:
+            if known.startswith(first_label + "."):
+                corrected = f"{short_name}.{known}"
+                break
+
+        assert corrected == "ws01.child.contoso.local"
+
+    def test_multiple_matching_domains_uses_first(self):
+        """Test behavior when multiple domains could match."""
+        # Edge case: what if we have both child.contoso.local
+        # and child.fabrikam.local? Current logic uses first match.
+        hostname = "srv01.child.local"
+        known_domains = {"child.contoso.local", "child.fabrikam.local"}
+
+        parts = hostname.lower().split(".", 1)
+        _, domain_suffix = parts[0], parts[1]
+
+        first_label = domain_suffix.split(".")[0]
+        matches = [k for k in known_domains if k.startswith(first_label + ".")]
+
+        # Should find matches (order not guaranteed due to set)
+        assert len(matches) == 2
+        # Code will use first match from iteration
+
+    def test_short_hostname_not_affected(self):
+        """Test that short hostnames without domain are not affected."""
+        hostname = "ws01"
+
+        # No dot means no domain suffix to correct
+        has_domain = "." in hostname
+
+        assert has_domain is False
+
+
+class TestLDAPCredentialExtraction:
+    """Tests for LDAP credential extraction edge cases.
+
+    When parsing LDAP output, the password field (often in description)
+    can appear BEFORE the sAMAccountName. The extraction logic must
+    reset context at entry boundaries to avoid false positives.
+    """
+
+    def test_ldap_password_before_samaccountname_no_false_positive(self):
+        """Ensure password isn't associated with previous entry's username.
+
+        Bug scenario: LDAP output has description (with password) before
+        sAMAccountName. Without proper boundary detection, password would
+        be associated with the PREVIOUS user.
+        """
+        from ares.tools.red.reconnaissance import NetworkEnumerationTools
+
+        # LDAP-style output where password appears before sAMAccountName
+        ldap_output = """
+dn: CN=Test User,OU=Users,DC=contoso,DC=local
+sAMAccountName: testuser
+description: Test account
+
+dn: CN=Service Account,OU=Users,DC=contoso,DC=local
+description: Password: SecretP@ss123
+sAMAccountName: svc_backup
+"""
+        tools = NetworkEnumerationTools()
+        creds = tools._extract_passwords_from_user_enum_output(ldap_output)
+
+        # Should find exactly one credential: svc_backup with SecretP@ss123
+        # Should NOT find testuser with SecretP@ss123 (false positive)
+        assert len(creds) == 1
+        username, password = creds[0]
+        assert username == "svc_backup"
+        assert password == "SecretP@ss123"  # pragma: allowlist secret
+
+    def test_ldap_entry_boundary_resets_context(self):
+        """Test that 'dn:' lines reset the user context.
+
+        Each LDAP entry starts with 'dn:'. The current_user tracker must
+        be cleared when crossing entry boundaries.
+        """
+        from ares.tools.red.reconnaissance import NetworkEnumerationTools
+
+        # Multiple LDAP entries with passwords
+        ldap_output = """
+dn: CN=User One,OU=Users,DC=contoso,DC=local
+sAMAccountName: user_one
+description: Password: Pass1
+
+dn: CN=User Two,OU=Users,DC=contoso,DC=local
+sAMAccountName: user_two
+description: Password: Pass2
+
+dn: CN=User Three,OU=Users,DC=contoso,DC=local
+description: Password: Pass3
+sAMAccountName: user_three
+"""
+        tools = NetworkEnumerationTools()
+        creds = tools._extract_passwords_from_user_enum_output(ldap_output)
+
+        # Should find three credentials with correct associations
+        creds_dict = dict(creds)
+        assert len(creds_dict) == 3
+        assert creds_dict.get("user_one") == "Pass1"
+        assert creds_dict.get("user_two") == "Pass2"
+        assert creds_dict.get("user_three") == "Pass3"
+
+    def test_extraction_module_ldap_boundary_handling(self):
+        """Test extraction.py also handles LDAP boundaries correctly."""
+        from ares.core.dispatcher.extraction import extract_plaintext_passwords_from_output
+
+        # LDAP output with password before sAMAccountName
+        ldap_output = """
+dn: CN=Admin,OU=Users,DC=contoso,DC=local
+sAMAccountName: admin
+
+dn: CN=SQL Service,OU=Service,DC=contoso,DC=local
+description: Password: SqlP@ss!
+sAMAccountName: sql_svc
+"""
+        creds = extract_plaintext_passwords_from_output(ldap_output)
+
+        # Should find sql_svc, NOT admin
+        assert len(creds) == 1
+        username, password, _domain = creds[0]
+        assert username == "sql_svc"
+        assert password == "SqlP@ss!"  # pragma: allowlist secret


### PR DESCRIPTION
**Key Changes:**

- Added robust hostname-to-FQDN normalization, resolving NetBIOS and truncated domains
- Implemented dict iteration safety by snapshotting in all critical vulnerability/host loops
- Introduced a Redis circuit breaker and error debouncer for resilient Redis operations
- Enhanced credential extraction from LDAP, fixing boundary and username association bugs

**Added:**

- Redis circuit breaker and debounced error logging in `ares/core/circuit_breaker.py` to prevent thundering herd and reduce log spam during Redis outages
- New hostname normalization method `resolve_hostname_to_fqdn` in `SharedRedTeamState` to map NetBIOS/short/partial hostnames to canonical FQDNs based on discovered hosts
- Tests for circuit breaker, dict iteration safety, hostname normalization, and truncated domain correction
- Extraction logic for LDAP entries in credential parsing to correctly associate passwords with usernames even if password appears before sAMAccountName

**Changed:**

- All dict iterations over `discovered_vulnerabilities`, `domain_controllers`, `pending_tasks`, and similar are now snapshot via `list(...)` to prevent `RuntimeError: dictionary changed size during iteration` in concurrent/threaded contexts
- Host addition logic now prefers more specific FQDNs (e.g., upgrades from `winterfell.sevenkingdoms.local` to `winterfell.north.sevenkingdoms.local`)
- Red/blue agent factories and orchestrator now resolve hostnames to canonical FQDNs when emitting spans or tracking targets, ensuring consistent graph nodes
- Task queue now uses the circuit breaker and error debouncer for all Redis operations, failing fast when Redis is unavailable and reducing log spam
- Nmap/BloodHound parsing improved: truncated AD DNS hostnames are corrected using discovered LDAP domains
- Extraction modules and recon tools now properly reset context at LDAP entry boundaries to avoid associating passwords with the wrong user
- Documentation and orchestrator interface updated to clarify that vulnerability targets must always be hostnames or IPs, never account names

**Removed:**

- Fallback logic that constructed fake FQDNs from NetBIOS and domain group names in Nmap enrichment (now only uses discovered FQDNs)
- Manual error deduplication in Redis connection logic (now centralized via the debouncer and circuit breaker)
- Redundant code paths for host/target normalization that did not consider partial/truncated domain issues