### PR TITLE
ci: improve ansible collection install robustness and pre-commit performance

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -297,9 +297,21 @@ jobs:
       - name: Install galaxy dependencies
         working-directory: ${{ env.COLLECTION_PATH }}/ansible
         shell: bash
+        env:
+          ANSIBLE_GALAXY_SERVER_TIMEOUT: "120"
         run: |
-          ansible-galaxy collection install -r requirements.yml
-          ansible-galaxy install -r requirements.yml
+          for i in 1 2 3 4 5; do
+            ansible-galaxy collection install -r requirements.yml --timeout 120 && break
+            echo "Attempt $i/5 failed, retrying in $((i * 10))s..."
+            sleep $((i * 10))
+            [ $i -eq 5 ] && echo "All attempts failed" && exit 1
+          done
+          for i in 1 2 3 4 5; do
+            ansible-galaxy install -r requirements.yml && break
+            echo "Attempt $i/5 failed, retrying in $((i * 10))s..."
+            sleep $((i * 10))
+            [ $i -eq 5 ] && echo "All attempts failed" && exit 1
+          done
 
       - name: Build and install collection locally
         working-directory: ${{ env.COLLECTION_PATH }}/ansible
@@ -394,9 +406,21 @@ jobs:
       - name: Install galaxy dependencies
         working-directory: ${{ env.COLLECTION_PATH }}/ansible
         shell: bash
+        env:
+          ANSIBLE_GALAXY_SERVER_TIMEOUT: "120"
         run: |
-          ansible-galaxy collection install -r requirements.yml
-          ansible-galaxy install -r requirements.yml
+          for i in 1 2 3 4 5; do
+            ansible-galaxy collection install -r requirements.yml --timeout 120 && break
+            echo "Attempt $i/5 failed, retrying in $((i * 10))s..."
+            sleep $((i * 10))
+            [ $i -eq 5 ] && echo "All attempts failed" && exit 1
+          done
+          for i in 1 2 3 4 5; do
+            ansible-galaxy install -r requirements.yml && break
+            echo "Attempt $i/5 failed, retrying in $((i * 10))s..."
+            sleep $((i * 10))
+            [ $i -eq 5 ] && echo "All attempts failed" && exit 1
+          done
 
       - name: Build and install collection locally
         working-directory: ${{ env.COLLECTION_PATH }}/ansible

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -67,9 +67,23 @@ jobs:
         run: |
           go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
+      - name: Cache Ansible collections
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.ansible/collections
+          key: ${{ runner.os }}-ansible-collections-${{ hashFiles('ansible/requirements.yml') }}
+
       - name: Install Ansible collections
+        env:
+          ANSIBLE_GALAXY_SERVER_TIMEOUT: "120"
         run: |
-          ansible-galaxy collection install -r ansible/requirements.yml --force --no-deps
+          for i in 1 2 3 4 5; do
+            ansible-galaxy collection install -r ansible/requirements.yml --force --no-deps --timeout 120 && exit 0
+            echo "Attempt $i/5 failed, retrying in $((i * 10))s..."
+            sleep $((i * 10))
+          done
+          echo "All attempts failed"
+          exit 1
 
       - name: Build and install local collection
         working-directory: ansible

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,8 @@ repos:
         # corrupting it with stale blob references.
         entry: env -u GIT_INDEX_FILE ansible-lint -v --force-color -c .hooks/ansible/ansible-lint.yaml
         language: python
-        always_run: true
+        always_run: false
+        files: ^ansible/
         additional_dependencies: [".[community]"]
 
   - repo: https://github.com/Yelp/detect-secrets
@@ -109,7 +110,8 @@ repos:
         name: Generate Ansible documentation with docsible
         entry: .hooks/ansible/docsible-hook.sh
         language: script
-        always_run: true
+        always_run: false
+        files: ^ansible/
         pass_filenames: false
         stages: [pre-commit]
 


### PR DESCRIPTION
**Key Changes:**

- Implement retry logic for Ansible collection installation in CI workflows
- Add caching for Ansible collections to speed up pre-commit CI runs
- Restrict pre-commit Ansible hooks to only run on relevant files for efficiency

**Added:**

- Ansible collections caching step in pre-commit GitHub Actions workflow to utilize cache based on requirements.yml hash

**Changed:**

- Ansible collection install steps in molecule and pre-commit workflows now use up to five retries with increasing sleep intervals and explicit timeout settings to reduce transient failures
- Set `ANSIBLE_GALAXY_SERVER_TIMEOUT` environment variable to 120 seconds for more robust dependency installs in CI
- Pre-commit Ansible lint and documentation hooks now only run on changes within the `ansible/` directory and no longer always run, improving CI performance and reducing unnecessary runs

**Removed:**

- Automatic always-run behavior for pre-commit Ansible lint and documentation hooks, limiting their scope to relevant file changes