### PR TITLE
feat: add exponential backoff + circuit breaker resilience for all Redis writes

### DIFF
--- a/src/ares/core/blue_state_backend.py
+++ b/src/ares/core/blue_state_backend.py
@@ -32,6 +32,11 @@ Redis key structure:
     ares:blue:inv:{id}:tasks:completed   HASH (task_id -> JSON)
     ares:blue:inv:{id}:technique_names   HASH (tech_id -> name)
     ares:blue:inv:{id}:recommendations   LIST
+
+Resilience:
+    All write operations use tenacity retry with exponential backoff + circuit breaker
+    to handle transient Redis connection issues (e.g., Sentinel failover, pod restarts).
+    Pattern matches redis-py's ExponentialBackoff(cap=10, base=1).
 """
 
 from __future__ import annotations
@@ -40,9 +45,31 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from ares.core.circuit_breaker import (
+    CircuitBreakerError,
+    get_error_debouncer,
+    get_redis_circuit,
+)
+from ares.core.redis_client import is_connection_error
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis
+
+# Redis connection error types for retry logic
+# Matches redis-py's default retry_on_error list
+_REDIS_RETRY_EXCEPTIONS = (
+    ConnectionError,
+    TimeoutError,
+    OSError,  # Includes ConnectionRefusedError, BrokenPipeError
+)
 
 
 class BlueStateBackend:
@@ -95,16 +122,32 @@ class BlueStateBackend:
     # TTL for all keys (24 hours)
     DEFAULT_TTL = 86400
 
-    def __init__(self, redis_client: Redis, investigation_id: str) -> None:
+    # Retry configuration matching redis-py's ExponentialBackoff(cap=10, base=1)
+    RETRY_MAX_ATTEMPTS = 3
+    RETRY_MULTIPLIER = 1.0  # base delay in seconds
+    RETRY_MAX_DELAY = 10.0  # cap in seconds
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        investigation_id: str,
+        *,
+        use_circuit_breaker: bool = True,
+    ) -> None:
         """Initialize the backend.
 
         Args:
             redis_client: Async Redis client (from create_redis_client).
             investigation_id: Unique investigation identifier.
+            use_circuit_breaker: Enable circuit breaker + retry for resilience.
         """
         self._redis = redis_client
         self._investigation_id = investigation_id
         self._key_prefix = f"{self.KEY_PREFIX}:{investigation_id}"
+        self._use_circuit_breaker = use_circuit_breaker
+        # Use shared circuit breaker and debouncer instances
+        self._circuit = get_redis_circuit() if use_circuit_breaker else None
+        self._debouncer = get_error_debouncer() if use_circuit_breaker else None
 
     def _key(self, suffix: str) -> str:
         """Build full Redis key."""
@@ -113,6 +156,81 @@ class BlueStateBackend:
     async def _set_ttl(self, key: str) -> None:
         """Set TTL on a key."""
         await self._redis.expire(key, self.DEFAULT_TTL)
+
+    async def _with_retry(self, operation_name: str, operation):
+        """Execute a Redis operation with circuit breaker + tenacity retry.
+
+        Provides resilience for transient Redis connection issues (Sentinel failover,
+        pod restarts, network blips). Pattern follows:
+        - redis-py's ExponentialBackoff(cap=10, base=1)
+        - tenacity's AsyncRetrying for async retry logic
+        - Shared circuit breaker for fail-fast when Redis is known to be down
+
+        Args:
+            operation_name: Name for logging (e.g., "add_evidence")
+            operation: Async callable that performs the Redis operation
+
+        Returns:
+            Result of the operation
+
+        Raises:
+            CircuitBreakerError: If circuit is open (fail-fast)
+            Exception: If all retries exhausted
+        """
+        # Fast path: no circuit breaker configured
+        if not self._circuit:
+            return await operation()
+
+        # Check circuit breaker FIRST - fail fast if Redis is known to be down
+        if not self._circuit.allow_request_sync():
+            remaining = self._circuit._get_remaining_open_time()
+            raise CircuitBreakerError(self._circuit.name, remaining)
+
+        last_exception: Exception | None = None
+
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(self.RETRY_MAX_ATTEMPTS),
+                wait=wait_exponential(
+                    multiplier=self.RETRY_MULTIPLIER,
+                    max=self.RETRY_MAX_DELAY,
+                ),
+                retry=retry_if_exception_type(_REDIS_RETRY_EXCEPTIONS),
+                reraise=True,
+            ):
+                with attempt:
+                    result = await operation()
+                    # Success - record and close circuit if half-open
+                    self._circuit.record_success_sync()
+                    return result
+
+        except RetryError as e:
+            # All retries exhausted
+            last_exception = e.last_attempt.exception()
+            if self._debouncer:
+                self._debouncer.log_error_sync(
+                    f"blue_state_backend_{operation_name}",
+                    f"Redis {operation_name} failed after {self.RETRY_MAX_ATTEMPTS} "
+                    f"retries: {last_exception}",
+                    level="warning",
+                )
+            # Record failure to potentially open circuit
+            if is_connection_error(last_exception):
+                self._circuit.record_failure_sync(last_exception)
+            raise last_exception from e
+
+        except Exception as e:
+            # Non-retryable error or retry logic raised
+            last_exception = e
+            if is_connection_error(e):
+                self._circuit.record_failure_sync(e)
+                if self._debouncer:
+                    self._debouncer.log_error_sync(
+                        f"blue_state_backend_{operation_name}",
+                        f"Redis {operation_name} connection error: {e}",
+                        level="warning",
+                    )
+            raise
 
     # =========================================================================
     # Evidence (Redis HASH with HSETNX for O(1) deduplication)
@@ -124,20 +242,22 @@ class BlueStateBackend:
         Deduplication key: ``{type}:{value_lower}`` derived from the evidence
         dict's ``type`` and ``value`` fields (case-insensitive).
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             evidence_dict: JSON-serializable evidence data. Expected to contain
                 at least ``type`` and ``value`` fields for dedup key generation.
 
         Returns:
-            True if added (new), False if duplicate.
+            True if added (new), False if duplicate or error.
         """
         key = self._key(self.KEY_EVIDENCE)
-        try:
-            ev_type = str(evidence_dict.get("type", "unknown")).strip().lower()
-            ev_value = str(evidence_dict.get("value", "")).strip().lower()
-            dedup_field = f"{ev_type}:{ev_value}"
+        ev_type = str(evidence_dict.get("type", "unknown")).strip().lower()
+        ev_value = str(evidence_dict.get("value", "")).strip().lower()
+        dedup_field = f"{ev_type}:{ev_value}"
+        data = json.dumps(evidence_dict, separators=(",", ":"), default=str)
 
-            data = json.dumps(evidence_dict, separators=(",", ":"), default=str)
+        async def _do_add():
             # HSETNX returns 1 if field was set (new), 0 if already existed
             added = await self._redis.hsetnx(key, dedup_field, data)
             if not added:
@@ -145,6 +265,12 @@ class BlueStateBackend:
                 return False
             await self._set_ttl(key)
             return True
+
+        try:
+            return await self._with_retry("add_evidence", _do_add)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping add_evidence for {dedup_field}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to add evidence to Redis: {e}")
             return False

--- a/src/ares/core/blue_task_queue.py
+++ b/src/ares/core/blue_task_queue.py
@@ -24,10 +24,16 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 from pydantic import BaseModel
 
