### PR TITLE
refactor: update test data and documentation to use contoso.local and child domains

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "dreadnode>=1.17.0",
+    "dreadnode>=1.17.0,<2.0.0",
     "cyclopts>=4.2.0",
     "loguru>=0.7.3",
     "httpx>=0.28.0,<1.0.0",

--- a/src/ares/agents/blue/multi_agent_orchestrator.py
+++ b/src/ares/agents/blue/multi_agent_orchestrator.py
@@ -402,17 +402,22 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
         return "\n".join(lines)
 
     async def _check_workers_alive_for_tasks(self, pending_task_ids: set[str]) -> tuple[bool, int]:
-        """Check if any workers are actively working on pending tasks.
+        """Check if workers are alive and could process pending tasks.
 
         Uses heartbeats to determine liveness. A worker is considered
-        alive if it has heartbeated recently AND claims to be working
-        on one of our pending tasks.
+        alive if it has heartbeated recently AND is either:
+        1. Working on one of our pending tasks (busy with our work), OR
+        2. Idle/available (could pick up our tasks from the queue)
+
+        This avoids false "no heartbeats" when workers are between tasks
+        or waiting on the queue.
 
         Args:
             pending_task_ids: Set of task IDs we're waiting for.
 
         Returns:
-            Tuple of (any_alive, alive_count).
+            Tuple of (any_alive, alive_count) where alive_count is workers
+            that could potentially process our tasks.
         """
         from datetime import datetime, timezone
 
@@ -428,31 +433,50 @@ class BlueOrchestratorTools(Toolset):  # type: ignore[misc]
             return (True, 0)
 
         now = datetime.now(timezone.utc)
-        alive_count = 0
+        working_on_our_tasks = 0
+        available_workers = 0
         stale_threshold_seconds = 60  # Heartbeat TTL
 
         for hb in heartbeats.values():
             current_task = hb.get("current_task")
+            status = hb.get("status", "unknown")
             timestamp_str = hb.get("timestamp")
 
-            if not current_task or current_task not in pending_task_ids:
-                continue
-
-            # Check heartbeat freshness
+            # Check heartbeat freshness first
             if timestamp_str:
                 try:
                     hb_time = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
                     age = (now - hb_time).total_seconds()
-                    if age <= stale_threshold_seconds:
-                        alive_count += 1
+                    if age > stale_threshold_seconds:
+                        # Stale heartbeat - worker might be dead
+                        continue
                 except (ValueError, TypeError):
-                    # Can't parse timestamp, assume alive
-                    alive_count += 1
+                    # Can't parse timestamp, skip this worker
+                    continue
             else:
-                # No timestamp but has current_task, assume alive
-                alive_count += 1
+                # No timestamp - can't verify freshness
+                continue
 
-        return (alive_count > 0, alive_count)
+            # Worker has fresh heartbeat - check if it's relevant to us
+            if current_task and current_task in pending_task_ids:
+                # Worker is actively working on one of our tasks
+                working_on_our_tasks += 1
+            elif status == "idle" or not current_task:
+                # Worker is available to pick up our tasks from the queue
+                available_workers += 1
+
+        # Consider alive if we have workers on our tasks OR available workers
+        # (available workers can pick up our pending tasks from the queue)
+        total_relevant = working_on_our_tasks + available_workers
+        any_alive = total_relevant > 0 or working_on_our_tasks > 0
+
+        if working_on_our_tasks > 0:
+            logger.debug(
+                f"Worker liveness: {working_on_our_tasks} on our tasks, "
+                f"{available_workers} available"
+            )
+
+        return (any_alive, working_on_our_tasks)
 
     @dn.tool_method  # type: ignore[untyped-decorator]
     async def wait_for_all_tasks(

--- a/src/ares/core/dispatcher/monitoring.py
+++ b/src/ares/core/dispatcher/monitoring.py
@@ -740,7 +740,7 @@ class MonitoringMixin:
 
         # Fallback to domain resolved from target host's FQDN
         # (non-domain-prefixed secretsdump output: "user:rid:lmhash:nthash:::")
-        # This correctly handles child domain DCs (e.g., winterfell serves north.sevenkingdoms.local)
+        # This correctly handles child domain DCs (e.g., dc02 serves child.contoso.local)
         if not domain:
             domain = self._resolve_domain_from_target_host(target_ip)
 

--- a/src/ares/core/dispatcher/result_processing.py
+++ b/src/ares/core/dispatcher/result_processing.py
@@ -595,6 +595,29 @@ class ResultProcessingMixin:
                 else:
                     details["has_credentials"] = False
 
+            # For ADCS vulnerabilities, ensure we have credential context for exploitation
+            # (worker may have run certipy_find with creds that orchestrator doesn't know about)
+            if vuln_type.startswith("adcs_"):
+                # If no credentials in details, try to find valid creds for the domain
+                if not details.get("username") or not details.get("password"):
+                    domain_hint = details.get("domain") or ""
+                    for cred in self.shared_state.all_credentials:
+                        # Prefer creds from the same domain, or any valid cred as fallback
+                        if cred.password and (
+                            not domain_hint or cred.domain.lower() == domain_hint.lower()
+                        ):
+                            details["username"] = cred.username
+                            details["password"] = cred.password
+                            details["domain"] = cred.domain
+                            break
+
+                # Log warning if ADCS details are sparse (helps debug)
+                if not details.get("ca_name") and not details.get("ca_host"):
+                    logger.debug(
+                        f"ADCS vulnerability {vuln_type} on {target} has sparse details: "
+                        f"{list(details.keys())}. ESC8 exploitation may require CA info."
+                    )
+
             # Queue the vulnerability and get its ID
             vuln_id = await self.queue_vulnerability(
                 vuln_type=vuln_type,

--- a/src/ares/core/dispatcher/result_processing.py
+++ b/src/ares/core/dispatcher/result_processing.py
@@ -106,7 +106,7 @@ class ResultProcessingMixin:
 
         # Extracted domain is NetBIOS (no ".") - check if target_domain matches
         # Check if target_domain starts with the NetBIOS name
-        # e.g., extracted="north", target="north.sevenkingdoms.local" → match
+        # e.g., extracted="child", target="child.contoso.local" -> match
         if (
             target_domain
             and "." in target_domain
@@ -507,7 +507,7 @@ class ResultProcessingMixin:
         # _extract_shares_from_output() in _process_output_text().
 
         # Get fallback domain for users by resolving from target host's FQDN
-        # This correctly handles child domain DCs (e.g., winterfell serves north.sevenkingdoms.local)
+        # This correctly handles child domain DCs (e.g., dc02 serves child.contoso.local)
         target_domain = self._resolve_domain_from_target_host(target_ip)
 
         discovered_users = result.get("discovered_users")
@@ -734,7 +734,7 @@ class ResultProcessingMixin:
         discovery_step = parent_attack_step + 1 if parent_credential_id else 0
 
         # Get fallback domain for hashes by resolving from target host's FQDN
-        # This correctly handles child domain DCs (e.g., winterfell serves north.sevenkingdoms.local)
+        # This correctly handles child domain DCs (e.g., dc02 serves child.contoso.local)
         target_domain = self._resolve_domain_from_target_host(target_ip)
 
         cred_data = result.get("credential")
@@ -772,8 +772,8 @@ class ResultProcessingMixin:
         if isinstance(hash_data, dict):
             # Resolve hash domain: prefer target_domain FQDN over LLM-extracted NetBIOS
             # When secretsdump runs against a DC, the target host's domain is authoritative.
-            # LLM often extracts "NORTH" (NetBIOS) from output like "NORTH\krbtgt:hash",
-            # but we should use "north.sevenkingdoms.local" from the DC's FQDN.
+            # LLM often extracts "CHILD" (NetBIOS) from output like "CHILD\krbtgt:hash",
+            # but we should use "child.contoso.local" from the DC's FQDN.
             extracted_domain = hash_data.get("domain", "").strip().lower()
             hash_domain = self._resolve_extracted_domain(extracted_domain, target_domain)
             hash_obj = Hash(
@@ -1029,9 +1029,9 @@ class ResultProcessingMixin:
         """Extract hosts from netexec SMB output.
 
         Parses two types of SMB output lines:
