### PR TITLE
feat: add attack chain implications and sentinel retry logic for investigations

### DIFF
--- a/src/ares/core/blue_orchestrator_service.py
+++ b/src/ares/core/blue_orchestrator_service.py
@@ -22,6 +22,7 @@ from ares.core.blue_task_queue import BlueTaskQueue
 from ares.core.config import get_namespace, get_redis_url
 from ares.core.litellm_env import configure_litellm_env
 from ares.core.redis_client import (
+    get_retry_delay,
     invalidate_sentinel_client,
     is_connection_error,
 )
@@ -639,14 +640,35 @@ class BlueOrchestratorService:
                     max_steps=request.max_steps,
                 )
 
-            # Run the investigation
+            # Run the investigation with retry for transient connection errors
             # Note: Status is updated to "completed" inside investigate() after report generation
             logger.info(f"Starting investigation: {request.investigation_id}")
-            result = await orchestrator.investigate(
-                alert=request.alert,
-                correlation_context=request.correlation_context,
-                investigation_id=request.investigation_id,
-            )
+            max_retries = 3
+            last_error: Exception | None = None
+            for attempt in range(max_retries):
+                try:
+                    result = await orchestrator.investigate(
+                        alert=request.alert,
+                        correlation_context=request.correlation_context,
+                        investigation_id=request.investigation_id,
+                    )
+                    break  # Success
+                except Exception as e:
+                    last_error = e
+                    if is_connection_error(e) and attempt < max_retries - 1:
+                        delay = get_retry_delay(attempt)
+                        logger.warning(
+                            f"Connection error in investigation {request.investigation_id} "
+                            f"(attempt {attempt + 1}/{max_retries}): {e}. "
+                            f"Retrying in {delay:.1f}s..."
+                        )
+                        invalidate_sentinel_client()
+                        await asyncio.sleep(delay)
+                    else:
+                        raise
+            else:
+                # All retries exhausted
+                raise last_error  # type: ignore[misc]
 
             completed_at = datetime.now(timezone.utc)
             elapsed = (completed_at - started_at).total_seconds()

--- a/src/ares/core/redis_client.py
+++ b/src/ares/core/redis_client.py
@@ -280,6 +280,8 @@ _CONNECTION_ERROR_KEYWORDS = frozenset(
         "getaddrinfo",
         "temporary failure in name resolution",
         "no address associated",
+        # Sentinel failover errors
+        "no master found",
     }
 )
 

--- a/src/ares/templates/blueteam/agents/escalation_triage.md.jinja
+++ b/src/ares/templates/blueteam/agents/escalation_triage.md.jinja
@@ -12,24 +12,33 @@ Reduce false escalations by making intelligent triage decisions. Currently 69% o
 
 You have **4 possible decisions**:
 
-### 1. CONFIRM - Human review required (ONLY for ACTIVE attacks)
+### 1. CONFIRM - Human review required (ACTIVE attacks OR domain compromise)
 ```
 confirm_escalation(reasoning="...", severity="critical|high|medium")
 ```
 
-**When to confirm (ALL must be true):**
+**When to confirm (ANY of these):**
 1. Attack is ACTIVELY IN PROGRESS right now
 2. Scope is expanding or cannot be contained automatically
 3. Immediate human decision is needed (not just documentation)
+4. **DOMAIN COMPROMISE INDICATORS** (even if historical - see below)
 
 **Specific scenarios:**
 - Active lateral movement across multiple hosts RIGHT NOW
 - Ongoing data exfiltration or ransomware encryption
 - Unknown/zero-day technique requiring expert analysis
 - Real-time incident response coordination needed
+- **T1003.006 (DCSync) confirmed** → krbtgt compromised = Golden Ticket capability
+- **Credential dump with krbtgt hash** → domain is fully compromised
+- **Constrained delegation to DC** → DA impersonation possible
+
+**DOMAIN COMPROMISE EXCEPTION**: Unlike other historical attacks, **domain admin compromise requires escalation even if not active**. Once krbtgt is dumped, the attacker has persistent access via Golden Tickets. This requires:
+- Immediate krbtgt password reset (twice)
+- Domain-wide credential reset assessment
+- Golden Ticket detection monitoring
 
 **DO NOT confirm for:**
-- Historical attacks (even severe ones like DCSync - downgrade instead)
+- Historical attacks that DON'T involve domain compromise
 - Documented attacks where findings are clear (downgrade)
 - Uncertainty by the investigation agent (downgrade)
 
