### PR TITLE
feat: add agent decision reasoning extraction and tracing for tool selection

### DIFF
--- a/src/ares/core/config.py
+++ b/src/ares/core/config.py
@@ -219,6 +219,8 @@ class OperationConfig:
     # Stop operation immediately when golden ticket is forged (for forest escalation)
     # NOTE: stop_on_domain_admin and stop_on_golden_ticket are mutually exclusive
     stop_on_golden_ticket: bool = False
+    # Multi-forest mode: continue operation until DA is achieved on all trusted forests
+    multi_forest_mode: bool = False
 
     # Rate limit retry settings (for worker agents)
     # Delays between retries when rate limited (list of seconds)
@@ -437,6 +439,7 @@ def _build_config(data: dict[str, Any]) -> OperationConfig:
         crack_task_grace_period=operation.get("crack_task_grace_period", 300.0),
         stop_on_domain_admin=operation.get("stop_on_domain_admin", False),
         stop_on_golden_ticket=operation.get("stop_on_golden_ticket", False),
+        multi_forest_mode=operation.get("multi_forest_mode", False),
         # Rate limit retry settings
         rate_limit_backoff_delays=operation.get(
             "rate_limit_backoff_delays", [5.0, 10.0, 20.0, 40.0, 60.0, 60.0]
@@ -1010,6 +1013,11 @@ def get_stop_on_domain_admin() -> bool:
 def get_stop_on_golden_ticket() -> bool:
     """Get whether to stop operation immediately when golden ticket is forged."""
     return load_config().stop_on_golden_ticket
+
+
+def get_multi_forest_mode() -> bool:
+    """Get whether multi-forest mode is enabled (continue until DA on all trusted forests)."""
+    return load_config().multi_forest_mode
 
 
 def get_operation_timeout() -> int:

--- a/src/ares/core/dispatcher/publishing.py
+++ b/src/ares/core/dispatcher/publishing.py
@@ -1212,16 +1212,11 @@ class PublishingMixin:
             event: The TimelineEvent to persist.
             task_queue: Optional task queue for threaded dispatch.
         """
-        # Serialize TimelineEvent to dict
-        event_dict = {
-            "id": event.id,
-            "timestamp": event.timestamp.isoformat(),
-            "description": event.description,
-            "evidence_ids": event.evidence_ids,
-            "mitre_techniques": event.mitre_techniques,
-            "confidence": event.confidence,
-            "source": event.source,
-        }
+        # Serialize TimelineEvent to dict (use to_dict() for consistent serialization)
+        event_dict = event.to_dict()
+        # Ensure timestamp is serialized as ISO string
+        if hasattr(event.timestamp, "isoformat"):
+            event_dict["timestamp"] = event.timestamp.isoformat()
 
         is_main_thread = threading.current_thread() is threading.main_thread()
         backend = getattr(self.shared_state, "_backend", None)

--- a/src/ares/core/factories/red_agents.py
+++ b/src/ares/core/factories/red_agents.py
@@ -21,13 +21,20 @@ from ares.core.config import (
     get_agent_config,
     get_max_context_tokens,
     get_min_messages_to_keep,
+    get_multi_forest_mode,
     get_stop_on_domain_admin,
     get_stop_on_golden_ticket,
 )
 from ares.core.dispatcher import RedTeamDispatcher
 from ares.core.models import AgentInfo, AgentRole, SharedRedTeamState
 from ares.core.templates import get_template_loader
-from ares.core.tracing import IP_PATTERN, TOOL_TO_TECHNIQUE, is_likely_fqdn, trace_tool_call
+from ares.core.tracing import (
+    IP_PATTERN,
+    TOOL_TO_TECHNIQUE,
+    is_likely_fqdn,
+    trace_decision,
+    trace_tool_call,
+)
 from ares.tools.red import (
     ACLExploitTools,
     BloodHoundTools,
@@ -169,22 +176,100 @@ ROLE_INSTRUCTIONS: dict[AgentRole, str] = {
 DEFAULT_MAX_STEPS = 75
 
 
-def load_agent_instructions(role: AgentRole) -> str:
+# =============================================================================
+# Decision Reasoning Extraction Helpers
+# =============================================================================
+
+
+def _extract_reasoning_text(content: str | list | None) -> str:
+    """Extract text reasoning from LLM message content.
+
+    The LLM response contains reasoning text before or alongside tool calls.
+    This extracts the text portions that explain the agent's decision.
+
+    Args:
+        content: Message content (string, list of parts, or None).
+
+    Returns:
+        Extracted reasoning text (may be empty).
+    """
+    if not content:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    # Handle list of content parts (TextPart, ContentText, etc.)
+    texts = []
+    for part in content:
+        if hasattr(part, "text"):
+            texts.append(part.text)
+        elif isinstance(part, str):
+            texts.append(part)
+    return " ".join(texts).strip()
+
+
+def _estimate_confidence(reasoning: str) -> float:
+    """Estimate confidence from language patterns in reasoning.
+
+    Heuristic confidence based on hedging language vs. assertive language.
+    This provides a rough signal for decision analysis.
+
+    Args:
+        reasoning: The reasoning text to analyze.
+
+    Returns:
+        Confidence score between 0.0 and 1.0.
+    """
+    if not reasoning:
+        return 0.5
+
+    lower = reasoning.lower()
+
+    # High confidence indicators
+    if any(w in lower for w in ["will", "must", "need to", "should", "going to"]):
+        return 0.9
+
+    # Medium-low confidence indicators
+    if any(w in lower for w in ["might", "try", "attempt", "could", "maybe", "possibly"]):
+        return 0.6
+
+    # Default medium-high
+    return 0.8
+
+
+def load_agent_instructions(
+    role: AgentRole,
+    shared_state: SharedRedTeamState | None = None,
+) -> str:
     """
     Load role-specific system instructions from template.
 
     Falls back to generic red team instructions if role-specific not found.
     Capabilities are loaded from config and passed to the template.
+
+    Args:
+        role: The agent role.
+        shared_state: Optional shared state for multi-forest mode context.
     """
     # Get capabilities from config (single source of truth)
     config_key = role.value  # e.g., "recon", "credential_access", "privesc"
     agent_config = get_agent_config(config_key)
     capabilities = agent_config.capabilities
 
+    # Multi-forest mode context for templates
+    multi_forest_mode = get_multi_forest_mode()
+    undominated_forests: list[str] = []
+    if multi_forest_mode and shared_state:
+        undominated_forests = shared_state.get_undominated_forests()
+
     template_path = ROLE_INSTRUCTIONS.get(role)
     if template_path:
         try:
-            return get_template_loader().render(template_path, capabilities=capabilities)
+            return get_template_loader().render(
+                template_path,
+                capabilities=capabilities,
+                multi_forest_mode=multi_forest_mode,
+                undominated_forests=undominated_forests,
+            )
         except Exception as e:
             logger.warning(f"Failed to load template {template_path}: {e}")
 
@@ -202,6 +287,8 @@ def load_agent_instructions(role: AgentRole) -> str:
         "redteam/agents/system_instructions.md.jinja",
         capabilities=capabilities,
         all_capabilities=all_capabilities,
+        multi_forest_mode=multi_forest_mode,
+        undominated_forests=undominated_forests,
     )
 
 
@@ -478,6 +565,91 @@ def create_role_hooks(
         return None
 
     hooks.extend([log_tool_usage, log_tool_result])
+
+    # Decision reasoning capture hook - records why agents chose specific tools
+    # This enables post-hoc analysis of agent decision patterns via timeline and OTel
+    async def capture_decision_reasoning(event: GenerationEnd) -> None:
+        """Capture reasoning from LLM tool selection for traceability.
+
+        When the LLM responds with tool calls, extract the reasoning text
+        and persist it to timeline + OTel for crash recovery and analysis.
+        """
+        if not isinstance(event, GenerationEnd):
+            return
+
+        # Only process messages with tool calls (actual decisions)
+        if not event.message or not getattr(event.message, "tool_calls", None):
+            return
+
+        tool_calls = event.message.tool_calls
+        if not tool_calls:
+            return
+
+        # Extract reasoning from message content (text before/with tool calls)
+        reasoning_text = _extract_reasoning_text(event.message.content)
+        tools_chosen = [tc.name for tc in tool_calls if hasattr(tc, "name")]
+        if not tools_chosen:
+            return
+
+        # Confidence heuristic from language patterns
+        confidence = _estimate_confidence(reasoning_text)
+
+        # Get operation_id for correlation
+        operation_id = getattr(shared_state, "operation_id", None) or getattr(
+            dispatcher, "operation_id", None
+        )
+
+        # Create timeline event with decision metadata
+        import json
+        import uuid
+        from datetime import datetime, timezone
+
+        from ares.core.models import TimelineEvent
+
+        extra_data = {
+            "decision_type": "tool_selection",
+            "tools_chosen": tools_chosen,
+            "reasoning_summary": reasoning_text[:500] if reasoning_text else "",
+        }
+        decision_event = TimelineEvent(
+            id=f"evt-decision-{uuid.uuid4().hex[:8]}",
+            timestamp=datetime.now(timezone.utc),
+            source=f"{role.value}_decision",
+            description=f"Agent chose {tools_chosen[0]}"
+            + (f" (+{len(tools_chosen) - 1} more)" if len(tools_chosen) > 1 else ""),
+            mitre_techniques=[TOOL_TO_TECHNIQUE.get(tools_chosen[0], "")],
+            confidence=confidence,
+            extra_data_json=json.dumps(extra_data),
+        )
+
+        # Add to in-memory timeline for immediate access
+        shared_state.operation_timeline.append(decision_event)
+
+        # Persist to Redis timeline (survives crash recovery)
+        # Use the backend pattern from publishing.py
+        backend = getattr(shared_state, "_backend", None)
+        if backend:
+            try:
+                event_dict = decision_event.to_dict()
+                # Ensure timestamp is serialized as ISO string
+                if hasattr(decision_event.timestamp, "isoformat"):
+                    event_dict["timestamp"] = decision_event.timestamp.isoformat()
+                await backend.add_timeline_event(event_dict)
+            except Exception as e:
+                logger.debug(f"Failed to persist decision event to Redis: {e}")
+
+        # Create OTel span for Tempo correlation
+        trace_decision(
+            role=role.value,
+            team="red",
+            tools_considered=tools_chosen,  # We only know what was chosen, not alternatives
+            tool_chosen=tools_chosen[0],
+            reasoning_summary=reasoning_text[:500] if reasoning_text else "",
+            confidence=confidence,
+            operation_id=operation_id,
+        )
+
+    hooks.append(capture_decision_reasoning)
 
     # Context management for ALL roles: summarize conversation when approaching token limits
     # This prevents context window exhaustion from accumulated tool outputs
@@ -1280,8 +1452,8 @@ def create_specialized_agent(
     if additional_tools:
         tools.extend(additional_tools)
 
-    # Load role-specific instructions
-    instructions = load_agent_instructions(role)
+    # Load role-specific instructions (with shared_state for multi-forest context)
+    instructions = load_agent_instructions(role, shared_state=shared_state)
 
     # Create hooks for this role
     hooks = create_role_hooks(role, dispatcher, shared_state)

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -2613,7 +2613,9 @@ class SharedRedTeamState:
         if hash_type == "ntlm" and username == "krbtgt":
             # Track which domains we have DA on (for multi-forest mode)
             domain_lower = domain.lower()
-            if domain_lower not in self.domain_admin_domains:
+            is_new_domain = domain_lower not in self.domain_admin_domains
+
+            if is_new_domain:
                 self.domain_admin_domains.append(domain_lower)
                 logger.info(f"Domain admin achieved on: {domain_lower}")
 
@@ -2621,43 +2623,46 @@ class SharedRedTeamState:
             if not self.has_domain_admin:
                 self.has_domain_admin = True
                 self.da_hash_id = hash_obj.id  # Store the ID for consistent attack chain building
+
+            # Only log, add weakness, and trace for NEW domain DA achievements
             # NOTE: Do NOT set completed_at here - that's controlled by stop_on_domain_admin
             # or stop_on_golden_ticket config in announcements.py
-            # Build attack path from credential chain instead of hardcoding
-            attack_chain = self.format_attack_chain(hash_obj)
-            self.domain_admin_path = attack_chain
-            logger.success(
-                f"🏆 DOMAIN ADMIN AUTO-DETECTED: {domain}\\{username} NTLM hash "
-                f"found in state (source: {source_agent})"
-            )
-            logger.info(f"Attack chain: {attack_chain}")
-            self.add_weakness(
-                f"### Domain Admin Achieved — krbtgt NTLM hash extracted\n"
-                f"**Attack Path:** {attack_chain}\n"
-                f"**Vulnerability:** krbtgt hash extracted via DCSync or ntds.dit dump, "
-                f"enabling Golden Ticket attacks.\n"
-                f"- **Affected Resource:** {domain} domain\n"
-                f"- **Discovery Method:** {source_agent}\n"
-                f"- **Impact:** Complete domain compromise. Golden Tickets grant indefinite DA access."
-            )
+            if is_new_domain:
+                # Build attack path from credential chain instead of hardcoding
+                attack_chain = self.format_attack_chain(hash_obj)
+                self.domain_admin_path = attack_chain
+                logger.success(
+                    f"🏆 DOMAIN ADMIN AUTO-DETECTED: {domain}\\{username} NTLM hash "
+                    f"found in state (source: {source_agent})"
+                )
+                logger.info(f"Attack chain: {attack_chain}")
+                self.add_weakness(
+                    f"### Domain Admin Achieved — krbtgt NTLM hash extracted\n"
+                    f"**Attack Path:** {attack_chain}\n"
+                    f"**Vulnerability:** krbtgt hash extracted via DCSync or ntds.dit dump, "
+                    f"enabling Golden Ticket attacks.\n"
+                    f"- **Affected Resource:** {domain} domain\n"
+                    f"- **Discovery Method:** {source_agent}\n"
+                    f"- **Impact:** Complete domain compromise. Golden Tickets grant indefinite DA access."
+                )
 
-            # Trace the domain admin achievement for OpenTelemetry
-            # This is critical for Grafana dashboards to show DA as achieved
-            from ares.core.tracing import trace_discovery
+                # Trace the domain admin achievement for OpenTelemetry
+                # This is critical for Grafana dashboards to show DA as achieved
+                from ares.core.tracing import trace_discovery
 
-            trace_discovery(
-                discovery_type="domain_admin",
-                source_agent=source_agent or "auto-detect",
-                operation_id=self.operation_id,
-                target_user="krbtgt",
-                target_domain=domain,
-                additional_attrs={
-                    "attack_path": attack_chain,
-                    "credential_type": "ntlm_hash",
-                    "mitre.technique.id": "T1003.006",  # DCSync/credential dumping
-                    "auto_detected": True,
-                },
-            )
+                trace_discovery(
+                    discovery_type="domain_admin",
+                    source_agent=source_agent or "auto-detect",
+                    operation_id=self.operation_id,
+                    target_user="krbtgt",
+                    target_domain=domain,
+                    additional_attrs={
+                        "attack_path": attack_chain,
+                        "credential_type": "ntlm_hash",
+                        "mitre.technique.id": "T1003.006",  # DCSync/credential dumping
+                        "auto_detected": True,
+                    },
+                )
 
         # Persist to Redis backend if available and in the correct event loop
         if self._can_persist_to_backend():

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -201,6 +201,7 @@ class TimelineEvent(Model):
         mitre_techniques: MITRE ATT&CK technique IDs associated with this event.
         confidence: Confidence score between 0.0 and 1.0.
         source: Source of this event (e.g., "investigation", "alert").
+        extra_data_json: Optional JSON-encoded structured metadata for decision tracing.
     """
 
     id: str
@@ -210,10 +211,31 @@ class TimelineEvent(Model):
     mitre_techniques: list[str] = wrapped("mitre-techniques", element(tag="technique", default=[]))
     confidence: float = 0.5
     source: str = "investigation"
+    # Store as JSON string to avoid pydantic_xml limitations with dict[str, Any]
+    extra_data_json: str | None = None
+
+    @property
+    def extra_data(self) -> dict[str, Any] | None:
+        """Get extra_data as dict (deserialized from JSON)."""
+        if self.extra_data_json is None:
+            return None
+        import json
+
+        try:
+            return json.loads(self.extra_data_json)
+        except (json.JSONDecodeError, TypeError):
+            return None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for storage."""
-        return self.model_dump(mode="json")
+        d = self.model_dump(mode="json")
+        # Convert extra_data_json to extra_data dict for storage
+        if self.extra_data_json:
+            d["extra_data"] = self.extra_data
+            d.pop("extra_data_json", None)
+        else:
+            d.pop("extra_data_json", None)
+        return d
 
 
 class InvestigativeQuestion(Model):
@@ -935,6 +957,63 @@ class SharedRedTeamState:
 
         self._background_tasks.add(task)
         task.add_done_callback(done_callback)
+
+    # =========================================================================
+    # Multi-Forest Mode Helpers
+    # =========================================================================
+
+    def all_forests_dominated(self) -> bool:
+        """Check if DA has been achieved on all trusted forests.
+
+        For multi-forest mode, the operation should only complete when
+        DA (krbtgt hash) has been obtained from ALL trusted forests,
+        not just the initial target domain.
+
+        Returns:
+            True if:
+            - No trusted domains discovered (nothing to pivot to)
+            - All trusted domains have been dominated (have DA)
+            False if there are undominated trusted domains.
+        """
+        if not self.trusted_domains:
+            # No trusted domains discovered yet - only have initial domain
+            return True
+
+        da_domains_lower = {d.lower() for d in self.domain_admin_domains}
+
+        for trusted in self.trusted_domains:
+            trusted_lower = trusted.lower()
+            # Skip if this is our target domain (we check that separately)
+            if self.target and trusted_lower == self.target.domain.lower():
+                continue
+            # Check if we have DA on this trusted domain
+            if trusted_lower not in da_domains_lower:
+                logger.debug(f"Trusted domain not yet dominated: {trusted}")
+                return False
+
+        return True
+
+    def get_undominated_forests(self) -> list[str]:
+        """Get list of trusted forests where we don't have DA yet.
+
+        Returns:
+            List of domain FQDNs that are trusted but not yet dominated.
+        """
+        if not self.trusted_domains:
+            return []
+
+        da_domains_lower = {d.lower() for d in self.domain_admin_domains}
+        undominated = []
+
+        for trusted in self.trusted_domains:
+            trusted_lower = trusted.lower()
+            # Skip if this is our target domain
+            if self.target and trusted_lower == self.target.domain.lower():
+                continue
+            if trusted_lower not in da_domains_lower:
+                undominated.append(trusted)
+
+        return undominated
 
     # =========================================================================
     # Processed Set Helpers (with Redis persistence)
@@ -2531,9 +2610,17 @@ class SharedRedTeamState:
         # - krbtgt only exists on DCs, so its hash proves DC-level access
         # - "Administrator" could be a LOCAL admin on a workstation (not DA!)
         # - Having 7 hashes instead of all ntds.dit hashes = NOT domain admin
-        if hash_type == "ntlm" and username == "krbtgt" and not self.has_domain_admin:
-            self.has_domain_admin = True
-            self.da_hash_id = hash_obj.id  # Store the ID for consistent attack chain building
+        if hash_type == "ntlm" and username == "krbtgt":
+            # Track which domains we have DA on (for multi-forest mode)
+            domain_lower = domain.lower()
+            if domain_lower not in self.domain_admin_domains:
+                self.domain_admin_domains.append(domain_lower)
+                logger.info(f"Domain admin achieved on: {domain_lower}")
+
+            # Only set global has_domain_admin flag on first DA
+            if not self.has_domain_admin:
+                self.has_domain_admin = True
+                self.da_hash_id = hash_obj.id  # Store the ID for consistent attack chain building
             # NOTE: Do NOT set completed_at here - that's controlled by stop_on_domain_admin
             # or stop_on_golden_ticket config in announcements.py
             # Build attack path from credential chain instead of hardcoding

--- a/src/ares/core/tracing.py
+++ b/src/ares/core/tracing.py
@@ -917,6 +917,71 @@ def trace_discovery(
         logger.debug(f"Failed to create discovery span: {e}")
 
 
+def trace_decision(
+    role: str,
+    team: str,
+    tools_considered: list[str],
+    tool_chosen: str,
+    reasoning_summary: str,
+    confidence: float | None = None,
+    operation_id: str | None = None,
+    task_id: str | None = None,
+) -> None:
+    """Record an agent tool selection decision as a span.
+
+    Creates a span capturing why an agent chose specific tools, including
+    the reasoning and alternatives considered. This enables post-hoc analysis
+    of agent decision patterns in Tempo.
+
+    Args:
+        role: Agent role making the decision (e.g., "credential_access").
+        team: Team name ("red" or "blue").
+        tools_considered: List of tool names the agent could have chosen.
+        tool_chosen: The tool name that was actually selected.
+        reasoning_summary: Truncated reasoning text from LLM response.
+        confidence: Optional confidence score (0.0 to 1.0) inferred from language.
+        operation_id: Optional operation ID for correlation.
+        task_id: Optional task ID for correlation.
+    """
+    attrs: dict[str, Any] = {
+        "service.namespace": "ares",
+        "attack_team": team,
+        "agent.role": role,
+        "decision.type": "tool_selection",
+        "decision.tool_chosen": tool_chosen,
+        "decision.reasoning_length": len(reasoning_summary),
+    }
+
+    # Store up to 5 considered tools (OTel array attribute)
+    if tools_considered:
+        attrs["decision.tools_considered"] = tools_considered[:5]
+
+    if confidence is not None:
+        attrs["decision.confidence"] = confidence
+
+    if operation_id:
+        attrs["attack_operation_id"] = operation_id
+
+    if task_id:
+        attrs["task.id"] = task_id
+
+    # Add MITRE technique for the chosen tool
+    technique_id = TOOL_TO_TECHNIQUE.get(tool_chosen)
+    if technique_id:
+        attrs["mitre.technique.id"] = technique_id
+
+    # Add tool category for the chosen tool
+    category = TOOL_TO_CATEGORY.get(tool_chosen)
+    if category:
+        attrs["attack_tool_category"] = category
+
+    try:
+        with dn.span(f"decision.{role}", attributes=attrs):
+            pass  # Point-in-time span
+    except Exception as e:
+        logger.debug(f"Failed to create decision span: {e}")
+
+
 def trace_blue_investigation(
     role: str,
     investigation_id: str,

--- a/tests/core/dispatcher/test_dispatcher.py
+++ b/tests/core/dispatcher/test_dispatcher.py
@@ -2077,8 +2077,8 @@ class TestDomainAdminTraceDiscovery:
         da_calls = [c for c in captured_calls if c["discovery_type"] == "domain_admin"]
         assert len(da_calls) == 0, "Non-krbtgt hash should NOT trigger domain_admin trace"
 
-    def test_add_hash_krbtgt_only_traces_once(self):
-        """Multiple krbtgt hashes should only trace DA once (first occurrence)."""
+    def test_add_hash_krbtgt_traces_each_domain_once(self):
+        """Multiple krbtgt hashes from different domains each trace DA (multi-forest support)."""
         from unittest.mock import patch
 
         from ares.core.models import Hash
@@ -2101,6 +2101,15 @@ class TestDomainAdminTraceDiscovery:
             source="secretsdump",
         )
 
+        # Same domain as hash1, should NOT trace again
+        krbtgt_hash3 = Hash(
+            username="krbtgt",
+            domain="contoso.local",
+            hash_type="ntlm",
+            hash_value="aad3b435b51404eeaad3b435b51404ee:cccc",
+            source="secretsdump",
+        )
+
         captured_calls = []
 
         def mock_trace_discovery(*args, **kwargs):
@@ -2109,10 +2118,12 @@ class TestDomainAdminTraceDiscovery:
         with patch("ares.core.tracing.trace_discovery", side_effect=mock_trace_discovery):
             state.add_hash(krbtgt_hash1, source_agent="lateral")
             state.add_hash(krbtgt_hash2, source_agent="lateral")
+            state.add_hash(krbtgt_hash3, source_agent="lateral")
 
         # Filter for domain_admin discovery only
         da_calls = [c for c in captured_calls if c["discovery_type"] == "domain_admin"]
 
-        # Should only trace once (first krbtgt sets has_domain_admin=True)
-        assert len(da_calls) == 1, f"Expected 1 domain_admin trace, got {len(da_calls)}"
-        assert da_calls[0]["target_domain"] == "contoso.local"
+        # Multi-forest mode: trace DA for each DISTINCT domain (dedup same domain)
+        assert len(da_calls) == 2, f"Expected 2 domain_admin traces, got {len(da_calls)}"
+        traced_domains = {c["target_domain"] for c in da_calls}
+        assert traced_domains == {"contoso.local", "child.contoso.local"}

--- a/tests/core/factories/test_red_agents.py
+++ b/tests/core/factories/test_red_agents.py
@@ -96,7 +96,7 @@ def test_create_specialized_agent_uses_set_state(monkeypatch):
     )
     monkeypatch.setattr(
         "ares.core.factories.red_agents.load_agent_instructions",
-        lambda _role, _shared_state=None: "instructions",
+        lambda _role, **_kwargs: "instructions",
     )
     monkeypatch.setattr(
         "ares.core.factories.red_agents.create_role_hooks",

--- a/tests/core/factories/test_red_agents.py
+++ b/tests/core/factories/test_red_agents.py
@@ -10,6 +10,8 @@ from dreadnode.agent.reactions import Finish
 from ares.core.config import AgentConfig
 from ares.core.dispatcher import RedTeamDispatcher
 from ares.core.factories.red_agents import (
+    _estimate_confidence,
+    _extract_reasoning_text,
     create_agent_info,
     create_multi_agent_ensemble,
     create_role_hooks,
@@ -1439,3 +1441,81 @@ Certificate Authorities
                         return
 
         pytest.fail("Expected publish_discovery to be called with enriched ESC8 details")
+
+
+# =============================================================================
+# Tests for decision reasoning helpers
+# =============================================================================
+
+
+class TestDecisionReasoningHelpers:
+    """Tests for _extract_reasoning_text and _estimate_confidence helper functions."""
+
+    def test_extract_reasoning_text_from_string(self):
+        """Extract reasoning from simple string content."""
+
+        result = _extract_reasoning_text("I will use secretsdump to get credentials")
+        assert result == "I will use secretsdump to get credentials"
+
+    def test_extract_reasoning_text_from_list(self):
+        """Extract reasoning from list of content parts."""
+
+        # Simulate list of content parts with text attribute
+        class TextPart:
+            def __init__(self, text: str):
+                self.text = text
+
+        content = [TextPart("First reasoning"), TextPart("Second reasoning")]
+        result = _extract_reasoning_text(content)
+        assert "First reasoning" in result
+        assert "Second reasoning" in result
+
+    def test_extract_reasoning_text_from_mixed_list(self):
+        """Extract reasoning handles mixed list with strings and objects."""
+
+        content = ["Direct text", MagicMock(text="Object text")]
+        result = _extract_reasoning_text(content)
+        assert "Direct text" in result
+        assert "Object text" in result
+
+    def test_extract_reasoning_text_from_none(self):
+        """Extract reasoning returns empty string for None."""
+
+        result = _extract_reasoning_text(None)
+        assert result == ""
+
+    def test_extract_reasoning_text_strips_whitespace(self):
+        """Extract reasoning strips leading/trailing whitespace."""
+
+        result = _extract_reasoning_text("  padded text  ")
+        assert result == "padded text"
+
+    def test_estimate_confidence_high_for_assertive(self):
+        """Estimate high confidence for assertive language."""
+
+        assert _estimate_confidence("I will use secretsdump") == 0.9
+        assert _estimate_confidence("We must run kerberoast") == 0.9
+        assert _estimate_confidence("I need to enumerate") == 0.9
+        assert _estimate_confidence("I should try psexec") == 0.9
+        assert _estimate_confidence("I'm going to run nmap") == 0.9
+
+    def test_estimate_confidence_medium_low_for_hedging(self):
+        """Estimate lower confidence for hedging language."""
+
+        assert _estimate_confidence("I might try secretsdump") == 0.6
+        assert _estimate_confidence("Let me attempt this") == 0.6
+        assert _estimate_confidence("This could work") == 0.6
+        assert _estimate_confidence("Maybe we can enumerate") == 0.6
+        assert _estimate_confidence("possibly this can succeed") == 0.6
+
+    def test_estimate_confidence_default_for_neutral(self):
+        """Estimate default confidence for neutral language."""
+
+        assert _estimate_confidence("Running secretsdump") == 0.8
+        assert _estimate_confidence("Executing kerberoast now") == 0.8
+
+    def test_estimate_confidence_handles_empty(self):
+        """Estimate default confidence for empty reasoning."""
+
+        assert _estimate_confidence("") == 0.5
+        assert _estimate_confidence(None) == 0.5  # type: ignore[arg-type]

--- a/tests/core/factories/test_red_agents.py
+++ b/tests/core/factories/test_red_agents.py
@@ -96,7 +96,7 @@ def test_create_specialized_agent_uses_set_state(monkeypatch):
     )
     monkeypatch.setattr(
         "ares.core.factories.red_agents.load_agent_instructions",
-        lambda _role: "instructions",
+        lambda _role, _shared_state=None: "instructions",
     )
     monkeypatch.setattr(
         "ares.core.factories.red_agents.create_role_hooks",

--- a/tests/core/test_tracing.py
+++ b/tests/core/test_tracing.py
@@ -1004,3 +1004,131 @@ class TestTraceBlueInvestigation:
         with patch("dreadnode.span", side_effect=Exception("Tracing unavailable")):
             # Should not raise - just logs debug
             trace_blue_investigation(role="triage", investigation_id="inv-fail")
+
+
+class TestTraceDecision:
+    """Tests for trace_decision function."""
+
+    def test_trace_decision_creates_span_with_tool_info(self):
+        """trace_decision should create a span with tool selection attributes."""
+        from unittest.mock import MagicMock, patch
+
+        from ares.core.tracing import trace_decision
+
+        mock_span = MagicMock()
+        mock_span.__enter__ = MagicMock(return_value=mock_span)
+        mock_span.__exit__ = MagicMock(return_value=False)
+
+        with patch("dreadnode.span", return_value=mock_span) as mock_dn_span:
+            trace_decision(
+                role="credential_access",
+                team="red",
+                tools_considered=["secretsdump", "kerberoast", "asrep_roast"],
+                tool_chosen="secretsdump",
+                reasoning_summary="I will use secretsdump to get credentials",
+                confidence=0.9,
+                operation_id="op-test-123",
+            )
+
+        mock_dn_span.assert_called_once()
+        call_kwargs = mock_dn_span.call_args[1]
+        attrs = call_kwargs["attributes"]
+
+        assert "decision.credential_access" in mock_dn_span.call_args[0][0]
+        assert attrs["decision.type"] == "tool_selection"
+        assert attrs["decision.tool_chosen"] == "secretsdump"
+        assert attrs["decision.tools_considered"] == ["secretsdump", "kerberoast", "asrep_roast"]
+        assert attrs["decision.confidence"] == 0.9
+        assert attrs["attack_operation_id"] == "op-test-123"
+
+    def test_trace_decision_adds_mitre_technique(self):
+        """trace_decision should add MITRE technique for known tools."""
+        from unittest.mock import MagicMock, patch
+
+        from ares.core.tracing import trace_decision
+
+        mock_span = MagicMock()
+        mock_span.__enter__ = MagicMock(return_value=mock_span)
+        mock_span.__exit__ = MagicMock(return_value=False)
+
+        with patch("dreadnode.span", return_value=mock_span) as mock_dn_span:
+            trace_decision(
+                role="credential_access",
+                team="red",
+                tools_considered=["secretsdump"],
+                tool_chosen="secretsdump",
+                reasoning_summary="Running DCSync",
+            )
+
+        call_kwargs = mock_dn_span.call_args[1]
+        attrs = call_kwargs["attributes"]
+
+        # secretsdump maps to T1003.006 (DCSync)
+        assert attrs["mitre.technique.id"] == "T1003.006"
+
+    def test_trace_decision_truncates_tools_considered(self):
+        """trace_decision should limit tools_considered to 5 entries."""
+        from unittest.mock import MagicMock, patch
+
+        from ares.core.tracing import trace_decision
+
+        mock_span = MagicMock()
+        mock_span.__enter__ = MagicMock(return_value=mock_span)
+        mock_span.__exit__ = MagicMock(return_value=False)
+
+        many_tools = [f"tool_{i}" for i in range(10)]
+
+        with patch("dreadnode.span", return_value=mock_span) as mock_dn_span:
+            trace_decision(
+                role="recon",
+                team="red",
+                tools_considered=many_tools,
+                tool_chosen="tool_0",
+                reasoning_summary="Testing",
+            )
+
+        call_kwargs = mock_dn_span.call_args[1]
+        attrs = call_kwargs["attributes"]
+
+        assert len(attrs["decision.tools_considered"]) == 5
+
+    def test_trace_decision_handles_exception(self):
+        """trace_decision should not raise if span creation fails."""
+        from unittest.mock import patch
+
+        from ares.core.tracing import trace_decision
+
+        with patch("dreadnode.span", side_effect=Exception("Tracing unavailable")):
+            # Should not raise - just logs debug
+            trace_decision(
+                role="recon",
+                team="red",
+                tools_considered=["nmap_scan"],
+                tool_chosen="nmap_scan",
+                reasoning_summary="Test",
+            )
+
+    def test_trace_decision_includes_tool_category(self):
+        """trace_decision should include attack_tool_category for known tools."""
+        from unittest.mock import MagicMock, patch
+
+        from ares.core.tracing import trace_decision
+
+        mock_span = MagicMock()
+        mock_span.__enter__ = MagicMock(return_value=mock_span)
+        mock_span.__exit__ = MagicMock(return_value=False)
+
+        with patch("dreadnode.span", return_value=mock_span) as mock_dn_span:
+            trace_decision(
+                role="lateral",
+                team="red",
+                tools_considered=["psexec"],
+                tool_chosen="psexec",
+                reasoning_summary="Use psexec for lateral movement",
+            )
+
+        call_kwargs = mock_dn_span.call_args[1]
+        attrs = call_kwargs["attributes"]
+
+        # psexec maps to LateralMovementTools category
+        assert attrs["attack_tool_category"] == "LateralMovementTools"


### PR DESCRIPTION

**Key Changes:**

- Introduced extraction and storage of agent tool selection reasoning for traceability
- Added OpenTelemetry span creation for agent tool selection decisions
- Enhanced TimelineEvent model with structured extra_data for decision events
- Provided helper functions and comprehensive unit tests for reasoning extraction and confidence estimation

**Added:**

- Decision reasoning extraction helpers `_extract_reasoning_text` and `_estimate_confidence` to parse LLM responses and estimate confidence heuristically
- Async hook in `create_role_hooks` to capture agent reasoning and tool selection, storing results in both the operation timeline and Redis for crash recovery
- OpenTelemetry tracing via `trace_decision`, recording tool selection decisions and reasoning for post-hoc analysis
- TimelineEvent model now includes an `extra_data_json` field for structured, JSON-encoded decision metadata
- Multi-forest helpers in `SharedRedTeamState` to identify and track undominated forests for multi-domain operations
- Unit tests for reasoning extraction, confidence estimation, and decision tracing in `test_red_agents.py` and `test_tracing.py`

**Changed:**

- Agent instruction templates now receive multi-forest context and undominated forests for more accurate role guidance
- Role-specific instruction loading updated to handle additional context
- TimelineEvent serialization in publishing and Redis persistence now uses the model's `to_dict()`, with consistent timestamp formatting and extra_data handling
- Domain admin tracking updated to manage multi-forest mode, allowing for DA status across multiple trusted domains

**Removed:**

- Manual, per-field TimelineEvent dict serialization in publishing; replaced with single `to_dict()` call for consistency