-        1. Banner lines with [*]: "SMB 10.1.2.183 445 KINGSLANDING [*] Windows 10..."
+        1. Banner lines with [*]: "SMB 192.168.58.10 445 DC01 [*] Windows 10..."
            - Extracts IP, hostname, and OS from the banner details
-        2. Non-banner lines: "SMB 10.1.2.240 445 WINTERFELL ADMIN$ Remote Admin"
+        2. Non-banner lines: "SMB 192.168.58.20 445 DC02 ADMIN$ Remote Admin"
            - Extracts IP and hostname only (OS will be "Unknown")
            - These appear in share enumeration, user enumeration, etc.
         """

--- a/src/ares/core/dispatcher/routing.py
+++ b/src/ares/core/dispatcher/routing.py
@@ -136,13 +136,27 @@ class RoutingMixin:
             )
 
         def _hostname_matches_domain(hostname: str, domain: str) -> bool:
-            """Check if hostname belongs to the domain."""
+            """Check if hostname belongs to the domain.
+
+            Extract the domain from hostname (everything after first component)
+            and compare exactly. This prevents dc01.child.contoso.local
+            from incorrectly matching contoso.local (parent domain).
+            """
             if not hostname or not domain:
                 return False
             hostname_lower = hostname.lower()
             domain_lower_check = domain.lower()
-            if hostname_lower.endswith(f".{domain_lower_check}"):
-                return True
+
+            # Extract domain from hostname: dc01.child.contoso.local
+            # -> child.contoso.local
+            parts = hostname_lower.split(".")
+            if len(parts) >= 2:
+                # Domain is everything after the hostname (first component)
+                hostname_domain = ".".join(parts[1:])
+                if hostname_domain == domain_lower_check:
+                    return True
+
+            # Fallback: hostname IS the domain (rare edge case)
             return hostname_lower == domain_lower_check
 
         # Check target first (if it belongs to this domain)
@@ -187,14 +201,12 @@ class RoutingMixin:
                     return host.ip
 
         # Priority 3.5: For child domains, find a DC in the same forest
-        # e.g., north.sevenkingdoms.local -> find a DC with hostname *.sevenkingdoms.local
+        # e.g., child.contoso.local -> find a DC with hostname *.contoso.local
         # that is NOT the parent domain's registered DC (prefer child domain's own DC)
         if domain_lower and "." in domain_lower:
             parts = domain_lower.split(".")
             if len(parts) >= 3:  # child.parent.tld has 3+ parts
-                parent_domain = ".".join(
-                    parts[1:]
-                )  # north.sevenkingdoms.local -> sevenkingdoms.local
+                parent_domain = ".".join(parts[1:])  # child.contoso.local -> contoso.local
                 parent_dc_ip = self.shared_state.domain_controllers.get(parent_domain)
 
                 # Find all DCs in the same forest (hostname ends with parent domain)
@@ -225,7 +237,7 @@ class RoutingMixin:
                     return parent_dc_ip
 
         # Priority 4: DNS SRV lookup (try before generic fallback - more accurate)
-        # This correctly finds DCs for child domains like north.sevenkingdoms.local
+        # This correctly finds DCs for child domains like child.contoso.local
         # when hostname data is incomplete or missing
         if domain_lower:
             dc_ip = self._dns_lookup_dc(domain_lower)
@@ -346,13 +358,13 @@ class RoutingMixin:
         """Query LDAP rootDSE to get the domain name a DC serves.
 
         Uses raw socket LDAP to query the defaultNamingContext attribute which
-        contains the domain DN (e.g., DC=north,DC=sevenkingdoms,DC=local).
+        contains the domain DN (e.g., DC=child,DC=contoso,DC=local).
 
         Args:
             dc_ip: IP address of the DC to query
 
         Returns:
-            Domain name (e.g., "north.sevenkingdoms.local") or empty string on failure
+            Domain name (e.g., "child.contoso.local") or empty string on failure
         """
         import socket
 
@@ -434,7 +446,7 @@ class RoutingMixin:
             )
             if match:
                 dn = match.group(1)
-                # Convert DN to domain name: DC=north,DC=sevenkingdoms,DC=local -> north.sevenkingdoms.local
+                # Convert DN to domain name: DC=child,DC=contoso,DC=local -> child.contoso.local
                 parts = []
                 for component in dn.split(","):
                     stripped = component.strip()

--- a/src/ares/core/factories/red_agents.py
+++ b/src/ares/core/factories/red_agents.py
@@ -350,9 +350,9 @@ def create_role_hooks(
                         break
 
                 # Normalize hostname to canonical FQDN from discovered hosts
-                # This resolves NetBIOS names (WINTERFELL) and wrong domain suffixes
-                # (winterfell.sevenkingdoms.local) to the canonical FQDN
-                # (winterfell.north.sevenkingdoms.local)
+                # This resolves NetBIOS names (DC02) and wrong domain suffixes
+                # (dc02.contoso.local) to the canonical FQDN
+                # (dc02.child.contoso.local)
                 if raw_hostname and shared_state:
                     canonical_fqdn = shared_state.resolve_hostname_to_fqdn(raw_hostname, target_ip)
                     if canonical_fqdn:
@@ -911,8 +911,8 @@ def create_role_hooks(
                         # Use extracted domain only - do NOT fallback to target_domain here.
                         # The orchestrator will resolve the correct domain from the target host's
                         # FQDN in _process_realtime_hash_discovery(). This correctly handles
-                        # child domain DCs (e.g., winterfell serves north.sevenkingdoms.local,
-                        # not the operation's target domain sevenkingdoms.local).
+                        # child domain DCs (e.g., dc02 serves child.contoso.local,
+                        # not the operation's target domain contoso.local).
                         hash_domain = h.domain or ""
                         await task_queue.publish_discovery(
                             operation_id=operation_id,
@@ -1003,6 +1003,19 @@ def create_role_hooks(
             if tool_name == "certipy_find":
                 esc_matches = re.findall(r"(ESC\d+)", output, re.IGNORECASE)
                 seen_esc = set()
+
+                # Parse CA details from certipy output for enriched vulnerability data
+                # Typical format: "CA Name : CONTOSO-CA" and "DNS Name : dc01.contoso.local"
+                ca_name_match = re.search(r"CA Name\s*:\s*([^\n]+)", output)
+                ca_dns_match = re.search(r"DNS Name\s*:\s*([^\n]+)", output)
+                ca_name = ca_name_match.group(1).strip() if ca_name_match else None
+                ca_host = ca_dns_match.group(1).strip() if ca_dns_match else None
+
+                # Get tool call args for credential context
+                args: dict[str, str] = {}
+                if hasattr(event, "tool_call") and event.tool_call:
+                    args = getattr(event.tool_call, "arguments", {}) or {}
+
                 for esc in esc_matches:
                     esc_type = esc.upper()
                     if esc_type in seen_esc:
@@ -1010,10 +1023,7 @@ def create_role_hooks(
                     seen_esc.add(esc_type)
 
                     # Extract target from tool call args, fallback to shared_state
-                    target = ""
-                    if hasattr(event, "tool_call") and event.tool_call:
-                        args = getattr(event.tool_call, "arguments", {}) or {}
-                        target = args.get("dc_ip", "") or args.get("domain", "")
+                    target = args.get("dc_ip", "") or args.get("domain", "")
                     if not target:
                         # Fallback to first DC or target domain
                         # domain_controllers is dict[str, str] mapping domain -> IP
@@ -1027,6 +1037,22 @@ def create_role_hooks(
                         logger.debug(f"Skipping ADCS vuln {esc_type}: no target available")
                         continue
 
+                    # Build enriched details for exploitation
+                    details: dict[str, str | None] = {"esc_type": esc_type}
+                    if ca_name:
+                        details["ca_name"] = ca_name
+                    if ca_host:
+                        details["ca_host"] = ca_host
+                    # Include credential context from the certipy_find call
+                    if args.get("domain"):
+                        details["domain"] = args["domain"]
+                    if args.get("dc_ip"):
+                        details["dc_ip"] = args["dc_ip"]
+                    if args.get("username"):
+                        details["username"] = args["username"]
+                    if args.get("password"):
+                        details["password"] = args["password"]
+
                     try:
                         await task_queue.publish_discovery(
                             operation_id=operation_id,
@@ -1034,12 +1060,15 @@ def create_role_hooks(
                             data={
                                 "vuln_type": f"adcs_{esc_type.lower()}",
                                 "target": target,
-                                "details": {"esc_type": esc_type},
+                                "details": details,
                                 "priority": 2 if esc_type in ("ESC1", "ESC4", "ESC8") else 5,
                             },
                             source_agent=log_name,
                         )
-                        logger.warning(f"📡 [{log_name}] Published ADCS vuln: {esc_type}")
+                        logger.warning(
+                            f"📡 [{log_name}] Published ADCS vuln: {esc_type} "
+                            f"(CA: {ca_name or 'unknown'}, host: {ca_host or target})"
+                        )
                     except Exception as e:
                         logger.warning(f"Failed to publish ADCS vulnerability: {e}")
 

--- a/src/ares/core/factories/red_agents.py
+++ b/src/ares/core/factories/red_agents.py
@@ -961,7 +961,8 @@ def create_role_hooks(
     # Real-time vulnerability discovery publishing
     # Tool set defined at module level: VULNERABILITY_EXTRACTION_TOOLS
     vuln_extraction_roles = {
-        AgentRole.PRIVESC,  # certipy_find
+        AgentRole.RECON,  # certipy_find (primary ADCS enumeration)
+        AgentRole.PRIVESC,  # certipy_find (may also run ADCS enum)
         AgentRole.LATERAL,  # mssql_enum_impersonation
     }
 

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -1523,7 +1523,7 @@ class SharedRedTeamState:
             return self.netbios_to_fqdn[netbios_lower]
 
         # 2. Check domain_controllers keys (FQDNs discovered early via DC enumeration)
-        # e.g., if netbios="north" and we have domain_controllers["north.sevenkingdoms.local"]
+        # e.g., if netbios="child" and we have domain_controllers["child.contoso.local"]
         matching_dc_domains = [
             d for d in self.domain_controllers if d.startswith(netbios_lower + ".")
         ]
@@ -1563,8 +1563,8 @@ class SharedRedTeamState:
     def resolve_hostname_to_fqdn(self, hostname: str, target_ip: str | None = None) -> str | None:
         """Resolve a hostname to its canonical FQDN from discovered hosts.
 
