### PR TITLE
fix: normalize credential and hash domains, improve MITRE mapping, and sync Redis state

### DIFF
--- a/src/ares/cli_ops.py
+++ b/src/ares/cli_ops.py
@@ -687,6 +687,12 @@ def _print_loot(state, *, json_output: bool = False) -> None:
     """Print loot from state in human-readable or JSON format."""
     import json as json_module
 
+    # Normalize credentials and hashes against discovered users
+    # This handles cases where domains are wrong due to race conditions or LLM hallucination
+    state.normalize_credential_domains_to_users()
+    state.normalize_hash_domains_to_users()
+    state.cleanup_invalid_domains()
+
     unique_users = _dedup_users(state.all_users)
     unique_creds = _dedup_credentials(state.all_credentials)
     unique_hashes = _dedup_hashes(state.all_hashes)

--- a/src/ares/core/dispatcher/publishing.py
+++ b/src/ares/core/dispatcher/publishing.py
@@ -71,14 +71,25 @@ class PublishingMixin:
             import uuid
             from datetime import datetime, timezone
 
+            # Determine MITRE techniques based on credential source
+            mitre_techniques = ["T1078"] if is_admin else ["T1552"]
+            cred_source_lower = (credential.source or "").lower()
+            if "kerberoast" in cred_source_lower:
+                mitre_techniques.append("T1558.003")  # Kerberoasting
+            if "asrep" in cred_source_lower or "as-rep" in cred_source_lower:
+                mitre_techniques.append("T1558.004")  # AS-REP Roasting
+            if "cracked" in cred_source_lower:
+                mitre_techniques.append("T1110")  # Brute Force (password cracking)
             timeline_event = TimelineEvent(
                 id=f"evt-cred-{uuid.uuid4().hex[:8]}",
                 timestamp=datetime.now(timezone.utc),
                 source=source_agent,
                 description=f"Credential discovered: {credential.domain}\\{credential.username} via {credential.source}",
-                mitre_techniques=["T1078"] if is_admin else ["T1552"],
+                mitre_techniques=mitre_techniques,
             )
             self.shared_state.operation_timeline.append(timeline_event)
+            # Add techniques to identified_techniques set for MITRE mapping in report
+            self.shared_state.identified_techniques.update(mitre_techniques)
             # Persist timeline event to Redis
             await self._persist_timeline_event(timeline_event, task_queue)
             is_main_thread = threading.current_thread() is threading.main_thread()
@@ -256,14 +267,46 @@ class PublishingMixin:
             )
             if is_critical:
                 event_desc = f"CRITICAL: {event_desc}"
+
+            # Determine MITRE techniques based on hash type and source
+            mitre_techniques = ["T1003"]  # OS Credential Dumping
+            hash_value_lower = (hash_obj.hash_value or "").lower()
+            hash_type_lower = (hash_obj.hash_type or "").lower()
+            hash_source_lower = (hash_obj.source or "").lower()
+
+            # Kerberoasting: TGS-REP hashes
+            if (
+                "$krb5tgs$" in hash_value_lower
+                or hash_type_lower in ("kerberoast", "krb5tgs", "tgs-rep", "tgs")
+                or "kerberoast" in hash_source_lower
+            ):
+                mitre_techniques.append("T1558.003")  # Kerberoasting
+
+            # AS-REP Roasting: AS-REP hashes
+            if (
+                "$krb5asrep$" in hash_value_lower
+                or hash_type_lower in ("asrep", "as-rep", "krb5asrep")
+                or "asrep" in hash_source_lower
+                or "as-rep" in hash_source_lower
+            ):
+                mitre_techniques.append("T1558.004")  # AS-REP Roasting
+
+            # DCSync or secretsdump for NTLM hashes
+            if hash_type_lower == "ntlm" and (
+                "secretsdump" in hash_source_lower or "dcsync" in hash_source_lower
+            ):
+                mitre_techniques.append("T1003.006")  # DCSync
+
             timeline_event = TimelineEvent(
                 id=f"evt-hash-{uuid.uuid4().hex[:8]}",
                 timestamp=datetime.now(timezone.utc),
                 source=source_agent,
                 description=event_desc,
-                mitre_techniques=["T1003"],  # OS Credential Dumping
+                mitre_techniques=mitre_techniques,
             )
             self.shared_state.operation_timeline.append(timeline_event)
+            # Add techniques to identified_techniques set for MITRE mapping in report
+            self.shared_state.identified_techniques.update(mitre_techniques)
             # Persist timeline event to Redis
             await self._persist_timeline_event(timeline_event, task_queue)
             if is_main_thread:

--- a/src/ares/core/dispatcher/result_processing.py
+++ b/src/ares/core/dispatcher/result_processing.py
@@ -364,6 +364,26 @@ class ResultProcessingMixin:
                 if success:
                     logger.info(f"✅ Marked vulnerability {vuln_id} as exploited")
 
+        # Mark parent vulnerability as exploited when chained task succeeds
+        # This handles the S4U chain: constrained_delegation exploit -> secretsdump
+        # The secretsdump task carries parent_vuln_id from the original exploit
+        # When secretsdump succeeds, it proves the S4U attack worked end-to-end
+        parent_vuln_id = task_params.get("parent_vuln_id", "")
+        if (
+            parent_vuln_id
+            and success
+            and parent_vuln_id not in self.shared_state.exploited_vulnerabilities
+        ):
+            result_dict = result if isinstance(result, dict) else {"output": str(result)}
+            await self.mark_vulnerability_exploited(
+                parent_vuln_id, success, result_dict, task_queue=task_queue
+            )
+            da_note = " (achieved DA!)" if self.shared_state.has_domain_admin else ""
+            logger.info(
+                f"✅ Marked parent vulnerability {parent_vuln_id} as exploited "
+                f"(chained secretsdump succeeded{da_note})"
+            )
+
         # Resolve any waiting futures
         self._resolve_task_future(task_id, success, result, error)
 

--- a/src/ares/core/dispatcher/routing.py
+++ b/src/ares/core/dispatcher/routing.py
@@ -592,7 +592,18 @@ class RoutingMixin:
 
         dc_ip = self._find_domain_controller_ip(domain)
 
-        logger.info(f"🎫 S4U SUCCESS! Auto-chaining secretsdump: {ticket_path} -> {target_host}")
+        # Get vuln_id from parent task to propagate through the chain
+        # This ensures the vulnerability is marked as exploited when secretsdump succeeds
+        parent_vuln_id = params.get("vuln_id", "")
+        if parent_vuln_id:
+            logger.info(
+                f"🎫 S4U SUCCESS! Auto-chaining secretsdump: {ticket_path} -> {target_host} "
+                f"(tracking vuln_id: {parent_vuln_id})"
+            )
+        else:
+            logger.info(
+                f"🎫 S4U SUCCESS! Auto-chaining secretsdump: {ticket_path} -> {target_host}"
+            )
 
         await self.request_credential_access(
             domain=domain,
@@ -605,6 +616,10 @@ class RoutingMixin:
                 "ticket_path": ticket_path,
                 "no_pass": True,  # nosec B105 - not a password, it's a flag
                 "dc_ip": dc_ip,
+                # Propagate vuln_id for exploitation tracking
+                # When secretsdump succeeds (especially if it dumps krbtgt),
+                # the parent vulnerability should be marked as exploited
+                "parent_vuln_id": parent_vuln_id,
             },
             task_queue=task_queue,
         )

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -1074,10 +1074,41 @@ class SharedRedTeamState:
                 if host.ip not in existing_host_ips:
                     self.all_hosts.append(host)
 