@@ -117,12 +126,30 @@ Most escalations should be **DOWNGRADED**. Check these in order:
 6. **Is there a specific, fillable data gap for a likely-confirm case?** → REINVESTIGATE
 7. **Is there an ACTIVE attack requiring real-time human response?** → CONFIRM
 
+## ATTACK CHAIN IMPLICATIONS (CRITICAL)
+
+Some techniques imply capabilities that WON'T appear in logs. **Do not downgrade based on absence of log evidence for these:**
+
+| Observed Technique | Implied Capability | Why No Logs? |
+|--------------------|-------------------|--------------|
+| **T1003.006 (DCSync)** | Golden Ticket (T1558.001) | Ticket forging is in-memory, no Windows events |
+| **T1003.001/003 (LSASS/NTDS dump)** | Golden Ticket if krbtgt obtained | Same - forgery leaves no trace |
+| **T1550.003 (Constrained Delegation)** | DA impersonation to target SPN | S4U2Proxy is legitimate Kerberos |
+| **T1558.003 (Kerberoasting)** | Offline password cracking | Cracking happens offline |
+
+**RULE**: If DCSync or credential dumping is confirmed, treat Golden Ticket as **CAPABILITY ACHIEVED** regardless of whether T1558.001 was detected. The absence of Golden Ticket detection means nothing - it's undetectable at creation time.
+
+**Example**: Investigation shows T1003.006 (DCSync) confirmed but T1558.001 (Golden Ticket) "NOT OBSERVED":
+- WRONG: "Golden Ticket not detected, downgrading"
+- RIGHT: "DCSync confirmed = Golden Ticket capability assumed. Escalating as domain compromise."
+
 ## DECISION CRITERIA CHECKLIST
 
 Before confirming (all must be true):
 - [ ] Evidence supports an actual attack (not just anomaly)
 - [ ] Confidence is HIGH (validated evidence, multiple sources)
 - [ ] Impact justifies analyst time
+- [ ] **Check ATTACK CHAIN IMPLICATIONS** - implied capabilities count as evidence
 
 Before downgrading:
 - [ ] Clear explanation for the activity (benign cause identified)
@@ -153,5 +180,11 @@ Your reasoning will be recorded for audit. Include:
 2. Why alternative decisions don't apply
 3. Confidence level justification
 
-Example reasoning:
+Example reasoning (active attack):
 "Confirmed escalation (high) because: (1) T1003.001 credential dumping detected on dc01.contoso.local, (2) krbtgt hash found in evidence, (3) multiple hosts show lateral movement. Not downgrading because activity is not consistent with known IT operations. Confidence 0.9 based on validated evidence from multiple sources."
+
+Example reasoning (domain compromise via attack chain):
+"Confirmed escalation (critical) because: (1) T1003.006 DCSync confirmed against dc01.contoso.local, (2) DCSync implies krbtgt hash extraction = Golden Ticket capability. Even though T1558.001 (Golden Ticket) was NOT OBSERVED in logs, this is expected - ticket forging is undetectable. Attack chain implication: domain is fully compromised. Requires immediate krbtgt reset. Confidence 0.95."
+
+Example reasoning (historical attack, no DA):
+"Downgraded escalation because: (1) Kerberoasting (T1558.003) detected but attack was 6 hours ago, (2) no lateral movement or privilege escalation followed, (3) affected accounts are service accounts with strong passwords. Attack chain: offline cracking is possible but not confirmed. Recommend password rotation but no immediate escalation needed. Confidence 0.8."

--- a/src/ares/tools/blue/triage_tools.py
+++ b/src/ares/tools/blue/triage_tools.py
@@ -69,6 +69,77 @@ class EscalationTriageTools(Toolset):  # type: ignore[misc]
         if self._completion_event:
             self._completion_event.set()
 