-from ares.core.config import get_agent_heartbeat_timeout, get_redis_url
+from ares.core.config import (
+    get_agent_heartbeat_timeout,
+    get_redis_retry_base_delay,
+    get_redis_retry_max_delay,
+    get_redis_url,
+)
 from ares.core.redis_client import (
     create_redis_client,
     get_redis_sentinel_config,
+    get_retry_delay,
     invalidate_sentinel_client,
     is_connection_error,
     timed_redis_write,
@@ -379,11 +385,11 @@ class BlueTaskQueue:
         target_role: str,
         params: dict[str, Any],
         task_id: str | None = None,
-        max_retries: int = 2,
+        max_retries: int = 5,
     ) -> str:
         """Submit a task to a role's queue.
 
-        Includes automatic retry on connection errors.
+        Includes automatic retry with exponential backoff on connection errors.
 
         Args:
             investigation_id: Investigation this task belongs to.
@@ -391,7 +397,7 @@ class BlueTaskQueue:
             target_role: Role to handle the task (triage, threat_hunter, etc.).
             params: Task-specific parameters.
             task_id: Optional task ID (generated if not provided).
-            max_retries: Max retries on connection error (default: 2).
+            max_retries: Max retries on connection error (default: 5, giving 6 total attempts).
 
         Returns:
             Task ID for tracking.
@@ -416,6 +422,8 @@ class BlueTaskQueue:
             queue_key = self._task_queue_key(investigation_id, target_role)
 
         last_error: Exception | None = None
+        base_delay = get_redis_retry_base_delay()
+        max_delay = get_redis_retry_max_delay()
 
         # Create PRODUCER span for Tempo service graph
         with producer_span(
@@ -453,7 +461,6 @@ class BlueTaskQueue:
                     )
                     await self._handle_connection_error(TimeoutError("Timeout submitting task"))
                     last_error = TimeoutError("Timeout submitting task after retries")
-                    continue
 
                 except Exception as e:
                     if is_connection_error(e):
@@ -463,8 +470,14 @@ class BlueTaskQueue:
                         )
                         await self._handle_connection_error(e)
                         last_error = e
-                        continue
-                    raise
+                    else:
+                        raise
+
+                # Exponential backoff before retry (except on last attempt)
+                if attempt < max_retries:
+                    delay = get_retry_delay(attempt, base_delay, max_delay)
+                    logger.info(f"Retrying submit_task in {delay:.1f}s")
+                    await asyncio.sleep(delay)
 
             if last_error:
                 logger.error(f"submit_task failed after {max_retries + 1} attempts: {last_error}")
@@ -475,22 +488,25 @@ class BlueTaskQueue:
         self,
         task_id: str,
         timeout: float = 300.0,
-        max_retries: int = 2,
+        max_retries: int = 5,
     ) -> BlueTaskResult | None:
         """Wait for a task result.
 
-        Includes automatic retry on connection errors.
+        Includes automatic retry with exponential backoff on connection errors.
+        This is critical for handling Sentinel failover where IPs may be stale.
 
         Args:
             task_id: Task ID to wait for.
             timeout: Maximum wait time in seconds.
-            max_retries: Max retries on connection error (default: 2).
+            max_retries: Max retries on connection error (default: 5, giving 6 total attempts).
 
         Returns:
             BlueTaskResult or None if timeout.
         """
         result_key = self._result_queue_key(task_id)
         last_error: Exception | None = None
+        base_delay = get_redis_retry_base_delay()
+        max_delay = get_redis_retry_max_delay()
 
         for attempt in range(max_retries + 1):
             if not self._connected:
@@ -520,7 +536,6 @@ class BlueTaskQueue:
                     TimeoutError("BRPOP hung - possible stale connection")
                 )
                 last_error = TimeoutError("BRPOP hung after retries")
-                continue
 
             except Exception as e:
                 if is_connection_error(e):
@@ -530,8 +545,14 @@ class BlueTaskQueue:
                     )
                     await self._handle_connection_error(e)
                     last_error = e
-                    continue
-                raise
+                else:
+                    raise
+
+            # Exponential backoff before retry (except on last attempt)
+            if attempt < max_retries:
+                delay = get_retry_delay(attempt, base_delay, max_delay)
+                logger.info(f"Retrying in {delay:.1f}s (attempt {attempt + 2}/{max_retries + 1})")
+                await asyncio.sleep(delay)
 
         if last_error:
             logger.error(f"wait_for_result failed after {max_retries + 1} attempts: {last_error}")
@@ -673,11 +694,11 @@ class BlueTaskQueue:
         error: str | None = None,
         worker_pod: str | None = None,
         agent_name: str | None = None,
-        max_retries: int = 2,
+        max_retries: int = 5,
     ) -> None:
         """Send task result back to orchestrator.
 
-        Includes automatic retry on connection errors.
+        Includes automatic retry with exponential backoff on connection errors.
 
         Args:
             task_id: Task ID.
@@ -686,7 +707,7 @@ class BlueTaskQueue:
             error: Error message if failed.
             worker_pod: Pod that processed the task.
             agent_name: Logical agent name.
-            max_retries: Max retries on connection error (default: 2).
+            max_retries: Max retries on connection error (default: 5, giving 6 total attempts).
         """
         task_result = BlueTaskResult(
             task_id=task_id,
@@ -699,6 +720,8 @@ class BlueTaskQueue:
 
         result_key = self._result_queue_key(task_id)
         last_error: Exception | None = None
+        base_delay = get_redis_retry_base_delay()
+        max_delay = get_redis_retry_max_delay()
 
         for attempt in range(max_retries + 1):
             if not self._connected:
@@ -723,7 +746,6 @@ class BlueTaskQueue:
                 )
                 await self._handle_connection_error(TimeoutError("Timeout sending result"))
                 last_error = TimeoutError("Timeout sending result after retries")
-                continue
 
             except Exception as e:
                 if is_connection_error(e):
@@ -733,8 +755,14 @@ class BlueTaskQueue:
                     )
                     await self._handle_connection_error(e)
                     last_error = e
-                    continue
-                raise
+                else:
+                    raise
+
+            # Exponential backoff before retry (except on last attempt)
+            if attempt < max_retries:
+                delay = get_retry_delay(attempt, base_delay, max_delay)
+                logger.info(f"Retrying send_result in {delay:.1f}s")
+                await asyncio.sleep(delay)
 
         if last_error:
             logger.error(f"send_result failed after {max_retries + 1} attempts: {last_error}")

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -3353,11 +3353,20 @@ async def _auto_golden_ticket(
                     output = stdout + "\n" + (stderr or "")
 
                     if returncode == 0 or "Saving ticket" in output:
+                        # Look up actual DC FQDN from discovered hosts (not hardcoded dc.{domain})
+                        dc_fqdn = None
+                        for host in state.all_hosts:
+                            if host.ip == dc_ip and host.hostname and "." in host.hostname:
+                                dc_fqdn = host.hostname
+                                break
+                        # Fallback to IP if no FQDN found
+                        dc_target = dc_fqdn or dc_ip
+
                         logger.success(
                             f"🎫 GOLDEN TICKET GENERATED for {domain}!\n"
                             f"→ Ticket saved as {ticket_path}\n"
                             f"→ Use: export KRB5CCNAME={ticket_path}\n"
-                            f"→ Then: psexec.py -k -no-pass dc.{domain}"
+                            f"→ Then: psexec.py -k -no-pass -target-ip {dc_ip} {dc_target}"
                         )
 
                         # Announce golden ticket - this sets has_golden_ticket, checkpoints,

--- a/src/ares/core/redis_client.py
+++ b/src/ares/core/redis_client.py
@@ -300,6 +300,27 @@ def is_connection_error(error: BaseException) -> bool:
     return any(keyword in error_str for keyword in _CONNECTION_ERROR_KEYWORDS)
 
 
+def get_retry_delay(attempt: int, base_delay: float = 1.0, max_delay: float = 10.0) -> float:
+    """Calculate exponential backoff delay for retry attempt.
+
+    Uses the idiomatic pattern from redis-py best practices:
+    - ExponentialBackoff(cap=10, base=1) - delay doubles each retry, capped at max
+
+    Args:
+        attempt: Zero-based attempt number (0 for first retry delay).
+        base_delay: Initial delay in seconds (default: 1.0).
+        max_delay: Maximum delay cap in seconds (default: 10.0).
+
+    Returns:
+        Delay in seconds before the next retry.
+
+    Example:
+        >>> [get_retry_delay(i) for i in range(6)]
+        [1.0, 2.0, 4.0, 8.0, 10.0, 10.0]
+    """
+    return min(base_delay * (2**attempt), max_delay)
+
+
 # Default timeout for Redis write operations (seconds)
 _DEFAULT_WRITE_TIMEOUT = float(os.getenv("REDIS_WRITE_TIMEOUT", "10.0"))
 

--- a/src/ares/core/state_backend.py
+++ b/src/ares/core/state_backend.py
@@ -24,6 +24,11 @@ Redis key structure:
     ares:op:{op_id}:dc_map            HASH
     ares:op:{op_id}:netbios_map       HASH
     ares:op:{op_id}:artifacts         HASH
+
+Resilience:
+    All write operations use tenacity retry with exponential backoff + circuit breaker
+    to handle transient Redis connection issues (e.g., Sentinel failover, pod restarts).
+    Pattern matches redis-py's ExponentialBackoff(cap=10, base=1).
 """
 
 from __future__ import annotations