-        When tools output hostnames like 'WINTERFELL' (NetBIOS) or
-        'winterfell.sevenkingdoms.local' (wrong/partial domain suffix),
+        When tools output hostnames like 'DC01' (NetBIOS) or
+        'dc01.contoso.local' (wrong/partial domain suffix),
         this method resolves them to the canonical FQDN based on
         discovered hosts in all_hosts.
 
@@ -2739,8 +2739,8 @@ class SharedRedTeamState:
                     )
 
                     # Check if new FQDN is more specific (more domain levels) than existing
-                    # e.g., "winterfell.north.sevenkingdoms.local" is more specific than
-                    # "winterfell.sevenkingdoms.local" and should be preferred
+                    # e.g., "dc02.child.contoso.local" is more specific than
+                    # "dc02.contoso.local" and should be preferred
                     new_is_more_specific = False
                     if new_is_fqdn and "." in existing_hostname:
                         existing_parts = existing_lower.split(".")
@@ -3225,7 +3225,7 @@ class SharedRedTeamState:
                 # Determine the domain of this DC
                 dc_domain = ""
                 if dc_host.hostname and "." in dc_host.hostname:
-                    # Extract domain from FQDN: winterfell.north.sevenkingdoms.local -> north.sevenkingdoms.local
+                    # Extract domain from FQDN: dc02.child.contoso.local -> child.contoso.local
                     parts = dc_host.hostname.lower().split(".", 1)
                     if len(parts) > 1:
                         dc_domain = parts[1]
@@ -3265,7 +3265,7 @@ class SharedRedTeamState:
         if d1_fqdn == d2_fqdn:
             return True
 
