### PR TITLE
ci: update workflow dependencies and permissions for improved security and reliability

### DIFF
--- a/.github/workflows/meta-sync-labels.yaml
+++ b/.github/workflows/meta-sync-labels.yaml
@@ -10,7 +10,6 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   labels:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -29,7 +29,6 @@ permissions:
   checks: write
   contents: read
   pull-requests: write # Allows merge queue updates
-  security-events: write # Required for GitHub Security tab
 
 jobs:
   pre-commit:
@@ -48,10 +47,10 @@ jobs:
         run: python3 -m pip install pre-commit
 
       - name: Setup go-task
-        uses: rnorton5432/setup-task@eec4717ae80f02d1614a4fecfa4a55d507768696 # v1.0.0
         if: always()
-        with:
-          task-version: ${{ env.TASK_VERSION }}
+        run: |
+          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin v${{ env.TASK_VERSION }}
+          task --version
 
       - name: Run pre-commit
         run: TASK_X_REMOTE_TASKFILES=1 task run-pre-commit -y

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -64,9 +64,12 @@ jobs:
           token: "${{ steps.app-token.outputs.token }}"
 
       - name: Override default config from dispatch variables
+        env:
+          INPUT_DRY_RUN: ${{ github.event.inputs.dryRun || env.WORKFLOW_DRY_RUN }}
+          INPUT_LOG_LEVEL: ${{ github.event.inputs.logLevel || env.WORKFLOW_LOG_LEVEL }}
         run: |
-          echo "RENOVATE_DRY_RUN=${{ github.event.inputs.dryRun || env.WORKFLOW_DRY_RUN }}" >> "${GITHUB_ENV}"
-          echo "LOG_LEVEL=${{ github.event.inputs.logLevel || env.WORKFLOW_LOG_LEVEL }}" >> "${GITHUB_ENV}"
+          echo "RENOVATE_DRY_RUN=${INPUT_DRY_RUN}" >> "${GITHUB_ENV}"
+          echo "LOG_LEVEL=${INPUT_LOG_LEVEL}" >> "${GITHUB_ENV}"
 
       - name: Delete old dashboard
         run: |

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo registry and build
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
 
@@ -123,7 +123,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -31,7 +31,7 @@ jobs:
     name: 🚨 Semgrep Analysis
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@sha256:a3d49dc967b8534a6a76628e50c51cbfe33eb7195dc2feab1fdc0f100852c8ef
 
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')


### PR DESCRIPTION
**Key Changes:**

- Updated Rust toolchain and Semgrep actions to use pinned commit SHAs for reproducibility
- Replaced deprecated `setup-task` GitHub Action with direct shell install in pre-commit workflow
- Adjusted workflow permissions to remove unnecessary write access
- Improved Renovate workflow environment variable handling for clarity

**Changed:**

- Updated all usages of `dtolnay/rust-toolchain@stable` to a specific commit SHA for consistent toolchain installations across `release.yaml` and `rust.yaml`
- Modified Semgrep workflow to use a container image with a pinned SHA, ensuring deterministic and secure image usage
- Replaced `rnorton5432/setup-task` GitHub Action with a shell-based installation for `go-task` in `pre-commit.yaml`, simplifying the setup and removing external dependency on the action
- Enhanced environment variable handling in `renovate.yaml` by explicitly setting and echoing `INPUT_DRY_RUN` and `INPUT_LOG_LEVEL`, improving clarity and maintainability
- Removed unnecessary `pull-requests: write` permission from `meta-sync-labels.yaml` and `security-events: write` from `pre-commit.yaml` to minimize required permissions and improve security

**Removed:**

- Eliminated `pull-requests: write` permission from `meta-sync-labels.yaml` since it is not required for the current workflow
- Removed `security-events: write` permission from `pre-commit.yaml` as it is not needed for pre-commit operations