@@ -33,6 +38,20 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from ares.core.circuit_breaker import (
+    CircuitBreakerError,
+    get_error_debouncer,
+    get_redis_circuit,
+)
+from ares.core.redis_client import is_connection_error
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis
@@ -45,6 +64,14 @@ if TYPE_CHECKING:
         User,
         VulnerabilityInfo,
     )
+
+# Redis connection error types for retry logic
+# Matches redis-py's default retry_on_error list
+_REDIS_RETRY_EXCEPTIONS = (
+    ConnectionError,
+    TimeoutError,
+    OSError,  # Includes ConnectionRefusedError, BrokenPipeError
+)
 
 
 class RedisStateBackend:
@@ -106,16 +133,33 @@ class RedisStateBackend:
     # TTL for all keys (24 hours)
     DEFAULT_TTL = 86400
 
-    def __init__(self, redis_client: Redis, operation_id: str):
+    # Retry configuration matching redis-py's ExponentialBackoff(cap=10, base=1)
+    # See: https://redis.io/docs/latest/develop/connect/clients/python/redis-py/
+    RETRY_MAX_ATTEMPTS = 3
+    RETRY_MULTIPLIER = 1.0  # base delay in seconds
+    RETRY_MAX_DELAY = 10.0  # cap in seconds
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        operation_id: str,
+        *,
+        use_circuit_breaker: bool = True,
+    ):
         """Initialize the backend.
 
         Args:
             redis_client: Async Redis client (from create_redis_client)
             operation_id: Unique operation identifier
+            use_circuit_breaker: Enable circuit breaker + retry for resilience
         """
         self._redis = redis_client
         self._operation_id = operation_id
         self._key_prefix = f"{self.KEY_PREFIX}:{operation_id}"
+        self._use_circuit_breaker = use_circuit_breaker
+        # Use shared circuit breaker and debouncer instances
+        self._circuit = get_redis_circuit() if use_circuit_breaker else None
+        self._debouncer = get_error_debouncer() if use_circuit_breaker else None
 
     def _key(self, suffix: str) -> str:
         """Build full Redis key."""
@@ -129,6 +173,81 @@ class RedisStateBackend:
         """Set TTL on a key."""
         await self._redis.expire(key, self.DEFAULT_TTL)
 
+    async def _with_retry(self, operation_name: str, operation):
+        """Execute a Redis operation with circuit breaker + tenacity retry.
+
+        Provides resilience for transient Redis connection issues (Sentinel failover,
+        pod restarts, network blips). Pattern follows:
+        - redis-py's ExponentialBackoff(cap=10, base=1)
+        - tenacity's AsyncRetrying for async retry logic
+        - Shared circuit breaker for fail-fast when Redis is known to be down
+
+        Args:
+            operation_name: Name for logging (e.g., "add_credential")
+            operation: Async callable that performs the Redis operation
+
+        Returns:
+            Result of the operation
+
+        Raises:
+            CircuitBreakerError: If circuit is open (fail-fast)
+            Exception: If all retries exhausted
+        """
+        # Fast path: no circuit breaker configured
+        if not self._circuit:
+            return await operation()
+
+        # Check circuit breaker FIRST - fail fast if Redis is known to be down
+        if not self._circuit.allow_request_sync():
+            remaining = self._circuit._get_remaining_open_time()
+            raise CircuitBreakerError(self._circuit.name, remaining)
+
+        last_exception: Exception | None = None
+
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(self.RETRY_MAX_ATTEMPTS),
+                wait=wait_exponential(
+                    multiplier=self.RETRY_MULTIPLIER,
+                    max=self.RETRY_MAX_DELAY,
+                ),
+                retry=retry_if_exception_type(_REDIS_RETRY_EXCEPTIONS),
+                reraise=True,
+            ):
+                with attempt:
+                    result = await operation()
+                    # Success - record and close circuit if half-open
+                    self._circuit.record_success_sync()
+                    return result
+
+        except RetryError as e:
+            # All retries exhausted
+            last_exception = e.last_attempt.exception()
+            if self._debouncer:
+                self._debouncer.log_error_sync(
+                    f"state_backend_{operation_name}",
+                    f"Redis {operation_name} failed after {self.RETRY_MAX_ATTEMPTS} "
+                    f"retries: {last_exception}",
+                    level="warning",
+                )
+            # Record failure to potentially open circuit
+            if is_connection_error(last_exception):
+                self._circuit.record_failure_sync(last_exception)
+            raise last_exception from e
+
+        except Exception as e:
+            # Non-retryable error or retry logic raised
+            last_exception = e
+            if is_connection_error(e):
+                self._circuit.record_failure_sync(e)
+                if self._debouncer:
+                    self._debouncer.log_error_sync(
+                        f"state_backend_{operation_name}",
+                        f"Redis {operation_name} connection error: {e}",
+                        level="warning",
+                    )
+            raise
+
     # =========================================================================
     # Credentials (Redis HASH with HSETNX for O(1) deduplication)
     # =========================================================================
@@ -139,16 +258,20 @@ class RedisStateBackend:
         Deduplication key: {domain}:{username}:{password} (case-insensitive)
         This ensures the same credential isn't stored twice.
 
+        Uses circuit breaker + exponential backoff retry for resilience against
+        transient Redis connection issues (Sentinel failover, pod restarts).
+
         Args:
             cred: Credential to add
 
         Returns:
-            True if added (new), False if duplicate
+            True if added (new), False if duplicate or error
         """
         key = self._key(self.KEY_CREDENTIALS)
-        try:
-            dedup_field = self._build_credential_dedup_key(cred)
-            data = _serialize_credential(cred)
+        dedup_field = self._build_credential_dedup_key(cred)
+        data = _serialize_credential(cred)
+
+        async def _do_add():
             # HSETNX returns 1 if field was set (new), 0 if already existed
             added = await self._redis.hsetnx(key, dedup_field, data)
             if not added:
@@ -156,6 +279,13 @@ class RedisStateBackend:
                 return False
             await self._set_ttl(key)
             return True
+
+        try:
+            return await self._with_retry("add_credential", _do_add)
+        except CircuitBreakerError:
+            # Circuit is open - fail fast, caller should retry later
+            logger.debug(f"Circuit breaker open, skipping add_credential for {dedup_field}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to add credential to Redis: {e}")
             return False
@@ -344,11 +474,13 @@ class RedisStateBackend:
         - Kerberoast: {domain}:{username}:{etype}:{spn}
         - NTLM/other: {domain}:{username}:{hash_value[:32]}
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             hash_obj: Hash to add
 
         Returns:
-            True if added, False if duplicate
+            True if added, False if duplicate or error
         """
         hash_type = (hash_obj.hash_type or "").strip().lower()
         hash_value = hash_obj.hash_value or ""
@@ -359,8 +491,9 @@ class RedisStateBackend:
         dedup_field = self._build_hash_dedup_key(hash_type, hash_value, domain, username)
 
         key = self._key(self.KEY_HASHES)
-        try:
-            data = _serialize_hash(hash_obj)
+        data = _serialize_hash(hash_obj)
+
+        async def _do_add():
             # HSETNX returns 1 if field was set (new), 0 if already existed
             added = await self._redis.hsetnx(key, dedup_field, data)
             if not added:
@@ -368,6 +501,12 @@ class RedisStateBackend:
                 return False
             await self._set_ttl(key)
             return True
+
+        try:
+            return await self._with_retry("add_hash", _do_add)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping add_hash for {dedup_field}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to add hash to Redis: {e}")
             return False
@@ -464,6 +603,7 @@ class RedisStateBackend:
         """Add a host to Redis LIST.
 
         Note: Deduplication/merging should be done by the caller before calling this method.
+        Uses circuit breaker + exponential backoff retry for resilience.
 
         Args:
             host: Host to add
@@ -472,11 +612,18 @@ class RedisStateBackend:
             True if added successfully
         """
         key = self._key(self.KEY_HOSTS)
-        try:
-            data = _serialize_host(host)
+        data = _serialize_host(host)
+
+        async def _do_add():
             await self._redis.rpush(key, data)
             await self._set_ttl(key)
             return True
+
+        try:
+            return await self._with_retry("add_host", _do_add)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping add_host for {host.ip}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to add host to Redis: {e}")
             return False
@@ -630,15 +777,18 @@ class RedisStateBackend:
         hash field, allowing semantically identical weaknesses with different
         wording to be deduplicated properly.
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             weakness: Full weakness description block
             dedup_key: Normalized deduplication key (from _extract_weakness_dedup_key)
 
         Returns:
-            True if added (was new), False if already existed
+            True if added (was new), False if already existed or error
         """
         key = self._key(self.KEY_WEAKNESSES)
-        try:
+
+        async def _do_add():
             # HSETNX returns 1 if field was set (new), 0 if already existed
             added = await self._redis.hsetnx(key, dedup_key, weakness)
             if not added:
@@ -646,6 +796,12 @@ class RedisStateBackend:
                 return False
             await self._set_ttl(key)
             return True
+
+        try:
+            return await self._with_retry("add_weakness", _do_add)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping add_weakness for {dedup_key}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to add weakness to Redis: {e}")
             return False
@@ -737,19 +893,28 @@ class RedisStateBackend:
     async def add_vulnerability(self, vuln: VulnerabilityInfo) -> bool:
         """Add a vulnerability to Redis HASH.
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             vuln: VulnerabilityInfo to add
 
         Returns:
-            True if added (new), False if already existed
+            True if added (new), False if already existed or error
         """
         key = self._key(self.KEY_VULNS)
-        try:
-            data = _serialize_vulnerability(vuln)
+        data = _serialize_vulnerability(vuln)
+
+        async def _do_add():
             # HSETNX returns 1 if field was set (new), 0 if already existed
             result = await self._redis.hsetnx(key, vuln.vuln_id, data)
             await self._set_ttl(key)
             return result == 1
+
+        try:
+            return await self._with_retry("add_vulnerability", _do_add)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping add_vulnerability for {vuln.vuln_id}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to add vulnerability to Redis: {e}")
             return False
@@ -771,6 +936,8 @@ class RedisStateBackend:
     async def mark_exploited(self, vuln_id: str) -> bool:
         """Mark a vulnerability as exploited.
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             vuln_id: Vulnerability ID to mark
 
@@ -778,10 +945,17 @@ class RedisStateBackend:
             True if marked successfully
         """
         key = self._key(self.KEY_EXPLOITED)
-        try:
+
+        async def _do_mark():
             await self._redis.sadd(key, vuln_id)
             await self._set_ttl(key)
             return True
+
+        try:
+            return await self._with_retry("mark_exploited", _do_mark)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping mark_exploited for {vuln_id}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to mark vulnerability exploited: {e}")
             return False
@@ -864,6 +1038,8 @@ class RedisStateBackend:
     async def set_meta(self, field: str, value: Any) -> bool:
         """Set a scalar meta field.
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             field: Field name
             value: Value (will be JSON serialized)
@@ -872,10 +1048,18 @@ class RedisStateBackend:
             True if set successfully
         """
         key = self._key(self.KEY_META)
-        try:
-            await self._redis.hset(key, field, json.dumps(value, default=str))
+        serialized = json.dumps(value, default=str)
+
+        async def _do_set():
+            await self._redis.hset(key, field, serialized)
             await self._set_ttl(key)
             return True
+
+        try:
+            return await self._with_retry("set_meta", _do_set)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping set_meta for {field}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to set meta field {field}: {e}")
             return False
@@ -1130,6 +1314,8 @@ class RedisStateBackend:
     async def store_artifact(self, artifact_key: str, content: str) -> bool:
         """Store a base64-encoded artifact.
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             artifact_key: Artifact key (e.g., "sysvol/login.bat")
             content: Base64-encoded content
@@ -1138,10 +1324,17 @@ class RedisStateBackend:
             True if stored successfully
         """
         key = self._key(self.KEY_ARTIFACTS)
-        try:
+
+        async def _do_store():
             await self._redis.hset(key, artifact_key, content)
             await self._set_ttl(key)
             return True
+
+        try:
+            return await self._with_retry("store_artifact", _do_store)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping store_artifact for {artifact_key}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to store artifact {artifact_key}: {e}")
             return False
@@ -1246,6 +1439,8 @@ class RedisStateBackend:
     async def add_pending_task(self, task_id: str, task_info: dict) -> bool:
         """Add a pending task to Redis HASH.
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             task_id: Unique task identifier
             task_info: Serialized TaskInfo dict
@@ -1254,11 +1449,18 @@ class RedisStateBackend:
             True if added successfully
         """
         redis_key = self._key(self.KEY_PENDING_TASKS)
-        try:
-            data = json.dumps(task_info, separators=(",", ":"), default=str)
+        data = json.dumps(task_info, separators=(",", ":"), default=str)
+
+        async def _do_add():
             await self._redis.hset(redis_key, task_id, data)
             await self._set_ttl(redis_key)
             return True
+
+        try:
+            return await self._with_retry("add_pending_task", _do_add)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping add_pending_task for {task_id}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to add pending task to Redis: {e}")
             return False
@@ -1332,6 +1534,8 @@ class RedisStateBackend:
     async def add_completed_task(self, task_id: str, task_result: dict) -> bool:
         """Add a completed task to Redis HASH.
 
+        Uses circuit breaker + exponential backoff retry for resilience.
+
         Args:
             task_id: Unique task identifier
             task_result: Serialized TaskResult dict
@@ -1340,11 +1544,18 @@ class RedisStateBackend:
             True if added successfully
         """
         redis_key = self._key(self.KEY_COMPLETED_TASKS)
-        try:
-            data = json.dumps(task_result, separators=(",", ":"), default=str)
+        data = json.dumps(task_result, separators=(",", ":"), default=str)
+
+        async def _do_add():
             await self._redis.hset(redis_key, task_id, data)
             await self._set_ttl(redis_key)
             return True
+
+        try:
+            return await self._with_retry("add_completed_task", _do_add)
+        except CircuitBreakerError:
+            logger.debug(f"Circuit breaker open, skipping add_completed_task for {task_id}")
+            return False
         except Exception as e:
             logger.warning(f"Failed to add completed task to Redis: {e}")
             return False

--- a/src/ares/core/task_queue.py
+++ b/src/ares/core/task_queue.py
@@ -20,10 +20,16 @@ from ares.core.circuit_breaker import (
     get_error_debouncer,
     get_redis_circuit,
 )
-from ares.core.config import get_agent_heartbeat_timeout, get_redis_url
+from ares.core.config import (
+    get_agent_heartbeat_timeout,
+    get_redis_retry_base_delay,
+    get_redis_retry_max_delay,
+    get_redis_url,
+)
 from ares.core.redis_client import (
     create_redis_client,
     get_redis_sentinel_config,
+    get_retry_delay,
     invalidate_sentinel_client,
     is_connection_error,
     timed_redis_write,
@@ -400,6 +406,7 @@ class RedisTaskQueue:
                 break
 
         # Check target_ips list (common in recon/credential_access payloads)
+        target_hostname = None
         if not target_ip:
             target_ips = payload.get("target_ips", [])
             if target_ips and isinstance(target_ips, list) and target_ips[0]:
@@ -409,8 +416,8 @@ class RedisTaskQueue:
                 elif is_likely_fqdn(first_target):
                     target_fqdn = first_target
                 elif first_target:
-                    # NetBIOS hostname - set as FQDN for span tracking
-                    target_fqdn = first_target
+                    # NetBIOS hostname - NOT an FQDN, use target_hostname
+                    target_hostname = first_target
 
         # Check target/host fields - distinguish FQDN from username
         for field in ("target", "host", "hostname"):
@@ -425,9 +432,9 @@ class RedisTaskQueue:
                 elif "." in val:
                     # Has dot but not FQDN -> likely username (e.g., "sansa.stark")
                     target_user = val
-                # Plain hostname without dots - set as FQDN for backwards compat
-                elif val and not target_fqdn:
-                    target_fqdn = val
+                # Plain hostname without dots - NOT an FQDN, use target_hostname
+                elif val and not target_hostname:
+                    target_hostname = val
                 break
 
         # Check explicit user fields
@@ -444,6 +451,7 @@ class RedisTaskQueue:
             team="red",
             target_ip=target_ip,
             target_fqdn=target_fqdn,
+            target_hostname=target_hostname,
             target_user=target_user,
             additional_attrs={
                 "task.id": task_id,
@@ -639,18 +647,18 @@ class RedisTaskQueue:
         self,
         role: str,
         timeout: float = 5.0,
-        max_retries: int = 2,
+        max_retries: int = 5,
     ) -> TaskMessage | None:
         """
         Poll for next task (blocking).
 