-        # Check if one is a prefix of the other (north vs north.sevenkingdoms.local)
+        # Check if one is a prefix of the other (child vs child.contoso.local)
         return d1_fqdn.startswith(d2 + ".") or d2_fqdn.startswith(d1 + ".")
 
     def update_golden_ticket_capability(
@@ -3586,8 +3586,8 @@ class SharedRedTeamState:
     def normalize_hash_domains_to_users(self) -> int:
         """Normalize hash domains to match discovered user domains.
 
-        Handles LLM hallucinations where the domain is misspelled (e.g., 'sevenkingdomain'
-        instead of 'sevenkingdoms'). For each hash, if the user exists in exactly one
+        Handles LLM hallucinations where the domain is misspelled (e.g., 'contosco'
+        instead of 'contoso'). For each hash, if the user exists in exactly one
         known domain and the hash's domain doesn't match, correct it.
 
         Returns:

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -398,8 +398,8 @@ async def _run_nmap_on_worker(targets: list[str], namespace: str) -> tuple[str, 
                     # Fallback: parse NetBIOS name from nbstat output
                     # NOTE: We only use the NetBIOS hostname, not the domain group name.
                     # Constructing FQDNs like "{netbios}.{domain}.local" is wrong because
-                    # we don't know the actual domain suffix (e.g., "north" could be
-                    # "north.sevenkingdoms.local", not "north.local"). The actual FQDN
+                    # we don't know the actual domain suffix (e.g., "child" could be
+                    # "child.contoso.local", not "child.local"). The actual FQDN
                     # will be discovered via DNS/LDAP enumeration.
                     nb_match = re.search(r"nbstat:\s*NetBIOS name:\s*([^,]+)", nb_stdout)
                     if nb_match:
@@ -3220,43 +3220,50 @@ async def _auto_golden_ticket(
                 )
 
                 # Need a credential or hash to run lookupsid
-                # First try password credential, then fall back to hash-based auth
+                # Priority: same-domain password > same-domain hash > cross-domain password > cross-domain hash
+                # Cross-domain auth often fails for SID lookup, so prefer same-domain creds
                 cred = None
                 auth_hash = None
 
-                # Try to find password credential for this domain first
+                # 1. Try to find password credential for this domain first (most reliable)
                 for c in state.all_credentials:
                     if c.password and c.domain and c.domain.lower() == domain.lower():
                         cred = c
                         break
 
+                # 2. Try same-domain NTLM hash (PTH) - more reliable than cross-domain password
                 if not cred:
-                    # Try any password credential
+                    for h in state.all_hashes:
+                        if h.hash_type.lower() != "ntlm":
+                            continue
+                        # Skip krbtgt and machine accounts - use regular user accounts
+                        if h.username.lower() == "krbtgt" or h.username.endswith("$"):
+                            continue
+                        # Same domain only
+                        if h.domain and h.domain.lower() == domain.lower():
+                            auth_hash = h
+                            logger.debug(
+                                f"🎫 Auto-golden-ticket: Using same-domain hash for {domain}: "
+                                f"{h.domain}\\{h.username}"
+                            )
+                            break
+
+                # 3. Try any password credential (cross-domain auth may work)
+                if not cred and not auth_hash:
                     for c in state.all_credentials:
                         if c.password:
                             cred = c
                             break
 
-                if not cred:
-                    # No password credential - try hash-based auth
-                    # Look for any NTLM hash we can use (prefer same domain, exclude krbtgt)
+                # 4. Try any NTLM hash (cross-domain PTH as last resort)
+                if not cred and not auth_hash:
                     for h in state.all_hashes:
                         if h.hash_type.lower() != "ntlm":
                             continue
-                        # Skip krbtgt - it's a service account, use a user account
-                        if h.username.lower() == "krbtgt":
+                        if h.username.lower() == "krbtgt" or h.username.endswith("$"):
                             continue
-                        # Prefer same domain
-                        if h.domain and h.domain.lower() == domain.lower():
-                            auth_hash = h
-                            break
-
-                    if not auth_hash:
-                        # Try any NTLM hash (cross-domain auth may work)
-                        for h in state.all_hashes:
-                            if h.hash_type.lower() == "ntlm" and h.username.lower() != "krbtgt":
-                                auth_hash = h
-                                break
+                        auth_hash = h
+                        break
 
                 if not cred and not auth_hash:
                     logger.warning(
@@ -3336,13 +3343,20 @@ async def _auto_golden_ticket(
 
                     output = stdout + "\n" + (stderr or "")
 
+                    # Debug log to see actual lookupsid output
+                    output_preview = output[:300].replace("\n", "\\n") if output else "<empty>"
+                    logger.debug(
+                        f"🎫 Auto-golden-ticket: lookupsid output for {domain}: {output_preview}"
+                    )
+
                     # Parse domain SID from output
                     sid_match = re.search(r"Domain SID is:\s*(S-\d+-\d+-\d+-\d+-\d+-\d+)", output)
                     if not sid_match:
                         # Lookupsid ran but couldn't extract SID - this is a permanent failure
                         # (bad creds, wrong domain, etc.)
                         logger.warning(
-                            f"🎫 Auto-golden-ticket: Could not extract domain SID for {domain}"
+                            f"🎫 Auto-golden-ticket: Could not extract domain SID for {domain}, "
+                            f"output: {output_preview}"
                         )
                         state.add_golden_ticket(
                             {

--- a/src/ares/core/worker/dc_resolution.py
+++ b/src/ares/core/worker/dc_resolution.py
@@ -71,7 +71,7 @@ def resolve_dc_ip_for_domain(
 
     # Priority 0: Check cached domain_controllers (populated by orchestrator)
     # This handles child domains where hostname doesn't match domain FQDN
-    # e.g., north.sevenkingdoms.local DC is winterfell.sevenkingdoms.local
+    # e.g., child.contoso.local DC is dc02.contoso.local
     cached_dc = getattr(state, "domain_controllers", {}).get(domain_lower)
     if cached_dc:
         if provided_dc_ip and provided_dc_ip != cached_dc:

--- a/src/ares/templates/blueteam/agents/lateral_analyst.md.jinja
+++ b/src/ares/templates/blueteam/agents/lateral_analyst.md.jinja
@@ -115,23 +115,37 @@ For each new user found:
 
 When `get_host_activity` and `get_user_activity` are insufficient, use custom LogQL:
 
+**CRITICAL: Use the correct log source label:**
+- Windows Security events: `{job="windows-security"}` or `{channel="Security"}`
+- Windows System events: `{channel="System"}`
+- **NEVER** use `{alertname="..."}` — this queries alerts, not actual log data
+
 ```
 # Find all Type 3 (network) logons to a host
 query_loki_logs(
-    logql='{deployment="<deployment>"} |= "4624" |= "<hostname>" |= "LogonType\":\"3"',
-    ...
+    datasourceUid="loki",
+    logql='{job="windows-security"} | json | event_id = 4624 |~ "(?i)<hostname>" |~ "LogonType.{0,10}3"',
+    startRfc3339=<2 hours ago>,
+    endRfc3339=<now>,
+    limit=100
 )
 
 # Find all share access from a specific IP
 query_loki_logs(
-    logql='{deployment="<deployment>"} |= "5140" |= "<source_ip>"',
-    ...
+    datasourceUid="loki",
+    logql='{job="windows-security"} | json | event_id = 5140 |~ "<source_ip>"',
+    startRfc3339=<2 hours ago>,
+    endRfc3339=<now>,
+    limit=100
 )
 
 # Find remote service creation (PsExec indicator)
 query_loki_logs(
-    logql='{deployment="<deployment>"} |= "7045" |= "<hostname>"',
-    ...
+    datasourceUid="loki",
+    logql='{channel="System"} |= "7045" |~ "(?i)<hostname>"',
+    startRfc3339=<2 hours ago>,
+    endRfc3339=<now>,
+    limit=100
 )
 ```
 

--- a/src/ares/templates/blueteam/agents/orchestrator.md.jinja
+++ b/src/ares/templates/blueteam/agents/orchestrator.md.jinja
@@ -113,8 +113,8 @@ Call when:
 escalate_investigation(
     reason="Active credential theft attack chain",
     severity="critical",
-    attack_synopsis="Credential dumping (T1003) detected on winterfell.north.sevenkingdoms.local followed by lateral movement to castelblack within 30 minutes. Attacker used pass-the-hash with compromised NTLM hashes.",
-    recommendations=["Isolate winterfell and castelblack immediately", "Reset all credentials on affected hosts", "Check for golden ticket activity"]
+    attack_synopsis="Credential dumping (T1003) detected on dc02.child.contoso.local followed by lateral movement to sql01 within 30 minutes. Attacker used pass-the-hash with compromised NTLM hashes.",
+    recommendations=["Isolate dc02 and sql01 immediately", "Reset all credentials on affected hosts", "Check for golden ticket activity"]
 )
 ```
 

--- a/src/ares/templates/blueteam/agents/threat_hunter.md.jinja
+++ b/src/ares/templates/blueteam/agents/threat_hunter.md.jinja
@@ -83,10 +83,25 @@ For `high` and `critical` investigations, hunt the full chain:
 
 When pre-built detection queries are insufficient, write custom LogQL:
 
+**CRITICAL: Use the correct log source label:**
+- Windows Security events: `{job="windows-security"}` or `{channel="Security"}`
+- **NEVER** use `{alertname="..."}` — this queries alerts, not actual log data
+
 ```
 query_loki_logs(
-    datasourceUid=<datasource>,
-    logql='<custom_query>',
+    datasourceUid="loki",
+    logql='{job="windows-security"} | json | event_id = <EVENT_ID> |~ "<filter>"',
+    startRfc3339=<start>,
+    endRfc3339=<end>,
+    limit=100
+)
+```
+
+**Alternative if job label unavailable:**
+```
+query_loki_logs(
+    datasourceUid="loki",
+    logql='{channel="Security"} |= "<EVENT_ID>" |~ "<filter>"',
     startRfc3339=<start>,
     endRfc3339=<end>,
     limit=100

--- a/src/ares/templates/blueteam/agents/triage.md.jinja
+++ b/src/ares/templates/blueteam/agents/triage.md.jinja
@@ -19,23 +19,43 @@ If the alert already has severity=critical/high AND MITRE techniques, you can go
 
 ### Step 2: One Loki Query (1 tool call)
 
-Run ONE targeted query for the alert's core activity:
+Run ONE targeted query for the alert's core activity.
 
+**CRITICAL: Use the correct log source label:**
+- Windows Security events: `{job="windows-security"}` or `{channel="Security"}`
+- Windows Application events: `{channel="Application"}`
+- Windows System events: `{channel="System"}`
+- DO NOT use `{alertname="..."}` - this queries alerts, not logs
+
+**Query template for Windows Security events:**
 ```
 query_loki_logs(
     datasourceUid="loki",
-    logql='{deployment="<from_alert>"} |= "<primary_event_id>"',
-    startRfc3339=<1 hour ago>,
+    logql='{job="windows-security"} | json | event_id = <EVENT_ID>',
+    startRfc3339=<2 hours ago>,
     endRfc3339=<now>,
     limit=50
 )
 ```
 
-Pick the most relevant event ID:
-- Credential theft: `4625` or `4624`
-- Kerberos: `4769` or `4768`
-- Lateral movement: `4624` with `|= "LogonType" |= "3"`
-- DCSync: `4662`
+**Alternative if job label unavailable:**
+```
+query_loki_logs(
+    datasourceUid="loki",
+    logql='{channel="Security"} |= "<EVENT_ID>"',
+    startRfc3339=<2 hours ago>,
+    endRfc3339=<now>,
+    limit=50
+)
+```
+
+Pick the most relevant event ID based on attack type:
+- AS-REP Roasting: `event_id = 4768` with `|~ "PreAuthType.{0,10}0"`
+- Kerberoasting: `event_id = 4769` with `!~ "ServiceName.>krbtgt<"`
+- DCSync: `event_id = 4662` with `|~ "1131f6a"`
+- Credential theft: `event_id = 4625` (failed) or `event_id = 4624` (success)
+- Lateral movement: `event_id = 4624` with `|~ "LogonType.{0,10}(3|10)"`
+- SYSVOL/Share access: `event_id = 5140` or `event_id = 5145`
 
 ### Step 3: Record Evidence (1-2 tool calls)
 
@@ -73,3 +93,5 @@ triage_complete(
 - **DO NOT** expand time windows beyond 2 hours — leave deep history to the threat hunter
 - **DO NOT** run more than 2 Loki queries — one focused query is enough for triage
 - **ALWAYS** call `triage_complete()` — the orchestrator is waiting for your result
+- **NEVER** query `{alertname="..."}` — this searches for alerts, not log data. Always use `{job="windows-security"}` or `{channel="Security"}` to find the actual Windows events
+- **If query returns empty**: Try the alternative label selector. If both fail, note "no corroborating logs found" in triage summary — do NOT mark as false_positive unless you confirm benign pattern

--- a/src/ares/templates/redteam/agents/privesc.md.jinja
+++ b/src/ares/templates/redteam/agents/privesc.md.jinja
@@ -50,6 +50,31 @@ If enumeration shows your assigned credential has NO exploitable path:
 Do NOT spend 40 steps documenting vulnerabilities for OTHER users you don't have credentials for.
 Report what you found and let the orchestrator dispatch a new task with the right credential.
 
+### FAIL FAST when missing required parameters:
+**CRITICAL:** If your task payload is missing required data for the attack, fail IMMEDIATELY:
+
+| Vuln Type | Required Params | If Missing |
+|-----------|----------------|------------|
+| adcs_esc8 | ca_name, ca_host OR domain/dc_ip | Fail - cannot start relay without CA target |
+| adcs_esc1/esc4 | ca_name, template | Fail - cannot request cert without template |
+| constrained_delegation | target_spn, username, password | Fail - cannot perform S4U |
+| mssql_impersonation | target, username, password | Fail - cannot connect to SQL |
+
+**Example fail-fast for ESC8 without CA details:**
+```
+task_complete(
+    task_id="your_task_id",
+    result="FAILED: ESC8 task missing required params (ca_name, ca_host). "
+           "Need CA details from certipy_find. Task payload had: {params}",
+    success=False
+)
+```
+
+Do NOT:
+- Loop calling record_weakness about missing params
+- Spend steps trying to enumerate missing data (that's recon's job)
+- Call get_operation_summary hoping to find the data
+
 If you find yourself calling documentation tools more than attack tools, STOP and refocus on exploitation.
 
 ## Your Responsibilities
@@ -109,6 +134,10 @@ Or manually:
 ```
 
 ### ESC8 - Web Enrollment Relay
+**Required task params:** `ca_name`, `ca_host` (or `domain`/`dc_ip` to derive them)
+
+**If missing required params:** FAIL IMMEDIATELY with task_complete(success=False). Do NOT loop.
+
 When ESC8 vulnerability is found (coordinate with COERCION agent):
 ```
 1. COERCION agent starts ntlmrelayx_to_adcs(ca_host="CA_IP", template="DomainController")
@@ -117,6 +146,9 @@ When ESC8 vulnerability is found (coordinate with COERCION agent):
 4. certipy_auth(domain="contoso.local", pfx_file="dc.pfx", dc_ip="DC_IP")
 → Get DC machine account NTLM hash
 ```
+
+**Note:** ESC8 exploitation is primarily handled by the COERCION agent. If you receive an ESC8
+task without ca_host/ca_name, fail with: "ESC8 requires ca_host for relay target. Missing from payload."
 
 ### Shadow Credentials
 For any user/computer you have GenericAll on:

--- a/src/ares/tools/red/reconnaissance.py
+++ b/src/ares/tools/red/reconnaissance.py
@@ -507,7 +507,7 @@ class NetworkEnumerationTools(Toolset):
                     return hostname  # Domain is valid
 
                 # Try to find a known domain that this could be a truncation of
-                # e.g., "north.local" might be truncated "north.sevenkingdoms.local"
+                # e.g., "child.local" might be truncated "child.contoso.local"
                 domain_parts = domain_suffix.split(".")
                 if domain_parts:
                     first_label = domain_parts[0]  # e.g., "north"
@@ -581,19 +581,19 @@ class NetworkEnumerationTools(Toolset):
                         current_services.append(
                             f"{svc_match.group(1)}/{svc_match.group(2)} {svc_match.group(3)}"
                         )
-                    # Extract domain from LDAP line: "(Domain: sevenkingdoms.local, Site: ...)"
+                    # Extract domain from LDAP line: "(Domain: contoso.local, Site: ...)"
                     domain_match = re.search(r"\(Domain:\s*([^,)]+)", line)
                     if domain_match and not current_domain:
                         current_domain = domain_match.group(1).strip()
                         # Track discovered domains for fixing truncated hostnames
                         discovered_domains.add(current_domain.lower())
                     # Parse Service Info line for Host and OS
-                    # Format: "Service Info: Host: KINGSLANDING; OS: Windows; CPE: ..."
+                    # Format: "Service Info: Host: DC01; OS: Windows; CPE: ..."
                     if "Service Info:" in line:
                         host_match = re.search(r"Host:\s*([^;]+)", line)
                         if host_match:
                             # Always prefer Service Info hostname over DNS-derived name
-                            # This gives us "KINGSLANDING" instead of "ip-10-1-2-183.us-west-2.compute.internal"
+                            # This gives us "DC01" instead of "ip-192-168-58-10.us-west-2.compute.internal"
                             current_hostname = host_match.group(1).strip()
                         os_match = re.search(r"OS:\s*([^;]+)", line)
                         if os_match and not current_os:
@@ -783,7 +783,7 @@ class NetworkEnumerationTools(Toolset):
                                 if domain_match:
                                     netbios_domain = domain_match.group(1).strip().lower()
                                     # Resolve NetBIOS domain to FQDN using state if available
-                                    # e.g., "NORTH" -> "north.sevenkingdoms.local"
+                                    # e.g., "CHILD" -> "child.contoso.local"
                                     if self.state and hasattr(
                                         self.state, "_resolve_netbios_to_fqdn"
                                     ):

--- a/tests/core/dispatcher/test_announcements.py
+++ b/tests/core/dispatcher/test_announcements.py
@@ -165,8 +165,8 @@ class TestAnnouncementTracing:
     ):
         """announce_domain_admin should call trace_discovery with correct attributes."""
         await dispatcher.announce_domain_admin(
-            username="jon.snow",
-            domain="north.sevenkingdoms.local",
+            username="testuser",
+            domain="child.contoso.local",
             attack_path="privesc → krbtgt (NTLM)",
             credential_type="hash",
             source_agent="privesc",
@@ -178,8 +178,8 @@ class TestAnnouncementTracing:
         assert call_kwargs["discovery_type"] == "domain_admin"
         assert call_kwargs["source_agent"] == "privesc"
         assert call_kwargs["operation_id"] == "op-test-announce"
-        assert call_kwargs["target_user"] == "jon.snow"
-        assert call_kwargs["target_domain"] == "north.sevenkingdoms.local"
+        assert call_kwargs["target_user"] == "testuser"
+        assert call_kwargs["target_domain"] == "child.contoso.local"
         assert call_kwargs["additional_attrs"]["attack_path"] == "privesc → krbtgt (NTLM)"
         assert call_kwargs["additional_attrs"]["credential_type"] == "hash"
         assert call_kwargs["additional_attrs"]["mitre.technique.id"] == "T1003.006"

--- a/tests/core/dispatcher/test_dispatcher.py
+++ b/tests/core/dispatcher/test_dispatcher.py
@@ -78,18 +78,18 @@ async def test_get_exploitation_status_handles_string_result():
     dispatcher = RedTeamDispatcher()
     dispatcher._shared_state = SharedRedTeamState(operation_id="op-test-str-result")
 
-    vuln_key = b"ares:op:op-test-str-result:vulns:adcs_esc8_10.1.2.183"
+    vuln_key = b"ares:op:op-test-str-result:vulns:adcs_esc8_192.168.58.10"
     vuln_payload = json.dumps(
         {
             "type": "adcs_esc8",
-            "target": "10.1.2.183",
+            "target": "192.168.58.10",
             "details": {"ca_server": "ADCS01"},
             "discovered_by": "recon",
             "queued_at": "2024-01-01T00:00:00+00:00",
         }
     )
     # Bug case: result is a string error message, not a dict
-    exploit_key = b"ares:op:op-test-str-result:exploited:adcs_esc8_10.1.2.183"
+    exploit_key = b"ares:op:op-test-str-result:exploited:adcs_esc8_192.168.58.10"
     exploit_payload = json.dumps(
         {
             "success": False,
@@ -110,7 +110,7 @@ async def test_get_exploitation_status_handles_string_result():
     assert status["total_failed"] == 1
     assert len(status["failed"]) == 1
     assert status["failed"][0]["type"] == "adcs_esc8"
-    assert status["failed"][0]["target"] == "10.1.2.183"
+    assert status["failed"][0]["target"] == "192.168.58.10"
     # Error should be extracted from string result
     assert "AttributeError" in status["failed"][0]["error"]
 
@@ -541,6 +541,43 @@ class TestFindDomainControllerIp:
             f"Expected dc01.fabrikam.local (192.168.58.240), got {fabrikam_dc}"
         )
         assert fabrikam_dc != "192.168.58.146", "BUG: sql01 selected - 3389 matched as 389!"
+
+    def test_child_domain_does_not_match_parent(self):
+        """Child domain hosts must NOT match parent domain lookups.
+
+        dc01.child.contoso.local should NOT match contoso.local.
+        This was a critical bug where hostname.endswith(".contoso.local")
+        incorrectly matched child.contoso.local hosts to parent domain.
+        """
+        dispatcher = RedTeamDispatcher()
+        dispatcher._shared_state = SharedRedTeamState(operation_id="op-test-dc-child")
+
+        # Add parent domain DC
+        dispatcher._shared_state.all_hosts.append(
+            Host(
+                ip="192.168.58.10",
+                hostname="dc01.contoso.local",
+                roles=["Domain Controller"],
+                services=["88/tcp kerberos-sec", "389/tcp ldap"],
+            )
+        )
+        # Add child domain DC - should NOT match parent domain
+        dispatcher._shared_state.all_hosts.append(
+            Host(
+                ip="192.168.58.20",
+                hostname="dc02.child.contoso.local",
+                roles=["Domain Controller"],
+                services=["88/tcp kerberos-sec", "389/tcp ldap"],
+            )
+        )
+
+        # Looking up contoso.local MUST return dc01, NOT dc02
+        parent_dc = dispatcher._find_domain_controller_ip("contoso.local")
+        assert parent_dc == "192.168.58.10", f"Expected dc01 (192.168.58.10), got {parent_dc}"
+
+        # Looking up child.contoso.local MUST return dc02
+        child_dc = dispatcher._find_domain_controller_ip("child.contoso.local")
+        assert child_dc == "192.168.58.20", f"Expected dc02 (192.168.58.20), got {child_dc}"
 
     def test_uses_target_when_domain_matches(self):
         """When target.domain matches requested domain, use target.ip.
@@ -1425,8 +1462,8 @@ class TestDispatcherAddUserDelegation:
         """Dispatcher._add_user should prevent same user in parent and child domains.
 
         This is a regression test for a bug where:
-        1. User was added to sevenkingdoms.local
-        2. Same user was added to north.sevenkingdoms.local (child domain)
+        1. User was added to contoso.local
+        2. Same user was added to child.contoso.local (child domain)
         3. Bug: both were added because _add_user only checked exact match
         4. Fix: _add_user now delegates to shared_state.add_user() which handles parent/child
         """
@@ -1548,22 +1585,22 @@ class TestNormalizeCredentialDomainsToUsers:
         state = SharedRedTeamState(operation_id="op-test-normalize-cred")
 
         # User only exists in child domain
-        state.all_users.append(User(username="samwell.tarly", domain="north.sevenkingdoms.local"))
+        state.all_users.append(User(username="svc_backup", domain="child.contoso.local"))
 
         # Two credentials: one with parent domain (wrong), one with child domain (correct)
         state.all_credentials.append(
             Credential(
-                username="samwell.tarly",
-                password="Heartsbane",  # pragma: allowlist secret
-                domain="sevenkingdoms.local",
+                username="svc_backup",
+                password="BackupPass123",  # pragma: allowlist secret
+                domain="contoso.local",
                 source="test1",
             )
         )
         state.all_credentials.append(
             Credential(
-                username="samwell.tarly",
-                password="Heartsbane",  # pragma: allowlist secret
-                domain="north.sevenkingdoms.local",
+                username="svc_backup",
+                password="BackupPass123",  # pragma: allowlist secret
+                domain="child.contoso.local",
                 source="test2",
             )
         )
@@ -1574,7 +1611,7 @@ class TestNormalizeCredentialDomainsToUsers:
         # Should remove the parent domain credential
         assert removed == 1
         assert len(state.all_credentials) == 1
-        assert state.all_credentials[0].domain == "north.sevenkingdoms.local"
+        assert state.all_credentials[0].domain == "child.contoso.local"
 
     def test_keeps_legitimate_password_reuse_across_domains(self):
         """Same credential in multiple domains where user exists in both."""
@@ -1583,23 +1620,23 @@ class TestNormalizeCredentialDomainsToUsers:
         state = SharedRedTeamState(operation_id="op-test-legit-reuse")
 
         # User exists in BOTH domains (legitimate password reuse)
-        state.all_users.append(User(username="arya.stark", domain="sevenkingdoms.local"))
-        state.all_users.append(User(username="arya.stark", domain="north.sevenkingdoms.local"))
+        state.all_users.append(User(username="sql_svc", domain="contoso.local"))
+        state.all_users.append(User(username="sql_svc", domain="child.contoso.local"))
 
         # Credentials in both domains
         state.all_credentials.append(
             Credential(
-                username="arya.stark",
-                password="needle",  # pragma: allowlist secret
-                domain="sevenkingdoms.local",
+                username="sql_svc",
+                password="SqlPass123",  # pragma: allowlist secret
+                domain="contoso.local",
                 source="test1",
             )
         )
         state.all_credentials.append(
             Credential(
-                username="arya.stark",
-                password="needle",  # pragma: allowlist secret
-                domain="north.sevenkingdoms.local",
+                username="sql_svc",
+                password="SqlPass123",  # pragma: allowlist secret
+                domain="child.contoso.local",
                 source="test2",
             )
         )

--- a/tests/core/factories/test_red_agents.py
+++ b/tests/core/factories/test_red_agents.py
@@ -1371,3 +1371,71 @@ Password: SqlP@ss123
                         f"Should use target_domain contoso.local, got {call.kwargs['data']['domain']}"
                     )
                     return