+    def _get_implied_capabilities(self, techniques: set[str]) -> list[str]:
+        """Infer attack capabilities from observed techniques.
+
+        Certain techniques imply that other attacks are now possible,
+        even if we haven't observed them directly. This is critical for
+        triage - we shouldn't downgrade just because we didn't SEE the
+        follow-on attack in logs.
+
+        Args:
+            techniques: Set of observed MITRE technique IDs.
+
+        Returns:
+            List of implied capability warnings.
+        """
+        implied = []
+
+        # krbtgt hash extraction → Golden Ticket capability
+        # T1003.006 = DCSync, T1003.001 = LSASS dump, T1003.003 = NTDS.dit
+        credential_dump_techniques = {"T1003.006", "T1003.001", "T1003.003", "T1003"}
+        if credential_dump_techniques & techniques:
+            implied.append(
+                "GOLDEN TICKET CAPABILITY: Credential dumping detected (T1003.x). "
+                "If krbtgt hash was obtained, attacker can forge Golden Tickets. "
+                "Golden Ticket creation leaves NO log evidence - absence of T1558.001 "
+                "detection does NOT mean it wasn't created."
+            )
+
+        # Constrained delegation → impersonation to any service on target SPN
+        if "T1550.003" in techniques:
+            implied.append(
+                "PRIVILEGE ESCALATION CAPABILITY: Constrained delegation abuse detected. "
+                "Attacker can impersonate ANY user (including Domain Admin) to the "
+                "delegated service via S4U2Proxy. This can lead to DC compromise."
+            )
+
+        # Unconstrained delegation → TGT theft from any authenticating user
+        if any(t in techniques for t in ["T1558", "T1550"]):
+            has_delegation = "T1550.003" in techniques or any(
+                "delegation" in str(techniques).lower() for _ in [1]
+            )
+            if has_delegation:
+                implied.append(
+                    "DOMAIN COMPROMISE RISK: Delegation abuse can lead to domain admin "
+                    "access if a privileged user authenticates to the compromised service."
+                )
+
+        # Kerberoasting → offline password cracking capability
+        if "T1558.003" in techniques:
+            implied.append(
+                "CREDENTIAL COMPROMISE RISK: Kerberoasting detected. Attacker has "
+                "service account password hashes for offline cracking. Weak passwords "
+                "can be cracked in minutes."
+            )
+
+        # AS-REP Roasting → offline password cracking for pre-auth disabled accounts
+        if "T1558.004" in techniques:
+            implied.append(
+                "CREDENTIAL COMPROMISE RISK: AS-REP Roasting detected. Accounts with "
+                "Kerberos pre-auth disabled are vulnerable to offline password cracking."
+            )
+
+        # DCSync specifically → full domain compromise
+        if "T1003.006" in techniques:
+            implied.append(
+                "DOMAIN ADMIN ACHIEVED: DCSync (T1003.006) requires Domain Admin or "
+                "replication rights. If this technique was successful, the attacker "
+                "has DA-equivalent access and can extract ALL domain credentials."
+            )
+
+        return implied
+
     @dn.tool_method  # type: ignore[untyped-decorator]
     def get_investigation_context(self) -> str:
         """Get the full investigation context for triage decision.
@@ -172,6 +243,16 @@ class EscalationTriageTools(Toolset):  # type: ignore[misc]
         lines.append("")
         lines.append("--- SYNOPSIS ---")
         lines.append(state.attack_synopsis or "No synopsis generated")
+
+        # Attack chain implications - infer capabilities from observed techniques
+        lines.append("")
+        lines.append("--- ATTACK CHAIN IMPLICATIONS ---")
+        implied_capabilities = self._get_implied_capabilities(state.identified_techniques)
+        if implied_capabilities:
+            for capability in implied_capabilities:
+                lines.append(f"  ⚠️  {capability}")
+        else:
+            lines.append("  No additional implied capabilities")
 
         # Recommendations
         if state.recommendations:

--- a/tests/core/test_blue_orchestrator_service.py
+++ b/tests/core/test_blue_orchestrator_service.py
@@ -537,3 +537,109 @@ class TestBlueOrchestratorService:
         mock_task_queue.connect.assert_awaited_once()
         mock_blue_queue.disconnect.assert_awaited_once()
         mock_blue_queue.connect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_process_investigation_request_retries_on_sentinel_master_error(self):
+        """Test that _process_investigation_request retries on Sentinel master not found errors."""
+        service = BlueOrchestratorService(redis_url="redis://", namespace="test")
+        service._publish_investigation_status = AsyncMock()
+        service._grafana_url = "http://grafana:3000"
+        service._grafana_api_key = "test-key"  # pragma: allowlist secret
+
+        request_data = {
+            "investigation_id": "inv-sentinel-retry",
+            "alert": {"labels": {"alertname": "TestAlert", "severity": "low"}},
+            "model": "test-model",
+            "auto_route": True,
+        }
+
+        call_count = 0
+
+        async def mock_investigate(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call fails with Sentinel master not found
+                raise Exception("No master found for 'aresmaster'")  # noqa: TRY002
+            # Second call succeeds
+            return {
+                "investigation_id": "inv-sentinel-retry",
+                "status": "completed",
+                "evidence_count": 1,
+                "techniques_identified": [],
+            }
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.investigate = AsyncMock(side_effect=mock_investigate)
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "ares.agents.blue.InvestigationOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+            patch("ares.integrations.mitre.MITREAttackClient"),
+            patch("ares.core.litellm_env.configure_litellm_env"),
+            patch(
+                "ares.core.blue_orchestrator_service.invalidate_sentinel_client"
+            ) as mock_invalidate,
+        ):
+            await service._process_investigation_request(request_data)
+
+            # Should have retried and succeeded on second attempt
+            assert call_count == 2
+            mock_invalidate.assert_called_once()
+
+            # Should have published running status, not failed
+            status_calls = service._publish_investigation_status.call_args_list
+            # Check the last call was not a "failed" status
+            assert not any(call[0][1] == "failed" for call in status_calls), (
+                "Investigation should not have failed"
+            )
+
+    @pytest.mark.asyncio
+    async def test_process_investigation_request_fails_after_max_retries_on_sentinel_error(
+        self,
+    ):
+        """Test that investigation fails after exhausting retries on Sentinel errors."""
+        service = BlueOrchestratorService(redis_url="redis://", namespace="test")
+        service._publish_investigation_status = AsyncMock()
+        service._grafana_url = "http://grafana:3000"
+        service._grafana_api_key = "test-key"  # pragma: allowlist secret
+
+        request_data = {
+            "investigation_id": "inv-sentinel-exhaust",
+            "alert": {"labels": {"alertname": "TestAlert", "severity": "low"}},
+            "model": "test-model",
+            "auto_route": True,
+        }
+
+        mock_orchestrator = MagicMock()
+        # All calls fail with Sentinel error
+        mock_orchestrator.investigate = AsyncMock(
+            side_effect=Exception("No master found for 'aresmaster'")
+        )
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "ares.agents.blue.InvestigationOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+            patch("ares.integrations.mitre.MITREAttackClient"),
+            patch("ares.core.litellm_env.configure_litellm_env"),
+            patch("ares.core.blue_orchestrator_service.invalidate_sentinel_client"),
+        ):
+            await service._process_investigation_request(request_data)
+
+            # Should have tried 3 times (max_retries)
+            assert mock_orchestrator.investigate.await_count == 3
+
+            # Should have published "failed" status
+            failed_call = None
+            for call in service._publish_investigation_status.call_args_list:
+                if call[0][1] == "failed":
+                    failed_call = call
+                    break
+            assert failed_call is not None, "Should have published failed status"
+            assert "No master found" in failed_call[0][2]["error"]

--- a/tests/core/test_redis_client.py
+++ b/tests/core/test_redis_client.py
@@ -335,6 +335,8 @@ class TestIsConnectionError:
             "getaddrinfo failed: Name does not resolve",
             "Temporary failure in name resolution",
             "No address associated with hostname",
+            # Sentinel failover errors
+            "No master found for 'aresmaster'",
         ],
     )
     def test_detects_connection_errors(self, error_message: str) -> None:

--- a/tests/tools/blue/test_triage_tools.py
+++ b/tests/tools/blue/test_triage_tools.py
@@ -96,6 +96,78 @@ class TestEscalationTriageToolsInit:
         assert triage_tools._result_data == {}
 
 
+class TestGetImpliedCapabilities:
+    """Tests for _get_implied_capabilities method."""
+
+    def test_empty_techniques_returns_empty(self, triage_tools):
+        result = triage_tools._get_implied_capabilities(set())
+        assert result == []
+
+    def test_dcsync_implies_golden_ticket_and_da(self, triage_tools):
+        result = triage_tools._get_implied_capabilities({"T1003.006"})
+
+        assert len(result) == 2
+        assert any("GOLDEN TICKET CAPABILITY" in r for r in result)
+        assert any("DOMAIN ADMIN ACHIEVED" in r for r in result)
+        # Verify it explains why logs won't show golden ticket
+        golden_ticket_msg = next(r for r in result if "GOLDEN TICKET" in r)
+        assert "NO log evidence" in golden_ticket_msg
+
+    def test_lsass_dump_implies_golden_ticket(self, triage_tools):
+        result = triage_tools._get_implied_capabilities({"T1003.001"})
+
+        assert len(result) == 1
+        assert "GOLDEN TICKET CAPABILITY" in result[0]
+
+    def test_ntds_dump_implies_golden_ticket(self, triage_tools):
+        result = triage_tools._get_implied_capabilities({"T1003.003"})
+
+        assert len(result) == 1
+        assert "GOLDEN TICKET CAPABILITY" in result[0]
+
+    def test_generic_credential_dump_implies_golden_ticket(self, triage_tools):
+        result = triage_tools._get_implied_capabilities({"T1003"})
+
+        assert len(result) == 1
+        assert "GOLDEN TICKET CAPABILITY" in result[0]
+
+    def test_constrained_delegation_implies_privesc(self, triage_tools):
+        result = triage_tools._get_implied_capabilities({"T1550.003"})
+
+        assert len(result) >= 1
+        assert any("PRIVILEGE ESCALATION CAPABILITY" in r for r in result)
+        assert any("impersonate ANY user" in r for r in result)
+
+    def test_kerberoasting_implies_offline_cracking(self, triage_tools):
+        result = triage_tools._get_implied_capabilities({"T1558.003"})
+
+        assert len(result) == 1
+        assert "CREDENTIAL COMPROMISE RISK" in result[0]
+        assert "offline cracking" in result[0].lower()
+
+    def test_asrep_roasting_implies_offline_cracking(self, triage_tools):
+        result = triage_tools._get_implied_capabilities({"T1558.004"})
+
+        assert len(result) == 1
+        assert "CREDENTIAL COMPROMISE RISK" in result[0]
+        assert "pre-auth disabled" in result[0].lower()
+
+    def test_multiple_techniques_combine_implications(self, triage_tools):
+        # Simulate a full attack chain: DCSync + Kerberoasting
+        result = triage_tools._get_implied_capabilities({"T1003.006", "T1558.003"})
+
+        # Should have: golden ticket, DA achieved, kerberoasting
+        assert len(result) == 3
+        assert any("GOLDEN TICKET" in r for r in result)
+        assert any("DOMAIN ADMIN ACHIEVED" in r for r in result)
+        assert any("Kerberoasting" in r for r in result)
+
+    def test_unrelated_technique_returns_empty(self, triage_tools):
+        # T1087 is account discovery - no implied capabilities
+        result = triage_tools._get_implied_capabilities({"T1087.002"})
+        assert result == []
+
+
 class TestGetInvestigationContext:
     """Tests for get_investigation_context tool."""
 
@@ -121,6 +193,31 @@ class TestGetInvestigationContext:
         assert "Total evidence items: 2" in result
         assert "Level 6" in result  # TTPs
         assert "Level 2" in result  # IP Addresses
+
+    def test_includes_attack_chain_implications(self, triage_tools, mock_shared_state):
+        # mock_shared_state has T1003.001 which should trigger golden ticket implication
+        triage_tools.set_shared_state(mock_shared_state)
+        result = triage_tools.get_investigation_context()
+
+        assert "ATTACK CHAIN IMPLICATIONS" in result
+        assert "GOLDEN TICKET CAPABILITY" in result
+
+    def test_shows_no_implications_when_none(self, triage_tools, mock_shared_state):
+        # Set techniques that don't have implications
+        mock_shared_state.identified_techniques = {"T1087.002"}  # Account discovery only
+        triage_tools.set_shared_state(mock_shared_state)
+        result = triage_tools.get_investigation_context()
+
+        assert "ATTACK CHAIN IMPLICATIONS" in result
+        assert "No additional implied capabilities" in result
+
+    def test_dcsync_shows_both_implications(self, triage_tools, mock_shared_state):
+        mock_shared_state.identified_techniques = {"T1003.006"}
+        triage_tools.set_shared_state(mock_shared_state)
+        result = triage_tools.get_investigation_context()
+
+        assert "GOLDEN TICKET CAPABILITY" in result
+        assert "DOMAIN ADMIN ACHIEVED" in result
 
 
 class TestConfirmEscalation:


### PR DESCRIPTION


**Key Changes:**

- Introduced attack chain implication inference to triage tooling and templates
- Added retry logic for Sentinel connection errors during investigation handling
- Enhanced documentation and reasoning templates for domain compromise scenarios

**Added:**

- Attack chain implication logic in escalation triage tools, inferring critical
  capabilities (e.g., Golden Ticket creation, DA compromise) from observed MITRE
  techniques, and displaying them in investigation context for better triage
- New section in escalation triage Jinja template explaining attack chain
  implications and reasoning for domain compromise escalations
- Unit tests for implied capability inference covering key attack and privilege
  escalation scenarios, and investigation context rendering with and without
  implications
- Tests for investigation request retry logic on Redis Sentinel failover errors,
  ensuring retries and error status reporting

**Changed:**

- Investigation processing now retries up to 3 times on transient Redis Sentinel
  "no master found" errors, invalidates Sentinel client, and delays between
  attempts for resilience
- `is_connection_error` expanded to recognize Sentinel failover errors for
  improved error handling in orchestrator service and test coverage
- Triage tool investigation context output now always includes a dedicated
  "Attack Chain Implications" section, highlighting inferred risks and
  capabilities based on observed techniques
- Escalation triage template instructions updated to clarify when domain admin
  compromise requires escalation, even if some attacks are only implied

**Removed:**

- N/A