-        Includes automatic retry on stale connection detection to avoid missed
-        poll cycles when Sentinel pods restart.
+        Includes automatic retry with exponential backoff on stale connection
+        detection to avoid missed poll cycles when Sentinel pods restart.
 
         Args:
             role: Worker role to poll for
             timeout: How long to block waiting
-            max_retries: Max retries on stale connection (default: 2)
+            max_retries: Max retries on stale connection (default: 5, giving 6 total attempts)
 
         Returns:
             TaskMessage or None if timeout
@@ -660,6 +668,8 @@ class RedisTaskQueue:
         """
         queue_key = self._task_queue_key(role)
         last_error: Exception | None = None
+        base_delay = get_redis_retry_base_delay()
+        max_delay = get_redis_retry_max_delay()
 
         for attempt in range(max_retries + 1):
             if not self._connected:
@@ -693,8 +703,6 @@ class RedisTaskQueue:
                     TimeoutError("BRPOP hung - possible stale Sentinel connection")
                 )
                 last_error = TimeoutError("BRPOP hung after retries")
-                # Retry immediately after reconnection
-                continue
 
             except Exception as e:
                 if is_connection_error(e):
@@ -702,9 +710,14 @@ class RedisTaskQueue:
                     logger.warning(f"Connection error during poll ({attempt_info}): {e}")
                     self._handle_connection_error(e)
                     last_error = e
-                    # Retry on connection errors
-                    continue
-                raise
+                else:
+                    raise
+
+            # Exponential backoff before retry (except on last attempt)
+            if attempt < max_retries:
+                delay = get_retry_delay(attempt, base_delay, max_delay)
+                logger.info(f"Retrying poll in {delay:.1f}s")
+                await asyncio.sleep(delay)
 
         # All retries exhausted, return None to avoid blocking the worker loop
         if last_error:

--- a/src/ares/core/tracing.py
+++ b/src/ares/core/tracing.py
@@ -9,9 +9,11 @@ SDK and include attributes for:
 - attack_phase: Current phase of the operation
 
 OTel Semantic Convention attributes:
-- destination.address: Target FQDN (preferred for dashboard filtering) or IP address
+- destination.address: Target FQDN only (for dashboard "Target FQDN" column)
+- destination.ip: Target IP only (for dashboard "Target IP" column)
 - server.address: Target FQDN when attacking a server
-- host.name: Target hostname (derived from FQDN)
+- host.name: Target hostname (short name, derived from FQDN or NetBIOS name)
+- host.name.type: Hostname resolution quality ("fqdn", "netbios", or "ip_only")
 - user.name: Target username when attacking a user account
 
 Custom attack namespace attributes:
@@ -641,6 +643,17 @@ def create_agent_span_attributes(
         attrs["host.name"] = target_hostname
     elif target_fqdn:
         attrs["host.name"] = target_fqdn.split(".")[0]
+
+    # Indicate hostname resolution quality for observability
+    # - "fqdn": Full FQDN available (e.g., dc01.contoso.local)
+    # - "netbios": Only NetBIOS/plain hostname (e.g., dc01) - resolution failed or unavailable
+    # - "ip_only": Only IP address, no hostname at all
+    if target_fqdn:
+        attrs["host.name.type"] = "fqdn"
+    elif target_hostname:
+        attrs["host.name.type"] = "netbios"
+    elif target_ip:
+        attrs["host.name.type"] = "ip_only"
 
     if target_user:
         # OTel standard: user.name for usernames

--- a/src/ares/core/worker/_worker.py
+++ b/src/ares/core/worker/_worker.py
@@ -516,6 +516,7 @@ class RedisWorkerAgent:
         # Properly separate IPs, FQDNs, and usernames to avoid putting usernames in host fields
         target_ip = None
         target_fqdn = None
+        target_hostname = None
         target_user = None
 
         # Check explicit IP fields first
@@ -538,8 +539,8 @@ class RedisWorkerAgent:
                     # Has dot but not FQDN -> likely username (e.g., "sansa.stark")
                     target_user = val
                 elif val:
-                    # Plain hostname without dots
-                    target_fqdn = val
+                    # Plain hostname without dots - NOT an FQDN
+                    target_hostname = val
                 break
 
         # Check explicit user fields
@@ -567,6 +568,7 @@ class RedisWorkerAgent:
             "red",
             target_ip=target_ip,
             target_fqdn=target_fqdn,
+            target_hostname=target_hostname,
             target_user=target_user,
             target_environment=target_env,
         )

--- a/src/ares/core/worker/_worker.py
+++ b/src/ares/core/worker/_worker.py
@@ -150,14 +150,17 @@ def _is_rate_limit_error(exc: Exception) -> bool:
         "rate_limit",
         "ratelimit",
         "too many requests",
-        "429",
         "quota exceeded",
         "tokens per min",
         "requests per min",
         "tpm limit",
         "rpm limit",
     ]
-    return any(indicator in exc_str for indicator in rate_limit_indicators)
+    if any(indicator in exc_str for indicator in rate_limit_indicators):
+        return True
+
+    # Check for HTTP 429 status code with word boundaries (avoid matching in object IDs)
+    return bool(re.search(r"\b429\b", exc_str))
 
 
 def _extract_structured_payload(result_text: str) -> dict[str, Any] | None:

--- a/src/ares/templates/blueteam/agents/escalation_triage.md.jinja
+++ b/src/ares/templates/blueteam/agents/escalation_triage.md.jinja
@@ -6,60 +6,84 @@ You evaluate escalated security investigations to determine if they truly requir
 
 Reduce false escalations by making intelligent triage decisions. Currently 69% of investigations are escalated - your job is to filter out false positives and route investigations appropriately.
 
+**CRITICAL INSIGHT**: Many escalations are for HISTORICAL attacks (already happened) that should have been COMPLETED by the investigation agent. These should be DOWNGRADED with instructions to complete, not confirmed.
+
 ## DECISION FRAMEWORK
 
 You have **4 possible decisions**:
 
-### 1. CONFIRM - Human review required
+### 1. CONFIRM - Human review required (ONLY for ACTIVE attacks)
 ```
 confirm_escalation(reasoning="...", severity="critical|high|medium")
 ```
 
-**When to confirm:**
-- Active attack in progress (credential theft, lateral movement)
-- Domain admin or critical system compromise
-- Multiple correlated MITRE techniques in attack chain
-- Data exfiltration or ransomware indicators
-- APT-like persistence mechanisms
-- Unknown or zero-day techniques
+**When to confirm (ALL must be true):**
+1. Attack is ACTIVELY IN PROGRESS right now
+2. Scope is expanding or cannot be contained automatically
+3. Immediate human decision is needed (not just documentation)
+
+**Specific scenarios:**
+- Active lateral movement across multiple hosts RIGHT NOW
+- Ongoing data exfiltration or ransomware encryption
+- Unknown/zero-day technique requiring expert analysis
+- Real-time incident response coordination needed
+
+**DO NOT confirm for:**
+- Historical attacks (even severe ones like DCSync - downgrade instead)
+- Documented attacks where findings are clear (downgrade)
+- Uncertainty by the investigation agent (downgrade)
 
 **Severity guide:**
-- `critical`: Active breach, DA compromise, ransomware, data exfil
-- `high`: Confirmed attack technique, credential access, multiple hosts
-- `medium`: Single host compromise, isolated attack technique
+- `critical`: Active breach in progress, real-time response needed
+- `high`: Active attack, immediate containment required
+- `medium`: AVOID - medium severity escalations should usually be downgraded
 
-### 2. DOWNGRADE - No human review needed
+### 2. DOWNGRADE - No human review needed (PREFERRED for most escalations)
 ```
 downgrade_escalation(reasoning="...", is_false_positive=True|False)
 ```
 
 **When to downgrade:**
+- **HISTORICAL ATTACKS** - Attack happened but is no longer active (most common!)
+  - "DCSync detected 2 hours ago" → downgrade, investigation should complete
+  - "Kerberoasting found yesterday" → downgrade, document findings instead
+  - "Golden Ticket used last week" → downgrade, needs remediation not escalation
 - False positive from benign admin activity
 - Known authorized penetration testing (check for pentest notes in alert)
 - Automated security scanning by IT team
 - Log artifacts from legitimate software (backup, AV, EDR)
 - Already remediated incidents (no ongoing activity)
 - Isolated low-confidence indicators with no corroboration
+- **Investigation agent was uncertain** - uncertainty != escalation-worthy
 
 **is_false_positive:**
 - `True`: Complete false alarm, benign activity misidentified
-- `False`: Low priority, not worth human time
+- `False`: Real activity but not escalation-worthy (historical, documented, contained)
 
-### 3. REINVESTIGATE - Need more data
+### 3. REINVESTIGATE - Need more data (USE SPARINGLY)
 ```
 request_reinvestigation(reasoning="...", focus_areas=["area1", "area2"])
 ```
 
-**When to reinvestigate (MAX 2 CYCLES):**
-- Insufficient log data for critical time period
-- Need to check related hosts/users not yet investigated
-- Ambiguous indicators need correlation with other sources
-- Missing context (what is this host? who is this user?)
+**⚠️ AVOID reinvestigation when possible.** In most cases:
+- If data is missing, the investigation was inconclusive → DOWNGRADE with reasoning
+- If you need more info to decide, default to DOWNGRADE (reversible)
+- Reinvestigation adds delay without guaranteed benefit
+
+**Only reinvestigate when (MAX 2 CYCLES):**
+- Critical escalation that WOULD be confirmed if specific data existed
+- Clear, specific data gap that can be filled with one more query
+- High confidence that reinvestigation will resolve ambiguity
 
 **focus_areas examples:**
 - "Check host ws01.contoso.local for lateral movement"
 - "Verify user admin@contoso.local activity in past 24h"
 - "Correlate with network traffic logs"
+
+**Prefer DOWNGRADE over REINVESTIGATE when:**
+- General uncertainty (not specific data gap)
+- Historical attack where more data won't change response
+- Already done 1+ reinvestigation cycles
 
 ### 4. ROUTE - Send to specific team
 ```
@@ -78,7 +102,20 @@ route_to_team(reasoning="...", team="...", action="...")
 1. **Call get_investigation_context()** - Understand what you're triaging
 2. **Evaluate the evidence** - Check pyramid level, techniques, scope
 3. **Check the escalation reason** - Is it justified?
-4. **Make ONE decision** - Call exactly one decision tool
+4. **Determine if attack is ACTIVE (ongoing) or HISTORICAL**
+5. **Make ONE decision** - Call exactly one decision tool
+
+## DECISION PRIORITY (check in order)
+
+Most escalations should be **DOWNGRADED**. Check these in order:
+
+1. **Is the attack historical (not active right now)?** → DOWNGRADE
+2. **Was the agent uncertain rather than detecting ongoing threat?** → DOWNGRADE
+3. **Is there a clear benign explanation?** → DOWNGRADE (false positive)
+4. **Is it real but contained/documented?** → DOWNGRADE (not escalation-worthy)
+5. **Does it need a specific team's expertise?** → ROUTE
+6. **Is there a specific, fillable data gap for a likely-confirm case?** → REINVESTIGATE
+7. **Is there an ACTIVE attack requiring real-time human response?** → CONFIRM
 
 ## DECISION CRITERIA CHECKLIST
 

--- a/src/ares/templates/blueteam/agents/system_instructions.md.jinja
+++ b/src/ares/templates/blueteam/agents/system_instructions.md.jinja
@@ -300,6 +300,45 @@ Before completing, review all evidence: can you explain each item's role? If not
 Every host and user in your synopsis MUST have track_host/user_investigation() called.
 If synopsis says "attacked 5 DCs" but scope shows 1 investigated — that's inconsistent.
 
+## Completion vs Escalation Decision (CRITICAL)
+
+**DEFAULT ACTION IS COMPLETE.** You should complete 90%+ of investigations.
+Escalation is RARE — only for situations requiring immediate human intervention.
+
+### COMPLETE the investigation when:
+- ✅ You found evidence and documented it (even partial findings)
+- ✅ You found NO evidence (this IS a valid finding — low confidence completion)
+- ✅ Alert appears to be false positive or benign activity
+- ✅ Attack already happened but is no longer active (post-incident)
+- ✅ You identified the attack but it's contained/limited scope
+- ✅ You're uncertain about findings (complete with LOW confidence)
+- ✅ Query limit reached (summarize what you have)
+
+### ESCALATE only when ALL of these are true:
+1. ⚠️ Attack is ACTIVELY IN PROGRESS (happening right now, not historical)
+2. ⚠️ Attacker has or is about to achieve Domain Admin / Golden Ticket
+3. ⚠️ Immediate containment action is needed (isolate hosts, disable accounts)
+4. ⚠️ You cannot fully document the scope because it's still expanding
+
+**If the attack already happened (even 30 minutes ago), COMPLETE — don't escalate.**
+
+### Decision Examples
+
+| Scenario | Action | Why |
+|----------|--------|-----|
+| Kerberoasting detected 2 hours ago | COMPLETE | Historical, document findings |
+| DCSync detected, krbtgt extracted 1 hour ago | COMPLETE | Already happened, document it |
+| Active lateral movement across 20+ hosts RIGHT NOW | ESCALATE | Ongoing, expanding scope |
+| No matching events found | COMPLETE (low confidence) | "No evidence" is a finding |
+| Found evidence but uncertain of severity | COMPLETE (medium confidence) | Uncertainty != escalation |
+| Golden Ticket used yesterday | COMPLETE | Historical, needs remediation not escalation |
+
+### Escalation is NOT for:
+- ❌ Uncertainty about findings (use low confidence instead)
+- ❌ Historical attacks (even severe ones — document them)
+- ❌ Alerts you don't fully understand (investigate more or complete)
+- ❌ "Playing it safe" (this wastes analyst time)
+
 ## Completion
 
 Call complete_investigation(summary, attack_synopsis, recommendations):
@@ -316,11 +355,6 @@ On 2026-01-10 14:30 UTC, attacker from 10.0.4.186 password-sprayed domain accoun
 After 47 failures, authenticated as carol.ng at 14:45. Accessed SYSVOL at 14:52.
 Executed DCSync at 15:10, extracting krbtgt hash. Time to compromise: 40 minutes.
 ```
-
-Call escalate_investigation() if:
-- Active ongoing attack
-- Scope exceeds capacity
-- Human intervention needed
 
 ## Parallel Execution
 

--- a/src/ares/tools/blue/actions.py
+++ b/src/ares/tools/blue/actions.py
@@ -36,40 +36,54 @@ class CompletionTools(Toolset):  # type: ignore[misc]
         current_findings: str,
         immediate_actions: list[str],
     ) -> str:
-        """Escalate the investigation for human analyst review.
+        """Escalate the investigation for IMMEDIATE human intervention.
 
-        Call this if:
-        - You identify an active, ongoing attack
-        - The scope exceeds investigation capacity
-        - You need human analyst intervention
-        - Critical infrastructure is at risk
-        - Domain Admin or Golden Ticket activity detected
+        ⚠️ ESCALATION IS RARE — use complete_investigation() for 90%+ of cases.
+
+        ONLY escalate when ALL of these conditions are true:
+        1. Attack is ACTIVELY IN PROGRESS (happening right now, not historical)
+        2. Attacker has or is about to achieve Domain Admin / Golden Ticket
+        3. Immediate containment is needed (isolate hosts, disable accounts NOW)
+        4. Scope is still expanding and you cannot fully document it
+
+        DO NOT ESCALATE for:
+        - Historical attacks (even severe ones — complete with findings)
+        - Uncertainty about findings (use low confidence completion)
+        - Alerts you don't understand (investigate more or complete)
+        - "Playing it safe" (this wastes analyst time)
+
+        If the attack already happened (even 30 min ago), use complete_investigation().
 
         Args:
-            reason: Why escalation is needed.
-            severity: critical, high, or medium.
-            current_findings: Summary of what you've found so far.
-            immediate_actions: Actions that should be taken immediately.
+            reason: Why IMMEDIATE human action is needed (not just "attack detected").
+            severity: critical or high (medium should use complete_investigation).
+            current_findings: What's happening RIGHT NOW that requires intervention.
+            immediate_actions: Containment actions needed in the next 5-15 minutes.
 
         Returns:
             Confirmation message.
 
         Example:
+            >>> # CORRECT - Active attack requiring immediate response
             >>> await escalate_investigation(
-            ...     reason="Active lateral movement detected across 15+ hosts",
+            ...     reason="Active lateral movement across 15+ hosts RIGHT NOW, scope expanding",
             ...     severity="critical",
-            ...     current_findings="Attacker has Domain Admin credentials and is actively "
-            ...                      "exfiltrating data from file servers.",
+            ...     current_findings="Attacker is actively moving through network. New hosts "
+            ...                      "compromised in last 5 minutes. Cannot contain scope.",
             ...     immediate_actions=[
-            ...         "Isolate compromised domain controller",
-            ...         "Reset all privileged account passwords",
-            ...         "Block C2 IP addresses at firewall"
+            ...         "Isolate subnet 192.168.58.0/24 immediately",
+            ...         "Disable compromised service account svc_backup",
+            ...         "Block external IP 203.0.113.50 at firewall"
             ...     ]
             ... )
-            'Investigation escalated with severity=critical. Human analyst notified.'
+
+            >>> # WRONG - Should use complete_investigation instead
+            >>> # "DCSync detected 2 hours ago" — historical, not active
+            >>> # "Found evidence of Kerberoasting" — document it, don't escalate
+            >>> # "Uncertain about attack severity" — complete with low confidence
 
         See Also:
-            complete_investigation: For normal investigation completion.
+            complete_investigation: Use this for 90%+ of investigations (default).
         """
         if not self.state:
             return "ERROR: No investigation state. Cannot escalate."