+
+    @pytest.mark.asyncio
+    async def test_certipy_find_extracts_ca_details_for_esc8(self):
+        """Test that certipy_find extracts CA name and host for enriched ESC8 vulnerability."""
+        from ares.core.models import Target
+
+        shared_state = SharedRedTeamState(operation_id="op-test-esc8-details")
+        shared_state.target = Target(ip="192.168.58.10", domain="contoso.local")
+
+        # Mock dispatcher with task_queue attribute
+        mock_task_queue = MagicMock()
+        mock_task_queue.publish_discovery = AsyncMock()
+
+        dispatcher = MagicMock(spec=RedTeamDispatcher)
+        dispatcher.shared_state = shared_state
+        dispatcher._task_queue = mock_task_queue  # Hook reads task_queue from dispatcher
+
+        hooks = create_role_hooks(AgentRole.PRIVESC, dispatcher, shared_state)
+
+        # Simulate certipy_find output with CA details
+        certipy_find_output = """
+Certificate Authorities
+  0
+    CA Name                             : CONTOSO-CA
+    DNS Name                            : dc01.contoso.local
+    Certificate Subject                 : CN=CONTOSO-CA, DC=contoso, DC=local
+    Web Enrollment                      : Enabled
+    [!] Vulnerabilities
+      ESC8                              : Web Enrollment is vulnerable
+        """
+
+        event = self._make_tool_end_event("certipy_find", certipy_find_output)
+        # Add tool call args for credential context
+        event.tool_call.arguments = {
+            "domain": "contoso.local",
+            "dc_ip": "192.168.58.10",
+            "username": "testuser",
+            "password": "P@ssw0rd!",  # pragma: allowlist secret
+        }
+
+        for hook in hooks:
+            try:
+                await hook(event)
+            except TypeError:
+                pass
+
+        # Check that publish_discovery was called with enriched details
+        if mock_task_queue.publish_discovery.called:
+            for call in mock_task_queue.publish_discovery.call_args_list:
+                if call.kwargs.get("discovery_type") == "vulnerability":
+                    data = call.kwargs["data"]
+                    if data.get("vuln_type") == "adcs_esc8":
+                        details = data.get("details", {})
+                        assert details.get("ca_name") == "CONTOSO-CA", (
+                            f"Expected ca_name 'CONTOSO-CA', got {details.get('ca_name')}"
+                        )
+                        assert details.get("ca_host") == "dc01.contoso.local", (
+                            f"Expected ca_host 'dc01.contoso.local', got {details.get('ca_host')}"
+                        )
+                        assert details.get("domain") == "contoso.local", (
+                            f"Expected domain 'contoso.local', got {details.get('domain')}"
+                        )
+                        assert details.get("username") == "testuser", (
+                            f"Expected username 'testuser', got {details.get('username')}"
+                        )
+                        return
+
+        pytest.fail("Expected publish_discovery to be called with enriched ESC8 details")