+            # Refresh completion state flags (critical for accurate reporting)
+            has_da, da_path, _da_hash_id = await self._backend.get_domain_admin()
+            if has_da:
+                self.has_domain_admin = True
+                if da_path:
+                    self.domain_admin_path = da_path
+
+            has_gt = await self._backend.get_golden_ticket()
+            if has_gt:
+                self.has_golden_ticket = True
+
+            # Refresh golden tickets list
+            redis_golden_tickets = await self._backend.get_golden_tickets()
+            existing_gt_domains = {t.get("domain", "").lower() for t in self.golden_tickets}
+            for gt in redis_golden_tickets:
+                if gt.get("domain", "").lower() not in existing_gt_domains:
+                    self.golden_tickets.append(gt)
+
+            # Refresh completed_at timestamp
+            completed_at_str = await self._backend.get_meta("completed_at")
+            if completed_at_str and not self.completed_at:
+                from datetime import datetime
+
+                self.completed_at = datetime.fromisoformat(completed_at_str)
+
+            # Refresh completed flag
+            redis_completed = await self._backend.get_meta("completed", default=False)
+            if redis_completed:
+                self.completed = True
+
             logger.info(
                 f"State refreshed from Redis: {len(self.all_shares)} shares, "
                 f"{len(self.exploited_vulnerabilities)} exploited vulns, "
-                f"{len(self.all_credentials)} creds, {len(self.all_hashes)} hashes"
+                f"{len(self.all_credentials)} creds, {len(self.all_hashes)} hashes, "
+                f"DA={self.has_domain_admin}, GT={self.has_golden_ticket}"
             )
 
         except Exception as e:

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -1012,6 +1012,77 @@ class SharedRedTeamState:
 
                     logger.warning(f"Failed to load processed set {attr_name}: {e}")
 
+    async def refresh_from_redis(self) -> None:
+        """Refresh all collections from Redis into memory.
+
+        This should be called before report generation to ensure the orchestrator's
+        in-memory state includes data that workers persisted directly to Redis.
+        Workers write directly to Redis, but the orchestrator's memory doesn't
+        automatically sync those changes. This method fetches fresh data and
+        merges it with existing in-memory state.
+        """
+        if not self._backend:
+            logger.debug("No backend configured, skipping refresh_from_redis")
+            return
+
+        logger.info("Refreshing state from Redis before report generation...")
+
+        try:
+            # Refresh shares (workers add these directly to Redis)
+            redis_shares = await self._backend.get_shares()
+            existing_share_keys = {(s.host, s.name) for s in self.all_shares}
+            for share in redis_shares:
+                if (share.host, share.name) not in existing_share_keys:
+                    self.all_shares.append(share)
+
+            # Refresh exploited vulnerabilities
+            redis_exploited = await self._backend.get_exploited_vulnerabilities()
+            self.exploited_vulnerabilities.update(redis_exploited)
+
+            # Refresh credentials (workers may add via threaded consumers)
+            redis_creds = await self._backend.get_credentials()
+            existing_cred_keys = {
+                (c.username.lower(), c.domain.lower(), c.password) for c in self.all_credentials
+            }
+            for cred in redis_creds:
+                key = (cred.username.lower(), cred.domain.lower(), cred.password)
+                if key not in existing_cred_keys:
+                    self.all_credentials.append(cred)
+
+            # Refresh hashes
+            redis_hashes = await self._backend.get_hashes()
+            existing_hash_keys = {
+                (h.username.lower(), h.domain.lower(), h.hash_value) for h in self.all_hashes
+            }
+            for h in redis_hashes:
+                key = (h.username.lower(), h.domain.lower(), h.hash_value)
+                if key not in existing_hash_keys:
+                    self.all_hashes.append(h)
+
+            # Refresh users
+            redis_users = await self._backend.get_users()
+            existing_user_keys = {(u.username.lower(), u.domain.lower()) for u in self.all_users}
+            for user in redis_users:
+                user_key = (user.username.lower(), user.domain.lower())
+                if user_key not in existing_user_keys:
+                    self.all_users.append(user)
+
+            # Refresh hosts
+            redis_hosts = await self._backend.get_hosts()
+            existing_host_ips = {h.ip for h in self.all_hosts}
+            for host in redis_hosts:
+                if host.ip not in existing_host_ips:
+                    self.all_hosts.append(host)
+
+            logger.info(
+                f"State refreshed from Redis: {len(self.all_shares)} shares, "
+                f"{len(self.exploited_vulnerabilities)} exploited vulns, "
+                f"{len(self.all_credentials)} creds, {len(self.all_hashes)} hashes"
+            )
+
+        except Exception as e:
+            logger.warning(f"Failed to refresh state from Redis: {e}")
+
     async def cleanup_background_tasks(self) -> None:
         """Cancel and await all pending background publish tasks.
 
@@ -2087,9 +2158,17 @@ class SharedRedTeamState:
 
         When a new FQDN domain is added, retroactively normalizes any existing
         credentials/users/hashes that have a matching NetBIOS domain name.
+
+        Only accepts valid FQDN domains (must contain at least one dot).
+        Single-word names (hostnames, NetBIOS names) are rejected.
         """
         normalized = (domain or "").strip().lower()
         if not normalized:
+            return False
+        # Reject single-word entries - these are hostnames or NetBIOS names, not FQDN domains
+        # Valid AD domains always have at least one dot (e.g., contoso.local)
+        if "." not in normalized:
+            logger.debug(f"Rejected non-FQDN domain: {normalized}")
             return False
         if any(existing.lower() == normalized for existing in self.all_domains):
             return False
@@ -2812,7 +2891,7 @@ class SharedRedTeamState:
         if ips:
             return ips
 
-        # User accounts with dots/underscores (svc_backup, admin.user)
+        # User accounts with dots/underscores (svc_backup, admin.user, jon.snow)
         user_accounts = [
             m.group(1)
             for m in re.finditer(r"\b([a-z]+[._][a-z]+)\b", block_lower)
@@ -2820,6 +2899,17 @@ class SharedRedTeamState:
         ]
         if user_accounts:
             return user_accounts