--- a/tests/core/test_redis_client.py
+++ b/tests/core/test_redis_client.py
@@ -16,6 +16,7 @@ from ares.core.redis_client import (
     create_redis_client,
     create_verified_redis_client,
     get_redis_sentinel_config,
+    get_retry_delay,
     is_connection_error,
     timed_redis_write,
 )
@@ -444,3 +445,39 @@ class TestTimedRedisWrite:
 
         result = await timed_redis_write(none_returning_op(), timeout=5.0)
         assert result is None
+
+
+class TestGetRetryDelay:
+    """Tests for get_retry_delay() exponential backoff helper."""
+
+    def test_exponential_backoff_sequence(self) -> None:
+        """Test that delays follow exponential backoff pattern."""
+        delays = [get_retry_delay(i) for i in range(6)]
+        assert delays == [1.0, 2.0, 4.0, 8.0, 10.0, 10.0]
+
+    def test_respects_max_delay_cap(self) -> None:
+        """Test that delay is capped at max_delay."""
+        # With default max_delay=10, attempt 4+ should be capped
+        assert get_retry_delay(4) == 10.0
+        assert get_retry_delay(10) == 10.0
+        assert get_retry_delay(100) == 10.0
+
+    def test_custom_base_delay(self) -> None:
+        """Test that custom base_delay is used."""
+        delays = [get_retry_delay(i, base_delay=0.5) for i in range(4)]
+        assert delays == [0.5, 1.0, 2.0, 4.0]
+
+    def test_custom_max_delay(self) -> None:
+        """Test that custom max_delay is respected."""
+        delays = [get_retry_delay(i, base_delay=1.0, max_delay=5.0) for i in range(6)]
+        assert delays == [1.0, 2.0, 4.0, 5.0, 5.0, 5.0]
+
+    def test_both_custom_params(self) -> None:
+        """Test with both custom base_delay and max_delay."""
+        delays = [get_retry_delay(i, base_delay=0.5, max_delay=3.0) for i in range(6)]
+        assert delays == [0.5, 1.0, 2.0, 3.0, 3.0, 3.0]
+
+    def test_first_attempt_equals_base_delay(self) -> None:
+        """Test that attempt 0 returns base_delay (2^0 = 1)."""
+        assert get_retry_delay(0, base_delay=2.0) == 2.0
+        assert get_retry_delay(0, base_delay=0.1) == 0.1