--- a/tests/core/persistent_store/test_persistent_store.py
+++ b/tests/core/persistent_store/test_persistent_store.py
@@ -315,7 +315,7 @@ class TestHelperFunctions:
         from ares.core.persistent_store.store import _is_ip
 
         assert _is_ip("192.168.58.10") is True
-        assert _is_ip("10.0.0.1") is True
+        assert _is_ip("192.168.58.20") is True
         assert _is_ip("255.255.255.255") is True
 
     def test_is_ip_invalid(self):

--- a/tests/core/test_evidence_validation.py
+++ b/tests/core/test_evidence_validation.py
@@ -718,10 +718,10 @@ class TestTargetDomainScope:
 
     def test_multiple_target_domains(self):
         """Test multiple target domains all work."""
-        set_target_domains(["sevenkingdoms.local", "north.sevenkingdoms.local", "essos.local"])
-        assert _is_in_target_scope("winterfell.north.sevenkingdoms.local") is True
-        assert _is_in_target_scope("kingslanding.sevenkingdoms.local") is True
-        assert _is_in_target_scope("meereen.essos.local") is True
+        set_target_domains(["contoso.local", "child.contoso.local", "fabrikam.local"])
+        assert _is_in_target_scope("dc02.child.contoso.local") is True
+        assert _is_in_target_scope("dc01.contoso.local") is True
+        assert _is_in_target_scope("dc01.fabrikam.local") is True
         assert _is_in_target_scope("unrelated.domain.com") is False
 
     def test_clear_domains_resets_scope(self):

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1033,13 +1033,13 @@ class TestResolveNetBIOSToFQDN:
 
         state = SharedRedTeamState(operation_id="test-op")
         # DC discovered early - this is the common case
