### PR TITLE
ci: fix build-and-push-templates workflow stuck on unavailable runners

### DIFF
--- a/.github/workflows/build-and-push-templates.yaml
+++ b/.github/workflows/build-and-push-templates.yaml
@@ -46,7 +46,7 @@ env:
 jobs:
   discover-templates:
     name: Discover templates
-    runs-on: ubuntu24.04-amd64-8-core
+    runs-on: ubuntu-latest
     outputs:
       # Base templates (use external base images like ubuntu:22.04)
       base_matrix: ${{ steps.discover.outputs.base_matrix }}
@@ -258,13 +258,13 @@ jobs:
                 if ($supported_platforms | index("amd64")) then
                   [{
                     "arch": "amd64",
-                    "runner": "ubuntu24.04-amd64-8-core"
+                    "runner": "ubuntu-latest"
                   }]
                 else [] end +
                 if ($supported_platforms | index("arm64")) then
                   [{
                     "arch": "arm64",
-                    "runner": "ubuntu24.04-arm64-8-core"
+                    "runner": "ubuntu-24.04-arm64"
                   }]
                 else [] end
               )[] |
@@ -736,7 +736,7 @@ jobs:
     name: "[Base] Create manifest for ${{ matrix.name }}"
     needs: [discover-templates, build-base-images]
     if: github.event_name != 'pull_request' && needs.discover-templates.outputs.has_base_templates == 'true'
-    runs-on: ubuntu24.04-amd64-8-core
+    runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.discover-templates.outputs.base_templates) }}
       fail-fast: false
@@ -1230,7 +1230,7 @@ jobs:
       github.event_name != 'pull_request' &&
       needs.discover-templates.outputs.has_dependent_templates == 'true' &&
       needs.build-dependent-images.result == 'success'
-    runs-on: ubuntu24.04-amd64-8-core
+    runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.discover-templates.outputs.dependent_templates) }}
       fail-fast: false
@@ -1619,7 +1619,7 @@ jobs:
     name: "[GPU] Create manifest for ${{ matrix.name }}"
     needs: [discover-templates, build-gpu-base-images]
     if: github.event_name != 'pull_request' && needs.discover-templates.outputs.has_gpu_base_templates == 'true'
-    runs-on: ubuntu24.04-amd64-8-core
+    runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.discover-templates.outputs.gpu_base_templates) }}
       fail-fast: false
@@ -1951,7 +1951,7 @@ jobs:
       github.event_name != 'pull_request' &&
       needs.discover-templates.outputs.has_gpu_dependent_templates == 'true' &&
       needs.build-gpu-dependent-images.result == 'success'
-    runs-on: ubuntu24.04-amd64-8-core
+    runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.discover-templates.outputs.gpu_dependent_templates) }}
       fail-fast: false
@@ -2072,7 +2072,7 @@ jobs:
 
   build-summary:
     name: Build Summary
-    runs-on: ubuntu24.04-amd64-8-core
+    runs-on: ubuntu-latest
     needs: [discover-templates, build-base-images, merge-base-manifests, build-dependent-images, merge-dependent-manifests, build-gpu-base-images, merge-gpu-base-manifests, build-gpu-dependent-images, merge-gpu-dependent-manifests]
     if: always()
     steps:


### PR DESCRIPTION
## Summary

- The `build-and-push-templates` workflow was permanently stuck in `pending`/`queued` because it referenced `ubuntu24.04-amd64-8-core` and `ubuntu24.04-arm64-8-core` runners that aren't available to this repo
- Replaced all amd64 runner references with `ubuntu-latest` (matching the working `test-template-builds` and `rust` workflows)
- Updated the arm64 matrix runner to `ubuntu-24.04-arm64` (GitHub's standard public arm64 runner label)
- Cancelled 5 stuck workflow runs that had been queued for up to an hour

## Test plan

- [ ] Verify the workflow triggers and jobs actually start on the next push to `main` that touches `warpgate-templates/`
- [ ] Confirm arm64 builds pick up the `ubuntu-24.04-arm64` runner correctly