--- a/tests/core/test_task_queue.py
+++ b/tests/core/test_task_queue.py
@@ -1591,9 +1591,11 @@ class TestSpanTargetExtraction:
             )
 
         # dc_ip (192.168.58.10) should NOT be used as target_ip
-        # target_fqdn should be "MEEREEN" (from target_ips)
+        # target_hostname should be "MEEREEN" (NetBIOS name from target_ips)
+        # target_fqdn should be None since MEEREEN is not an FQDN
         assert captured_kwargs.get("target_ip") is None
-        assert captured_kwargs.get("target_fqdn") == "MEEREEN"
+        assert captured_kwargs.get("target_fqdn") is None
+        assert captured_kwargs.get("target_hostname") == "MEEREEN"
 
     @pytest.mark.asyncio
     async def test_target_ips_list_ip_used_as_target_ip(self, task_queue, mock_redis_client):

--- a/tests/core/test_tracing.py
+++ b/tests/core/test_tracing.py
@@ -605,6 +605,36 @@ class TestIpFqdnSeparation:
         # IP is not in dc_ips set, so should be server
         assert attrs["attack_target_type"] == "server"
 
+    def test_host_name_type_fqdn(self):
+        """host.name.type should be 'fqdn' when target_fqdn is provided."""
+        attrs = create_agent_span_attributes("lateral", "red", target_fqdn="dc01.contoso.local")
+        assert attrs["host.name.type"] == "fqdn"
+
+    def test_host_name_type_netbios(self):
+        """host.name.type should be 'netbios' when only target_hostname is provided."""
+        attrs = create_agent_span_attributes("lateral", "red", target_hostname="dc01")
+        assert attrs["host.name.type"] == "netbios"
+
+    def test_host_name_type_ip_only(self):
+        """host.name.type should be 'ip_only' when only target_ip is provided."""
+        attrs = create_agent_span_attributes("lateral", "red", target_ip="192.168.58.10")
+        assert attrs["host.name.type"] == "ip_only"
+
+    def test_host_name_type_fqdn_preferred_over_hostname(self):
+        """host.name.type should be 'fqdn' when both FQDN and hostname provided."""
+        attrs = create_agent_span_attributes(
+            "lateral",
+            "red",
+            target_fqdn="dc01.contoso.local",
+            target_hostname="dc01",
+        )
+        assert attrs["host.name.type"] == "fqdn"
+
+    def test_host_name_type_not_set_when_no_target(self):
+        """host.name.type should not be set when no target info provided."""
+        attrs = create_agent_span_attributes("lateral", "red")
+        assert "host.name.type" not in attrs
+
 
 class TestMitreMappings:
     """Tests for MITRE mappings completeness."""