+
+        # Also check for usernames after dashes (e.g., "Constrained Delegation - user.name")
+        # Normalize various dash types first (em-dash \u2014 and en-dash \u2013)
+        normalized = block_lower.replace("\u2014", "-").replace("\u2013", "-")
+        title_usernames = [
+            m.group(1)
+            for m in re.finditer(r"-\s*([a-z][a-z0-9._]+)\s*$", normalized, re.MULTILINE)
+            if "." in m.group(1) or "_" in m.group(1)
+        ]
+        if title_usernames:
+            return title_usernames
 
         # Hostnames with digits (dc01, sql01)
         common_words = {
@@ -2887,7 +2977,13 @@ class SharedRedTeamState:
         The key is derived from weakness TYPE + affected entities.
         This handles LLM rephrasing the same finding with different titles.
         """
+        # Normalize the block: lowercase, normalize dashes, collapse whitespace
         block_lower = block.lower()
+        # Normalize various dash types to regular dash (em-dash \u2014 and en-dash \u2013)
+        block_lower = block_lower.replace("\u2014", "-").replace("\u2013", "-")
+        # Collapse multiple spaces
+        block_lower = " ".join(block_lower.split())
+
         entities = self._extract_entities_from_weakness(block_lower)
         weakness_type = self._classify_weakness_type(block_lower)
         unique_entities = sorted(set(entities))
@@ -3348,6 +3444,237 @@ class SharedRedTeamState:
             cred.password = password
             deduped.append(cred)
         return deduped
+
+    def normalize_credential_domains_to_users(self) -> int:
+        """Normalize credential domains to match discovered user domains.
+
+        Handles cross-domain duplicates where the same credential was stored
+        with different domains (e.g., parent vs child domain). This happens
+        when credentials are added before user enumeration completes, or when
+        Redis updates fail from threaded consumers.
+
+        For each username:password pair with multiple domain entries:
+        - If user exists in exactly one domain, keep only that credential
+        - If user exists in multiple domains, keep all (legitimate password reuse)
+        - If user not found, keep the most specific domain (longest FQDN)
+
+        Returns:
+            Number of duplicate credentials removed.
+        """
+        # Build user domain lookup: username -> set of domains
+        user_domains: dict[str, set[str]] = {}
+        for user in self.all_users:
+            username_lower = user.username.lower()
+            if user.domain:
+                user_domains.setdefault(username_lower, set()).add(user.domain.lower())
+
+        # Group credentials by username:password
+        cred_groups: dict[str, list[Credential]] = {}
+        for cred in self.all_credentials:
+            key = f"{cred.username.lower()}:{cred.password}"
+            cred_groups.setdefault(key, []).append(cred)
+
+        # Process each group
+        normalized: list[Credential] = []
+        removed = 0
+
+        for key, creds in cred_groups.items():
+            username_lower = creds[0].username.lower()
+            domains_for_user = user_domains.get(username_lower, set())
+
+            if len(creds) == 1:
+                # Only one credential for this username:password
+                cred = creds[0]
+                # Check if domain needs correction based on where user actually exists
+                if len(domains_for_user) == 1:
+                    correct_domain = next(iter(domains_for_user))
+                    if cred.domain.lower() != correct_domain:
+                        old_domain = cred.domain
+                        cred.domain = correct_domain
+                        logger.info(
+                            f"Credential domain corrected: {cred.username} "
+                            f"{old_domain} -> {correct_domain}"
+                        )
+                normalized.append(cred)
+                continue
+
+            # Multiple credentials with same username:password but different domains
+            if len(domains_for_user) == 0:
+                # User not enumerated - keep most specific (longest) domain
+                best = max(creds, key=lambda c: len(c.domain))
+                normalized.append(best)
+                removed += len(creds) - 1
+                logger.debug(
+                    f"Credential dedup (no user): {key.split(':')[0]} - "
+                    f"kept {best.domain}, removed {len(creds) - 1} others"
+                )
+            elif len(domains_for_user) == 1:
+                # User exists in exactly one domain - keep only matching credential
+                correct_domain = next(iter(domains_for_user))
+                kept = None
+                for cred in creds:
+                    if cred.domain.lower() == correct_domain:
+                        kept = cred
+                        break
+                if kept:
+                    normalized.append(kept)
+                    removed += len(creds) - 1
+                    logger.info(
+                        f"Credential dedup (user in {correct_domain}): {key.split(':')[0]} - "
+                        f"removed {len(creds) - 1} cross-domain duplicates"
+                    )
+                else:
+                    # No exact match - update the most specific credential's domain
+                    best = max(creds, key=lambda c: len(c.domain))
+                    old_domain = best.domain
+                    best.domain = correct_domain
+                    normalized.append(best)
+                    removed += len(creds) - 1
+                    logger.info(
+                        f"Credential domain corrected: {key.split(':')[0]} "
+                        f"{old_domain} -> {correct_domain}"
+                    )
+            else:
+                # User exists in multiple domains - check which credentials match actual domains
+                for cred in creds:
+                    if cred.domain.lower() in domains_for_user:
+                        normalized.append(cred)
+                    else:
+                        removed += 1
+                        logger.debug(
+                            f"Credential dedup (multi-domain): removed "
+                            f"{cred.domain}\\{cred.username} (user not in that domain)"
+                        )
+
+        if removed > 0:
+            self.all_credentials = normalized
+            logger.info(f"Normalized {removed} cross-domain credential duplicate(s)")
+
+        return removed
+
+    def normalize_hash_domains_to_users(self) -> int:
+        """Normalize hash domains to match discovered user domains.
+
+        Handles LLM hallucinations where the domain is misspelled (e.g., 'sevenkingdomain'
+        instead of 'sevenkingdoms'). For each hash, if the user exists in exactly one
+        known domain and the hash's domain doesn't match, correct it.
+
+        Returns:
+            Number of hashes with domains corrected.
+        """
+        # Build user domain lookup: username -> set of domains
+        user_domains: dict[str, set[str]] = {}
+        for user in self.all_users:
+            username_lower = user.username.lower()
+            if user.domain:
+                user_domains.setdefault(username_lower, set()).add(user.domain.lower())
+
+        # Build set of known valid domains from AUTHORITATIVE sources only
+        # (not from all_domains which may contain LLM-hallucinated typos)
+        known_domains: set[str] = set()
+        # From user domains
+        for domains_set in user_domains.values():
+            known_domains.update(domains_set)
+        # From host FQDNs
+        for host in self.all_hosts:
+            if host.hostname and "." in host.hostname:
+                parts = host.hostname.lower().split(".")
+                if len(parts) > 1:
+                    known_domains.add(".".join(parts[1:]))
+        # From target
+        if self.target and self.target.domain:
+            known_domains.add(self.target.domain.lower())
+
+        corrected = 0
+        seen_hashes: set[str] = set()  # For deduplication after normalization
+        normalized_hashes: list[Hash] = []
+
+        for hash_obj in self.all_hashes:
+            username_lower = hash_obj.username.lower()
+            hash_domain = (hash_obj.domain or "").lower()
+
+            # Skip well-known accounts that exist in every domain
+            if username_lower in {"krbtgt", "administrator", "guest", "defaultaccount"}:
+                # Still dedupe by hash value
+                dedup_key = f"{hash_domain}:{username_lower}:{hash_obj.hash_value}"
+                if dedup_key not in seen_hashes:
+                    seen_hashes.add(dedup_key)
+                    normalized_hashes.append(hash_obj)
+                continue
+
+            domains_for_user = user_domains.get(username_lower, set())
+
+            # If hash domain is not in known domains but user exists in exactly one domain
+            if hash_domain not in known_domains and len(domains_for_user) == 1:
+                correct_domain = next(iter(domains_for_user))
+                old_domain = hash_obj.domain
+                hash_obj.domain = correct_domain
+                corrected += 1
+                logger.info(
+                    f"Hash domain corrected: {username_lower} {old_domain} -> {correct_domain}"
+                )
+
+            # Deduplicate by hash value (after potential domain correction)
+            dedup_key = f"{hash_obj.domain.lower()}:{username_lower}:{hash_obj.hash_value}"
+            if dedup_key not in seen_hashes:
+                seen_hashes.add(dedup_key)
+                normalized_hashes.append(hash_obj)
+
+        if corrected > 0 or len(normalized_hashes) != len(self.all_hashes):
+            removed = len(self.all_hashes) - len(normalized_hashes)
+            self.all_hashes = normalized_hashes
+            if corrected > 0:
+                logger.info(f"Normalized {corrected} hash domain(s)")
+            if removed > 0:
+                logger.info(f"Removed {removed} duplicate hash(es) after normalization")
+
+        return corrected
+
+    def cleanup_invalid_domains(self) -> int:
+        """Remove domains that don't match any known valid pattern.
+
+        Cleans up typo domains like 'sevenkingdomain.local' that were added
+        due to LLM hallucination. A domain is considered invalid if:
+        - No users exist in that domain
+        - No hosts have that domain in their FQDN
+        - It's not the target domain
+
+        Returns:
+            Number of invalid domains removed.
+        """
+        # Build set of valid domains from various sources
+        valid_domains: set[str] = set()
+
+        # From target
+        if self.target and self.target.domain:
+            valid_domains.add(self.target.domain.lower())
+
+        # From hosts (extract domain from FQDN)
+        for host in self.all_hosts:
+            if host.hostname and "." in host.hostname:
+                parts = host.hostname.lower().split(".")
+                if len(parts) > 1:
+                    valid_domains.add(".".join(parts[1:]))
+
+        # From users
+        for user in self.all_users:
+            if user.domain:
+                valid_domains.add(user.domain.lower())
+
+        # Check which domains in all_domains are actually valid
+        invalid_domains = []
+        for domain in self.all_domains:
+            domain_lower = domain.lower()
+            if domain_lower not in valid_domains:
+                invalid_domains.append(domain)
+
+        # Remove invalid domains
+        if invalid_domains:
+            self.all_domains = [d for d in self.all_domains if d.lower() in valid_domains]
+            for domain in invalid_domains:
+                logger.info(f"Removed invalid domain: {domain}")
+
+        return len(invalid_domains)
 
     @staticmethod
     def _extract_domains(state: SharedRedTeamState) -> list[str]:

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -3150,9 +3150,14 @@ async def _auto_golden_ticket(
     """
     import re
 
+    first_check = True
     while True:
         try:
-            await asyncio.sleep(check_interval)
+            # Check immediately on first iteration, then sleep between subsequent checks.
+            # This avoids missing krbtgt hashes discovered just before we start.
+            if not first_check:
+                await asyncio.sleep(check_interval)
+            first_check = False
 
             state = dispatcher.shared_state
 

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -1042,6 +1042,10 @@ async def run_multi_agent_operation(
         final_state = dispatcher.shared_state
         end_time = datetime.now(timezone.utc)
 
+        # Refresh state from Redis before report generation
+        # Workers write directly to Redis, but orchestrator memory doesn't auto-sync
+        await final_state.refresh_from_redis()
+
         report_path = None
         report_markdown = None
         try:

--- a/src/ares/core/orchestrator_service.py
+++ b/src/ares/core/orchestrator_service.py
@@ -146,7 +146,7 @@ class OrchestratorService:
         return result
 
     async def _get_checkpoint_time(self, op_id: str) -> datetime | None:
-        if self.task_queue is None:
+        if self.task_queue is None or self.task_queue._client is None:
             return None
         # Read started_at from redis-native meta hash
         meta_key = f"ares:op:{op_id}:meta"

--- a/src/ares/core/recovery.py
+++ b/src/ares/core/recovery.py
@@ -328,6 +328,23 @@ class OperationRecoveryManager:
         if techniques:
             logger.info(f"Loaded {len(techniques)} MITRE techniques from Redis")
 
+        # Normalize credentials and hashes against discovered users
+        # This handles cases where Redis updates failed from threaded consumers
+        # or LLM hallucinated typo domains
+        cred_fixed = state.normalize_credential_domains_to_users()
+        hash_fixed = state.normalize_hash_domains_to_users()
+        state.cleanup_invalid_domains()  # Side-effect: modifies state in place
+
+        # Persist corrections to Redis
+        if cred_fixed > 0:
+            for cred in state.all_credentials:
+                await backend.add_credential(cred)
+        if hash_fixed > 0:
+            for h in state.all_hashes:
+                await backend.add_hash(h)
+        # Note: domain cleanup not persisted - invalid domains will remain in Redis
+        # but won't affect operation since they're not in memory
+
     def _dedupe_hashes(self, hashes: list) -> list:
         """Deduplicate hashes, keeping first occurrence.
 

--- a/src/ares/reports/redteam.py
+++ b/src/ares/reports/redteam.py
@@ -9,12 +9,113 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
 
 from ares.core.templates import get_template_loader
 
 if TYPE_CHECKING:
     from ares.core.models import SharedRedTeamState
+
+
+@lru_cache(maxsize=1)
+def _load_mitre_techniques() -> dict[str, str]:
+    """Load MITRE technique names from YAML file.
+
+    Returns:
+        Dict mapping technique IDs to names (e.g., "T1003" -> "OS Credential Dumping")
+    """
+    yaml_path = Path(__file__).parent.parent / "templates" / "mitre_techniques.yaml"
+    try:
+        with open(yaml_path) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def _get_technique_display(technique_id: str) -> str:
+    """Get display string for a MITRE technique ID.
+
+    Args:
+        technique_id: MITRE technique ID (e.g., "T1003.006")
+
+    Returns:
+        Formatted string like "T1003.006 (DCSync)" or just "T1003.006" if unknown
+    """
+    techniques = _load_mitre_techniques()
+    name = techniques.get(technique_id)
+    if name:
+        return f"{technique_id} ({name})"
+    return technique_id
+
+
+def _format_vuln_details(details: Any) -> str:
+    """Format vulnerability details dict as readable text.
+
+    Args:
+        details: Vulnerability details (dict, str, or other)
+
+    Returns:
+        Human-readable formatted string
+    """
+    if not details:
+        return "-"
+    if isinstance(details, str):
+        return details
+    if not isinstance(details, dict):
+        return str(details)
+
+    # Key display names and order
+    key_display = {
+        "account": "Account",
+        "account_name": "Account",
+        "username": "Username",
+        "domain": "Domain",
+        "target_spn": "Target SPN",
+        "delegation_type": "Type",
+        "dc_ip": "DC IP",
+        "ca_name": "CA Name",
+        "ca_host": "CA Host",
+        "hostname": "Hostname",
+        "hash": "Hash",
+        "note": "Note",
+        "attack_type": "Attack Type",
+        "adcs_server": "ADCS Server",
+    }
+
+    # Skip internal/redundant keys
+    skip_keys = {
+        "has_credentials",
+        "discovered_by",
+        "services",
+        "available_credentials",
+        "attack_steps",
+        "is_sql_account",
+    }
+
+    parts = []
+    for key, display_name in key_display.items():
+        if key in details and key not in skip_keys:
+            value = details[key]
+            if value is not None and value != "":
+                parts.append(f"{display_name}: {value}")
+
+    # Add any remaining keys not in key_display
+    for key, value in details.items():
+        if (
+            key not in key_display
+            and key not in skip_keys
+            and value is not None
+            and value != ""
+            and not isinstance(value, (list, dict))
+        ):
+            display_key = key.replace("_", " ").title()
+            parts.append(f"{display_key}: {value}")
+
+    return "; ".join(parts) if parts else "-"
 
 
 def _parse_weakness_block(block: str) -> dict[str, str]:
@@ -147,10 +248,13 @@ class RedTeamReportGenerator:
                     "target": vuln.target,
                     "priority": vuln.priority,
                     "exploited": vuln_id in state.exploited_vulnerabilities,
-                    "details": vuln.details or "",
+                    "details": _format_vuln_details(vuln.details),
                 }
             )
         discovered_vulns.sort(key=lambda v: v.get("priority", 999))  # type: ignore[arg-type,return-value]
+
+        # Enrich MITRE techniques with names
+        techniques_enriched = [_get_technique_display(t) for t in sorted(all_techniques)]
 
         # Render the report using the template
         target_ips = state.target_ips or ([state.target.ip] if state.target else [])
@@ -180,7 +284,7 @@ class RedTeamReportGenerator:
             weaknesses=_deduplicate_weaknesses(state.all_weaknesses),
             discovered_vulns=discovered_vulns,
             timeline=state.operation_timeline,
-            techniques_identified=sorted(all_techniques),
+            techniques_identified=techniques_enriched,
         )
 
     def _generate_executive_summary(self, state: SharedRedTeamState) -> str:
@@ -370,7 +474,7 @@ def generate_comprehensive_report(state: SharedRedTeamState) -> str:
                 "target_host": vuln.target,
                 "priority": vuln.priority,
                 "exploited": vuln_id in state.exploited_vulnerabilities,
-                "details": vuln.details or "",
+                "details": _format_vuln_details(vuln.details),
             }
         )
     discovered_vulns.sort(key=lambda v: v.get("priority", 999))  # type: ignore[arg-type,return-value]
@@ -389,6 +493,9 @@ def generate_comprehensive_report(state: SharedRedTeamState) -> str:
         # Collect techniques from timeline events into the aggregate set
         if event.mitre_techniques:
             all_techniques.update(event.mitre_techniques)
+
+    # Enrich MITRE techniques with names
+    techniques_enriched = [_get_technique_display(t) for t in sorted(all_techniques)]
 
     # Get target info
     target_ip = state.target.ip if state.target else "Unknown"
@@ -418,7 +525,7 @@ def generate_comprehensive_report(state: SharedRedTeamState) -> str:
         shares=state.all_shares,
         weaknesses=_deduplicate_weaknesses(state.all_weaknesses),
         timeline=timeline,
-        techniques=sorted(all_techniques),
+        techniques=techniques_enriched,
         discovered_vulns=discovered_vulns,
         vulnerabilities_found=len(state.discovered_vulnerabilities),
         vulnerabilities_exploited=len(state.exploited_vulnerabilities),

--- a/src/ares/reports/redteam.py
+++ b/src/ares/reports/redteam.py
@@ -47,6 +47,31 @@ def _parse_weakness_block(block: str) -> dict[str, str]:
     return result
 
 
+def _deduplicate_weaknesses(weaknesses: list[str]) -> list[dict[str, str]]:
+    """Parse and deduplicate weaknesses by normalized title.
+
+    This provides a final deduplication pass at report generation time
+    to catch any duplicates that might have slipped through.
+    """
+    seen_titles: set[str] = set()
+    result: list[dict[str, str]] = []
+
+    for w in weaknesses:
+        parsed = _parse_weakness_block(w)
+        title = parsed.get("title", "").strip()
+        # Normalize title for deduplication: lowercase, normalize dashes (em-dash \u2014, en-dash \u2013)
+        normalized_title = title.lower().replace("\u2014", "-").replace("\u2013", "-")
+        normalized_title = " ".join(normalized_title.split())
+
+        if normalized_title and normalized_title in seen_titles:
+            continue
+        if normalized_title:
+            seen_titles.add(normalized_title)
+        result.append(parsed)
+
+    return result
+
+
 class RedTeamReportGenerator:
     """Generates markdown reports from red team operation results.
 
@@ -82,6 +107,9 @@ class RedTeamReportGenerator:
             user_key = (user.domain.lower(), user.username.lower())
             if user_key not in seen_users:
                 seen_users.add(user_key)
+                # Normalize is_admin for known admin usernames
+                if user.username.lower() in ("administrator", "krbtgt"):
+                    user.is_admin = True
                 unique_users.append(user)
 
         # Deduplicate credentials (case-insensitive on domain+username+password)
@@ -91,18 +119,17 @@ class RedTeamReportGenerator:
             cred_key = (cred.domain.lower(), cred.username.lower(), cred.password)
             if cred_key not in seen_creds:
                 seen_creds.add(cred_key)
+                # Normalize is_admin for known admin usernames
+                if cred.username.lower() in ("administrator", "krbtgt"):
+                    cred.is_admin = True
                 unique_creds.append(cred)
 
         # Calculate counts from SharedRedTeamState
         host_count = len(state.all_hosts)
         credential_count = len(unique_creds)
 
-        # Count admins - check is_admin flag OR known admin usernames
-        admin_count = sum(
-            1
-            for c in unique_creds
-            if c.is_admin or c.username.lower() in ("administrator", "krbtgt")
-        )
+        # Count admins (is_admin already normalized above)
+        admin_count = sum(1 for c in unique_creds if c.is_admin)
 
         # Aggregate MITRE techniques from timeline events
         all_techniques: set[str] = set(state.identified_techniques)
@@ -150,7 +177,7 @@ class RedTeamReportGenerator:
             users=unique_users,
             credentials=unique_creds,
             shares=state.all_shares,
-            weaknesses=[_parse_weakness_block(w) for w in state.all_weaknesses],
+            weaknesses=_deduplicate_weaknesses(state.all_weaknesses),
             discovered_vulns=discovered_vulns,
             timeline=state.operation_timeline,
             techniques_identified=sorted(all_techniques),
@@ -176,17 +203,16 @@ class RedTeamReportGenerator:
             cred_key = (cred.domain.lower(), cred.username.lower(), cred.password)
             if cred_key not in seen_creds:
                 seen_creds.add(cred_key)
+                # Normalize is_admin for known admin usernames (match generate())
+                if cred.username.lower() in ("administrator", "krbtgt"):
+                    cred.is_admin = True
                 unique_creds.append(cred)
 
         # Calculate counts from SharedRedTeamState
         host_count = len(state.all_hosts)
         credential_count = len(unique_creds)
-        # Count admins - check is_admin flag OR known admin usernames (match generate())
-        admin_count = sum(
-            1
-            for c in unique_creds
-            if c.is_admin or c.username.lower() in ("administrator", "krbtgt")
-        )
+        # Count admins (is_admin already normalized above)
+        admin_count = sum(1 for c in unique_creds if c.is_admin)
         vulnerability_count = len(state.discovered_vulnerabilities)
         exploited_count = len(state.exploited_vulnerabilities)
 
@@ -306,6 +332,9 @@ def generate_comprehensive_report(state: SharedRedTeamState) -> str:
         key = (cred.domain.lower(), cred.username.lower(), cred.password)
         if key not in seen_creds:
             seen_creds.add(key)
+            # Normalize is_admin for known admin usernames
+            if cred.username.lower() in ("administrator", "krbtgt"):
+                cred.is_admin = True
             unique_creds.append(cred)
 
     seen_hashes: set[tuple[str, str, str]] = set()
@@ -386,7 +415,8 @@ def generate_comprehensive_report(state: SharedRedTeamState) -> str:
         users=state.all_users,
         credentials=unique_creds,
         hashes=unique_hashes,
-        weaknesses=[_parse_weakness_block(w) for w in state.all_weaknesses],
+        shares=state.all_shares,
+        weaknesses=_deduplicate_weaknesses(state.all_weaknesses),
         timeline=timeline,
         techniques=sorted(all_techniques),
         discovered_vulns=discovered_vulns,

--- a/src/ares/templates/mitre_techniques.yaml
+++ b/src/ares/templates/mitre_techniques.yaml
@@ -1,0 +1,96 @@
+# MITRE ATT&CK Technique Names
+# Static mapping for report generation without network dependency
+# Reference: https://attack.mitre.org/techniques/enterprise/
+---
+
+# Credential Access (TA0006)
+T1003: "OS Credential Dumping"
+T1003.001: "LSASS Memory"
+T1003.002: "Security Account Manager"
+T1003.003: "NTDS"
+T1003.004: "LSA Secrets"
+T1003.005: "Cached Domain Credentials"
+T1003.006: "DCSync"
+
+T1110: "Brute Force"
+T1110.001: "Password Guessing"
+T1110.002: "Password Cracking"
+T1110.003: "Password Spraying"
+T1110.004: "Credential Stuffing"
+
+T1552: "Unsecured Credentials"
+T1552.001: "Credentials In Files"
+T1552.002: "Credentials in Registry"
+T1552.004: "Private Keys"
+T1552.006: "Group Policy Preferences"
+
+T1555: "Credentials from Password Stores"
+
+T1558: "Steal or Forge Kerberos Tickets"
+T1558.001: "Golden Ticket"
+T1558.002: "Silver Ticket"
+T1558.003: "Kerberoasting"
+T1558.004: "AS-REP Roasting"
+
+# Discovery (TA0007)
+T1016: "System Network Configuration Discovery"
+T1018: "Remote System Discovery"
+T1033: "System Owner/User Discovery"
+T1046: "Network Service Discovery"
+
+T1069: "Permission Groups Discovery"
+T1069.001: "Local Groups"
+T1069.002: "Domain Groups"
+
+T1082: "System Information Discovery"
+
+T1087: "Account Discovery"
+T1087.001: "Local Account"
+T1087.002: "Domain Account"
+
+T1135: "Network Share Discovery"
+T1201: "Password Policy Discovery"
+
+# Lateral Movement (TA0008)
+T1021: "Remote Services"
+T1021.001: "Remote Desktop Protocol"
+T1021.002: "SMB/Windows Admin Shares"
+T1021.003: "Distributed Component Object Model"
+T1021.006: "Windows Remote Management"
+
+T1550: "Use Alternate Authentication Material"
+T1550.002: "Pass the Hash"
+T1550.003: "Pass the Ticket"
+
+# Privilege Escalation (TA0004)
+T1068: "Exploitation for Privilege Escalation"
+
+T1078: "Valid Accounts"
+T1078.002: "Domain Accounts"
+
+T1134: "Access Token Manipulation"
+
+T1484: "Domain Policy Modification"
+T1484.001: "Group Policy Modification"
+
+# Persistence (TA0003)
+T1098: "Account Manipulation"
+
+T1136: "Create Account"
+T1136.002: "Domain Account"
+
+# Execution (TA0002)
+T1047: "Windows Management Instrumentation"
+T1053: "Scheduled Task/Job"
+
+T1059: "Command and Scripting Interpreter"
+T1059.001: "PowerShell"
+
+T1569: "System Services"
+T1569.002: "Service Execution"
+
+# Defense Evasion (TA0005)
+T1070: "Indicator Removal"
+T1070.001: "Clear Windows Event Logs"
+
+T1562: "Impair Defenses"

--- a/src/ares/templates/redteam/reports/comprehensive_report.md.jinja
+++ b/src/ares/templates/redteam/reports/comprehensive_report.md.jinja
@@ -52,6 +52,7 @@ Persistent domain access has been established via Golden Ticket.
 | NTLM Hashes Captured | {{ hashes|length }} |
 | Vulnerabilities Found | {{ vulnerabilities_found }} |
 | Vulnerabilities Exploited | {{ vulnerabilities_exploited }} |
+| Network Shares | {{ shares|length if shares else 0 }} |
 
 ---
 
@@ -78,6 +79,20 @@ Persistent domain access has been established via Golden Ticket.
 {% endif %}
 
 {% endfor %}
+
+---
+
+## Network Shares
+
+{% if shares %}
+| Share | Host | Permissions |
+|-------|------|-------------|
+{% for share in shares %}
+| {{ share.name }} | {{ share.host }} | {{ share.permissions or '-' }} |
+{% endfor %}
+{% else %}
+No network shares discovered.
+{% endif %}
 
 ---
 

--- a/tests/core/dispatcher/test_dispatcher.py
+++ b/tests/core/dispatcher/test_dispatcher.py
@@ -1468,26 +1468,29 @@ class TestDispatcherAddUserDelegation:
 class TestRetroactiveDomainNormalize:
     """Tests for retroactive domain normalization."""
 
-    def test_retroactive_normalize_removes_netbios_from_domains(self):
-        """Adding FQDN should remove corresponding NetBIOS from all_domains."""
-        state = SharedRedTeamState(operation_id="op-test-retro-netbios")
+    def test_add_domain_rejects_netbios_names(self):
+        """NetBIOS names (single-word, no dot) should be rejected from all_domains."""
+        state = SharedRedTeamState(operation_id="op-test-netbios-reject")
 
-        # Add NetBIOS domain first
-        state.add_domain("child")
-        assert "child" in state.all_domains
-
-        # Add FQDN - should trigger retroactive normalization
-        state.add_domain("child.contoso.local")
-
-        # NetBIOS should be removed
+        # NetBIOS names should be rejected (no dot = not a valid FQDN)
+        result = state.add_domain("child")
+        assert result is False
         assert "child" not in state.all_domains
+
+        result = state.add_domain("CONTOSO")
+        assert result is False
+        assert "contoso" not in state.all_domains
+
+        # FQDNs should be accepted
+        result = state.add_domain("child.contoso.local")
+        assert result is True
         assert "child.contoso.local" in state.all_domains
 
     def test_retroactive_normalize_updates_credentials(self):
         """Adding FQDN should update credentials with NetBIOS domain."""
         state = SharedRedTeamState(operation_id="op-test-retro-creds")
 
-        # Add credential with NetBIOS domain
+        # Add credential with NetBIOS domain (simulating tool output with short domain)
         cred = Credential(
             username="sql_svc",
             password="SqlP@ss!",  # pragma: allowlist secret
@@ -1495,12 +1498,13 @@ class TestRetroactiveDomainNormalize:
             source="test",
         )
         state.all_credentials.append(cred)
-        state.add_domain("child")
+        # Note: add_domain("child") would be rejected now, but the credential
+        # was added directly to all_credentials with the NetBIOS domain
 
-        # Add FQDN
+        # Add FQDN - should trigger retroactive normalization of credentials
         state.add_domain("child.contoso.local")
 
-        # Credential should be updated
+        # Credential should be updated to use FQDN
         assert state.all_credentials[0].domain == "child.contoso.local"
 
     def test_retroactive_normalize_triggers_parent_child_normalization(self):
@@ -1531,6 +1535,106 @@ class TestRetroactiveDomainNormalize:
         state.add_domain("child.contoso.local")
 
         # Credential should be updated to child domain
+        assert state.all_credentials[0].domain == "child.contoso.local"
+
+
+class TestNormalizeCredentialDomainsToUsers:
+    """Tests for normalize_credential_domains_to_users method."""
+
+    def test_removes_cross_domain_duplicate_when_user_in_one_domain(self):
+        """Same credential with different domains, user only exists in one domain."""
+        from ares.core.models import User
+
+        state = SharedRedTeamState(operation_id="op-test-normalize-cred")
+
+        # User only exists in child domain
+        state.all_users.append(User(username="samwell.tarly", domain="north.sevenkingdoms.local"))
+
+        # Two credentials: one with parent domain (wrong), one with child domain (correct)
+        state.all_credentials.append(
+            Credential(
+                username="samwell.tarly",
+                password="Heartsbane",  # pragma: allowlist secret
+                domain="sevenkingdoms.local",
+                source="test1",
+            )
+        )
+        state.all_credentials.append(
+            Credential(
+                username="samwell.tarly",
+                password="Heartsbane",  # pragma: allowlist secret
+                domain="north.sevenkingdoms.local",
+                source="test2",
+            )
+        )
+
+        # Run normalization
+        removed = state.normalize_credential_domains_to_users()
+
+        # Should remove the parent domain credential
+        assert removed == 1
+        assert len(state.all_credentials) == 1
+        assert state.all_credentials[0].domain == "north.sevenkingdoms.local"
+
+    def test_keeps_legitimate_password_reuse_across_domains(self):
+        """Same credential in multiple domains where user exists in both."""
+        from ares.core.models import User
+
+        state = SharedRedTeamState(operation_id="op-test-legit-reuse")
+
+        # User exists in BOTH domains (legitimate password reuse)
+        state.all_users.append(User(username="arya.stark", domain="sevenkingdoms.local"))
+        state.all_users.append(User(username="arya.stark", domain="north.sevenkingdoms.local"))
+
+        # Credentials in both domains
+        state.all_credentials.append(
+            Credential(
+                username="arya.stark",
+                password="needle",  # pragma: allowlist secret
+                domain="sevenkingdoms.local",
+                source="test1",
+            )
+        )
+        state.all_credentials.append(
+            Credential(
+                username="arya.stark",
+                password="needle",  # pragma: allowlist secret
+                domain="north.sevenkingdoms.local",
+                source="test2",
+            )
+        )
+
+        # Run normalization
+        removed = state.normalize_credential_domains_to_users()
+
+        # Should keep both (user exists in both domains)
+        assert removed == 0
+        assert len(state.all_credentials) == 2
+
+    def test_corrects_credential_domain_when_no_exact_match(self):
+        """Credential with wrong domain, user exists in different domain."""
+        from ares.core.models import User
+
+        state = SharedRedTeamState(operation_id="op-test-correct-domain")
+
+        # User only exists in child domain
+        state.all_users.append(User(username="sql_svc", domain="child.contoso.local"))
+
+        # Credential has parent domain (wrong)
+        state.all_credentials.append(
+            Credential(
+                username="sql_svc",
+                password="SqlP@ss123!",  # pragma: allowlist secret
+                domain="contoso.local",
+                source="test",
+            )
+        )
+
+        # Run normalization
+        state.normalize_credential_domains_to_users()
+
+        # Should correct the domain (treated as duplicate removal + domain fix)
+        assert len(state.all_credentials) == 1
         assert state.all_credentials[0].domain == "child.contoso.local"
 
 

--- a/tests/core/dispatcher/test_result_processing.py
+++ b/tests/core/dispatcher/test_result_processing.py
@@ -857,5 +857,148 @@ class TestResultProcessingPassesTaskQueue:
         assert call_kwargs.get("task_queue") is mock_task_queue
 
 
+class TestParentVulnIdTracking:
+    """Tests for parent_vuln_id propagation through S4U chain.
+
+    When a constrained_delegation exploit dispatches a chained secretsdump task,
+    the parent_vuln_id is passed through so the vulnerability can be marked as
+    exploited when secretsdump succeeds.
+    """
+
+    @pytest.mark.asyncio
+    async def test_secretsdump_marks_parent_vuln_exploited(self):
+        """When secretsdump with parent_vuln_id succeeds, parent vuln is marked exploited."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ares.core.dispatcher._dispatcher import RedTeamDispatcher
+        from ares.core.models import SharedRedTeamState, TaskInfo
+
+        dispatcher = RedTeamDispatcher()
+        dispatcher._shared_state = SharedRedTeamState(operation_id="op-test-parent-vuln")
+        dispatcher._running = True
+        dispatcher._redis_client = AsyncMock()
+
+        # Mock the methods we don't want to actually run
+        dispatcher._persist_completed_task = AsyncMock()
+        dispatcher._auto_chain_s4u_lateral_movement = AsyncMock(return_value=0)
+        dispatcher.mark_vulnerability_exploited = AsyncMock()
+        dispatcher._get_task_info_from_redis = AsyncMock(return_value=None)
+
+        # Create mock task_queue
+        mock_task_queue = MagicMock()
+        mock_task_queue.redis = AsyncMock()
+
+        # Create task info for secretsdump (credential_access) with parent_vuln_id
+        task_info = TaskInfo(
+            task_id="task-secretsdump-1",
+            task_type="credential_access",  # NOT "exploit"
+            assigned_agent="credaccess",
+            params={"parent_vuln_id": "constrained_delegation_192.168.58.10_abc123"},
+        )
+        dispatcher._shared_state.pending_tasks["task-secretsdump-1"] = task_info
+
+        # Also need to mock the persist method
+        dispatcher._persist_task_info_to_redis = AsyncMock()
+
+        result = {"output": "Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6..."}
+
+        await dispatcher.complete_task(
+            task_id="task-secretsdump-1",
+            success=True,
+            result=result,
+            source_agent="credaccess",
+            task_queue=mock_task_queue,
+        )
+
+        # mark_vulnerability_exploited should be called for the parent_vuln_id
+        dispatcher.mark_vulnerability_exploited.assert_called_once()
+        call_args = dispatcher.mark_vulnerability_exploited.call_args
+        assert call_args.args[0] == "constrained_delegation_192.168.58.10_abc123"
+        assert call_args.args[1] is True  # success=True
+
+    @pytest.mark.asyncio
+    async def test_secretsdump_without_parent_vuln_id_does_not_mark(self):
+        """Secretsdump without parent_vuln_id doesn't call mark_vulnerability_exploited."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ares.core.dispatcher._dispatcher import RedTeamDispatcher
+        from ares.core.models import SharedRedTeamState, TaskInfo
+
+        dispatcher = RedTeamDispatcher()
+        dispatcher._shared_state = SharedRedTeamState(operation_id="op-test-no-parent")
+        dispatcher._running = True
+        dispatcher._redis_client = AsyncMock()
+
+        # Mock the methods we don't want to actually run
+        dispatcher._persist_completed_task = AsyncMock()
+        dispatcher._auto_chain_s4u_lateral_movement = AsyncMock(return_value=0)
+        dispatcher.mark_vulnerability_exploited = AsyncMock()
+        dispatcher._get_task_info_from_redis = AsyncMock(return_value=None)
+
+        # Create task info for secretsdump without parent_vuln_id
+        task_info = TaskInfo(
+            task_id="task-secretsdump-2",
+            task_type="credential_access",
+            assigned_agent="credaccess",
+            params={},  # No parent_vuln_id
+        )
+        dispatcher._shared_state.pending_tasks["task-secretsdump-2"] = task_info
+
+        dispatcher._persist_task_info_to_redis = AsyncMock()
+
+        result = {"output": "Some output"}
+
+        await dispatcher.complete_task(
+            task_id="task-secretsdump-2",
+            success=True,
+            result=result,
+            source_agent="credaccess",
+            task_queue=MagicMock(),
+        )
+
+        # mark_vulnerability_exploited should NOT be called
+        dispatcher.mark_vulnerability_exploited.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_secretsdump_does_not_mark_parent_vuln(self):
+        """Failed secretsdump with parent_vuln_id doesn't mark parent vuln exploited."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ares.core.dispatcher._dispatcher import RedTeamDispatcher
+        from ares.core.models import SharedRedTeamState, TaskInfo
+
+        dispatcher = RedTeamDispatcher()
+        dispatcher._shared_state = SharedRedTeamState(operation_id="op-test-failed")
+        dispatcher._running = True
+        dispatcher._redis_client = AsyncMock()
+
+        dispatcher._persist_completed_task = AsyncMock()
+        dispatcher._auto_chain_s4u_lateral_movement = AsyncMock(return_value=0)
+        dispatcher.mark_vulnerability_exploited = AsyncMock()
+        dispatcher._get_task_info_from_redis = AsyncMock(return_value=None)
+
+        task_info = TaskInfo(
+            task_id="task-secretsdump-3",
+            task_type="credential_access",
+            assigned_agent="credaccess",
+            params={"parent_vuln_id": "constrained_delegation_192.168.58.10_def456"},
+        )
+        dispatcher._shared_state.pending_tasks["task-secretsdump-3"] = task_info
+
+        dispatcher._persist_task_info_to_redis = AsyncMock()
+
+        await dispatcher.complete_task(
+            task_id="task-secretsdump-3",
+            success=False,  # Failed
+            result={"error": "Access denied"},
+            error="Access denied",
+            source_agent="credaccess",
+            task_queue=MagicMock(),
+        )
+
+        # mark_vulnerability_exploited should NOT be called for failed task
+        dispatcher.mark_vulnerability_exploited.assert_not_called()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/orchestrator/test_orchestrator.py
+++ b/tests/core/orchestrator/test_orchestrator.py
@@ -44,6 +44,7 @@ async def test_run_multi_agent_operation_skips_wait_when_completed(monkeypatch):
         pending_tasks={},
         processed_asrep_domains=set(),  # For immediate AS-REP dispatch
         golden_tickets=[],  # For _wait_for_golden_ticket
+        refresh_from_redis=AsyncMock(),  # For final state refresh
     )
 
     dispatcher = SimpleNamespace(shared_state=shared_state)


### PR DESCRIPTION


**Key Changes:**

- Added normalization methods to align credential and hash domains with discovered users
- Improved MITRE ATT&CK technique mapping for credentials and hashes in timeline events
- Implemented in-memory state refresh from Redis before report generation
- Enhanced deduplication and reporting of weaknesses and shares in red team reports

**Added:**

- Credential and hash domain normalization methods to retroactively correct domains
  and remove duplicates caused by race conditions or LLM hallucinations
- In-memory state refresh from Redis, ensuring orchestrator has all data before
  report generation (`refresh_from_redis` in `SharedRedTeamState`)
- Deduplication logic for weaknesses in report generation to avoid duplicate findings
- Comprehensive test coverage for credential normalization and parent vulnerability
  tracking for chained exploits

**Changed:**

- Timeline event MITRE technique mapping now dynamically adds appropriate
  techniques based on credential/hash source and type (e.g., Kerberoasting,
  AS-REP Roasting, DCSync)
- Orchestrator now calls `refresh_from_redis` before generating reports to
  ensure latest state is used
- Domain addition logic now rejects non-FQDN (single-word) domain names, ensuring
  only valid domains are accepted and used for normalization
- Weakness deduplication and admin normalization improved in report generation
  and markdown output
- Network share statistics and tables are now included in comprehensive reports
- Parent vulnerability ID is propagated and tracked through S4U exploit chains,
  ensuring correct exploitation tracking in chained attacks

**Removed:**

- Acceptance of NetBIOS-only (single-word) domain names as valid Active
  Directory domains (now rejected and not added to `all_domains`)