-        state.domain_controllers = {"north.sevenkingdoms.local": "192.168.58.240"}
+        state.domain_controllers = {"child.contoso.local": "192.168.58.240"}
 
-        # Should resolve "north" to "north.sevenkingdoms.local"
-        result = state._resolve_netbios_to_fqdn("north")
-        assert result == "north.sevenkingdoms.local"
+        # Should resolve "child" to "child.contoso.local"
+        result = state._resolve_netbios_to_fqdn("child")
+        assert result == "child.contoso.local"
         # Should also cache the mapping for future lookups
-        assert state.netbios_to_fqdn["north"] == "north.sevenkingdoms.local"
+        assert state.netbios_to_fqdn["child"] == "child.contoso.local"
 
     def test_domain_controllers_priority_over_target(self) -> None:
         """Test that domain_controllers takes priority over target.domain."""
@@ -1047,13 +1047,13 @@ class TestResolveNetBIOSToFQDN:
 
         state = SharedRedTeamState(operation_id="test-op")
         # Target is parent domain
-        state.target = Target(ip="192.168.58.1", domain="sevenkingdoms.local")
+        state.target = Target(ip="192.168.58.1", domain="contoso.local")
         # But DC for child domain is known
-        state.domain_controllers = {"north.sevenkingdoms.local": "192.168.58.240"}
+        state.domain_controllers = {"child.contoso.local": "192.168.58.240"}
 
         # Should prefer domain_controllers over target.domain
-        result = state._resolve_netbios_to_fqdn("north")
-        assert result == "north.sevenkingdoms.local"
+        result = state._resolve_netbios_to_fqdn("child")
+        assert result == "child.contoso.local"
 
 
 class TestAddNetBIOSMapping:
@@ -1986,10 +1986,10 @@ class TestGoldenTicketCapabilityDetection:
 
         state = SharedRedTeamState(operation_id="test-op")
 
-        # "north" should match "north.sevenkingdoms.local"
-        assert state._domains_match("north", "north.sevenkingdoms.local") is True
-        # But "north" should not match "south.sevenkingdoms.local"
-        assert state._domains_match("north", "south.sevenkingdoms.local") is False
+        # "child" should match "child.contoso.local"
+        assert state._domains_match("child", "child.contoso.local") is True
+        # But "child" should not match "other.contoso.local"
+        assert state._domains_match("child", "other.contoso.local") is False
 
     def test_golden_ticket_capable_creds_field_default(self) -> None:
         """Test golden_ticket_capable_creds field has empty dict default."""
@@ -2232,8 +2232,8 @@ class TestResolveHostnameToFQDN:
     """Tests for SharedRedTeamState.resolve_hostname_to_fqdn.
 
     This method normalizes hostnames to canonical FQDNs at the span emission layer.
-    It handles NetBIOS names (WINTERFELL), short names (winterfell), and wrong
-    domain suffixes (winterfell.sevenkingdoms.local -> winterfell.north.sevenkingdoms.local).
+    It handles NetBIOS names (DC02), short names (dc02), and wrong
+    domain suffixes (dc02.contoso.local -> dc02.child.contoso.local).
     """
 
     def test_resolves_netbios_to_fqdn(self) -> None:
@@ -2439,22 +2439,22 @@ class TestAddHostMerge:
     def test_prefers_more_specific_fqdn(self) -> None:
         """Test that more specific FQDN is preferred over less specific.
 
-        This is the GOAD scenario: winterfell.sevenkingdoms.local should be
-        upgraded to winterfell.north.sevenkingdoms.local (more specific).
+        This scenario: dc02.contoso.local should be
+        upgraded to dc02.child.contoso.local (more specific).
         """
         from ares.core.models import Host, SharedRedTeamState
 
         state = SharedRedTeamState(operation_id="test-op")
 
         # Add host with less specific FQDN first (wrong domain suffix)
-        state.add_host(Host(ip="10.1.2.240", hostname="winterfell.sevenkingdoms.local"))
-        assert state.all_hosts[0].hostname == "winterfell.sevenkingdoms.local"
+        state.add_host(Host(ip="192.168.58.240", hostname="dc02.contoso.local"))
+        assert state.all_hosts[0].hostname == "dc02.contoso.local"
 
         # Add same host with more specific FQDN (correct child domain)
-        state.add_host(Host(ip="10.1.2.240", hostname="winterfell.north.sevenkingdoms.local"))
+        state.add_host(Host(ip="192.168.58.240", hostname="dc02.child.contoso.local"))
         assert len(state.all_hosts) == 1
         # Should upgrade to more specific FQDN
-        assert state.all_hosts[0].hostname == "winterfell.north.sevenkingdoms.local"
+        assert state.all_hosts[0].hostname == "dc02.child.contoso.local"
 
     def test_does_not_downgrade_to_less_specific(self) -> None:
         """Test that a less specific FQDN does NOT replace a more specific one."""
@@ -2463,14 +2463,14 @@ class TestAddHostMerge:
         state = SharedRedTeamState(operation_id="test-op")
 
         # Add host with more specific FQDN first
-        state.add_host(Host(ip="10.1.2.240", hostname="winterfell.north.sevenkingdoms.local"))
-        assert state.all_hosts[0].hostname == "winterfell.north.sevenkingdoms.local"
+        state.add_host(Host(ip="192.168.58.240", hostname="dc02.child.contoso.local"))
+        assert state.all_hosts[0].hostname == "dc02.child.contoso.local"
 
         # Add same host with less specific FQDN - should NOT downgrade
-        state.add_host(Host(ip="10.1.2.240", hostname="winterfell.sevenkingdoms.local"))
+        state.add_host(Host(ip="192.168.58.240", hostname="dc02.contoso.local"))
         assert len(state.all_hosts) == 1
         # Should keep the more specific FQDN
-        assert state.all_hosts[0].hostname == "winterfell.north.sevenkingdoms.local"
+        assert state.all_hosts[0].hostname == "dc02.child.contoso.local"
 
     def test_requires_same_short_hostname_for_upgrade(self) -> None:
         """Test that FQDN upgrade only happens when short hostnames match."""

--- a/tests/core/test_tracing.py
+++ b/tests/core/test_tracing.py
@@ -392,7 +392,7 @@ class TestIsLikelyFqdn:
     def test_ip_address_returns_false(self):
         """IP addresses should return False (not FQDNs)."""
         assert is_likely_fqdn("192.168.58.10") is False
-        assert is_likely_fqdn("10.1.2.3") is False
+        assert is_likely_fqdn("192.168.58.20") is False
 
     def test_plain_hostname_returns_false(self):
         """Plain hostnames without dots should return False."""
@@ -887,7 +887,7 @@ class TestTraceToolCall:
         mock_span.__enter__ = MagicMock(return_value=mock_span)
         mock_span.__exit__ = MagicMock(return_value=False)
 
-        # Scenario: child domain user (north.sevenkingdoms.local) attacking parent domain
+        # Scenario: child domain user (child.contoso.local) attacking parent domain
         with patch("dreadnode.span", return_value=mock_span) as mock_dn_span:
             trace_tool_call(
                 "lateral",

--- a/tests/tools/blue/test_query_templates.py
+++ b/tests/tools/blue/test_query_templates.py
@@ -1410,7 +1410,7 @@ class TestS4UDelegationDetection:
 
     This detection catches the attack from op-20260214-141846:
     - jon.snow used constrained delegation via S4U2Proxy
-    - Impersonated Administrator to CIFS/winterfell
+    - Impersonated Administrator to CIFS/dc02
     - Led to secretsdump and krbtgt extraction
     """
 
@@ -1447,9 +1447,7 @@ class TestS4UDelegationDetection:
             mock_client.return_value.__aenter__.return_value.get = AsyncMock(
                 return_value=mock_response
             )
-            result = await tools.detect_s4u_delegation(
-                domain_controller="winterfell.north.contoso.local"
-            )
+            result = await tools.detect_s4u_delegation(domain_controller="dc02.child.contoso.local")
 
         assert result["_query_template"] == "s4u_delegation"
         assert result["_mitre_technique"] == "T1558.003"
@@ -1550,7 +1548,7 @@ class TestLSASecretsAccessDetection:
             mock_client.return_value.__aenter__.return_value.get = AsyncMock(
                 return_value=mock_response
             )
-            result = await tools.detect_lsa_secrets_access(target_host="winterfell.contoso.local")
+            result = await tools.detect_lsa_secrets_access(target_host="dc02.contoso.local")
 
         assert result["_query_template"] == "lsa_secrets_access"
 
@@ -1563,7 +1561,7 @@ class TestRemoteRegistryStartDetection:
     - Service state change to running/started
 
     From op-20260214-141846:
-    - "secretsdump started the RemoteRegistry service on winterfell"
+    - "secretsdump started the RemoteRegistry service on dc02"
     """
 
     @pytest.fixture
@@ -1600,8 +1598,6 @@ class TestRemoteRegistryStartDetection:
             mock_client.return_value.__aenter__.return_value.get = AsyncMock(
                 return_value=mock_response
             )
-            result = await tools.detect_remote_registry_start(
-                target_host="winterfell.contoso.local"
-            )
+            result = await tools.detect_remote_registry_start(target_host="dc02.contoso.local")
 
         assert result["_query_template"] == "remote_registry_start"


### PR DESCRIPTION

**Key Changes:**

- Updated all inline examples, comments, and test fixtures for new domain naming
- Enhanced ADCS vulnerability reporting to enrich details with CA name and host
- Improved domain controller resolution logic to prevent child/parent domain mismatches

**Added:**

- Extraction of CA name and CA host from `certipy_find` output for ADCS ESC8 vulnerabilities, enriching the vulnerability details for exploitation context in red team agent hooks
- Documentation and guidance on fail-fast handling when required parameters are missing for ADCS and other vulnerabilities in privilege escalation agent instructions

**Changed:**

- All code comments, test fixtures, docstrings, and documentation now use "contoso.local", "child.contoso.local", and related names instead of "sevenkingdoms.local" and its children
- Test cases and sample data updated to reflect the new domain structure, ensuring all scenarios (hostnames, FQDN, NetBIOS, DC resolution) use "contoso.local" and its child domains
- Domain controller selection logic in routing and dispatcher code now strictly matches child vs. parent domains, preventing incorrect host selection when domains share suffixes
- Blue team and red team agent instructions updated to clarify correct use of LogQL selectors and fail-fast logic, using the new canonical domain examples
- Vulnerability publishing hooks for `certipy_find` now extract and include CA details (name, host, credential context) for ESC8 and related ADCS vulnerabilities

**Removed:**

- Outdated domain references, hostnames, and scenario descriptions
- Legacy comments and docstrings that referenced old domain/host names or incorrect DC resolution behaviors