--- a/tests/core/worker/test_worker.py
+++ b/tests/core/worker/test_worker.py
@@ -1436,5 +1436,65 @@ class TestUpdateEtcHosts:
         assert "192.168.58.100  dc01.child.contoso.local dc01 child.contoso.local\n" in written
 
 
+class TestIsRateLimitError:
+    """Tests for _is_rate_limit_error function."""
+
+    def test_detects_rate_limit_in_exception_type(self):
+        """Test detection of rate limit from exception type name."""
+        from ares.core.worker._worker import _is_rate_limit_error
+
+        class RateLimitError(Exception):
+            pass
+
+        assert _is_rate_limit_error(RateLimitError("test"))
+
+    def test_detects_rate_limit_in_message(self):
+        """Test detection of rate limit from exception message."""
+        from ares.core.worker._worker import _is_rate_limit_error
+
+        assert _is_rate_limit_error(Exception("rate limit exceeded"))
+        assert _is_rate_limit_error(Exception("Rate_Limit_Error"))
+        assert _is_rate_limit_error(Exception("ratelimit"))
+        assert _is_rate_limit_error(Exception("Too many requests"))
+        assert _is_rate_limit_error(Exception("quota exceeded"))
+        assert _is_rate_limit_error(Exception("tokens per min limit"))
+        assert _is_rate_limit_error(Exception("requests per min exceeded"))
+        assert _is_rate_limit_error(Exception("TPM limit"))
+        assert _is_rate_limit_error(Exception("RPM limit reached"))
+
+    def test_detects_http_429_status(self):
+        """Test detection of HTTP 429 status code."""
+        from ares.core.worker._worker import _is_rate_limit_error
+
+        assert _is_rate_limit_error(Exception("Error 429: Too Many Requests"))
+        assert _is_rate_limit_error(Exception("status 429"))
+        assert _is_rate_limit_error(Exception("HTTP/1.1 429"))
+
+    def test_ignores_429_in_object_ids(self):
+        """Test that 429 in object IDs (like MagicMock) is not detected.
+
+        This prevents false positives when MagicMock objects have IDs
+        that happen to contain '429' as a substring.
+        """
+        from ares.core.worker._worker import _is_rate_limit_error
+
+        # Simulate MagicMock stringification with 429 in the ID
+        mock_str = "<MagicMock name='mock.error' id='139808142945184'>"
+        assert not _is_rate_limit_error(Exception(mock_str))
+
+        # Other object IDs that might contain 429
+        assert not _is_rate_limit_error(Exception("object at 0x14293456789"))
+        assert not _is_rate_limit_error(Exception("id=4290001234"))
+
+    def test_non_rate_limit_errors(self):
+        """Test that non-rate-limit errors are not detected."""
+        from ares.core.worker._worker import _is_rate_limit_error
+
+        assert not _is_rate_limit_error(Exception("Connection refused"))
+        assert not _is_rate_limit_error(Exception("timeout"))
+        assert not _is_rate_limit_error(Exception("invalid credentials"))
+        assert not _is_rate_limit_error(Exception("server error"))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiobreaker"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/eb/749ef48d3227fd62d500ff01fcd451f10111e00d822c200eb51782ba076a/aiobreaker-1.2.0.tar.gz", hash = "sha256:217a9cfa12e520bb2dd1934bace281d1d7deb8d7630dd183a6295fd22e323ce7", size = 15947, upload-time = "2021-05-17T11:58:05.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/c8/4cd4b2834012ffc71ae3fd69187f08a17f01f3937527b6b5e077f4f5d0db/aiobreaker-1.2.0-py3-none-any.whl", hash = "sha256:f275decad78bdd161715afeee67e5dde7967de54c836648b44f4eea1b5e41d60", size = 20700, upload-time = "2021-05-17T11:58:04.192Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -146,6 +155,7 @@ name = "ares"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiobreaker" },
     { name = "boto3" },
     { name = "cyclopts" },
     { name = "dreadnode" },
@@ -184,6 +194,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiobreaker", specifier = ">=1.2.0" },
     { name = "boto3", specifier = ">=1.42.25" },
     { name = "cyclopts", specifier = ">=4.2.0" },
     { name = "dreadnode", specifier = ">=1.17.0" },
@@ -3381,6 +3392,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
     { url = "https://files.pythonhosted.org/packages/78/89/f5554b13ebd71e05c0b002f95148033e730d3f7067f67423026cc9c69410/torch-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3282d9febd1e4e476630a099692b44fdc214ee9bf8ee5377732d9d9dfe5712e4", size = 145992610, upload-time = "2026-01-21T16:25:26.327Z" },
     { url = "https://files.pythonhosted.org/packages/ae/30/a3a2120621bf9c17779b169fc17e3dc29b230c29d0f8222f499f5e159aa8/torch-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a2f9edd8dbc99f62bc4dfb78af7bf89499bca3d753423ac1b4e06592e467b763", size = 915607863, upload-time = "2026-01-21T16:25:06.696Z" },
     { url = "https://files.pythonhosted.org/packages/6f/3d/c87b33c5f260a2a8ad68da7147e105f05868c281c63d65ed85aa4da98c66/torch-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:29b7009dba4b7a1c960260fc8ac85022c784250af43af9fb0ebafc9883782ebd", size = 113723116, upload-time = "2026-01-21T16:25:21.916Z" },


### PR DESCRIPTION

**Key Changes:**

- Implemented tenacity-based exponential backoff and circuit breaker retry logic
  for all Redis write operations in state backends and task queues
- Standardized retry and delay parameters to match redis-py's recommended
  ExponentialBackoff pattern
- Added granular tracing and span attribute improvements to separate FQDN,
  NetBIOS, and IP for target hosts
- Updated blue team escalation logic and documentation to favor completion for
  historical attacks and clarify rare escalation scenarios

**Added:**

- Tenacity-based async retry logic with exponential backoff and shared circuit
  breaker for all Redis write operations in `BlueStateBackend` and
  `RedisStateBackend`
- `_with_retry` helper methods to encapsulate retry/circuit breaker logic in
  backends
- `get_retry_delay` utility to calculate exponential backoff delays, with
  comprehensive unit tests
- New span attribute `host.name.type` to indicate hostname resolution quality
  (`fqdn`, `netbios`, or `ip_only`) in tracing for observability
- Extended tests for retry delay and tracing behaviors

**Changed:**

- All Redis write methods in state backends (`add_credential`, `add_hash`,
  `add_host`, `add_weakness`, `add_vulnerability`, `mark_exploited`,
  `set_meta`, `store_artifact`, `add_pending_task`, `add_completed_task`) now
  use circuit breaker and exponential backoff retry by default
- Blue and red task queue logic for `submit_task`, `wait_for_result`,
  `send_result`, and `poll_for_task` now employ exponential backoff and
  increased default retry attempts to handle transient Redis/Sentinel failures
- Improved span attribute extraction in task/worker queues and tracing:
  - Now distinguishes plain NetBIOS hostnames (`target_hostname`) from FQDNs
  - Avoids setting FQDN field for NetBIOS-only targets, provides new attribute
- Updated escalation and completion documentation/templates for blue team
  agents:
  - Escalation is now strongly discouraged for historical attacks and
    uncertainty
  - Completion is the default path for nearly all investigations
  - More precise criteria and examples for escalation vs. completion
- Enhanced escalation tool docstrings and examples to clarify correct vs.
  incorrect use cases for escalation

**Removed:**

- Previous logic that treated plain hostnames as FQDNs in tracing and span
  extraction for task and worker queues
- Outdated escalation guidance in blue team agent system instructions and
  escalation tool docstrings