### PR TITLE
refactor: unify redis key usage and collection loading for op data

### DIFF
--- a/ares-core/src/state/keys.rs
+++ b/ares-core/src/state/keys.rs
@@ -10,21 +10,21 @@ pub const LOCK_PREFIX: &str = "ares:lock";
 pub const TASK_STATUS_PREFIX: &str = "ares:task_status";
 
 // Collection key suffixes (appended to `ares:op:{op_id}:`)
-/// Redis SET key suffix for discovered credentials.
+/// Redis HASH key suffix for discovered credentials (dedup_key → JSON).
 pub const KEY_CREDENTIALS: &str = "credentials";
-/// Redis SET key suffix for discovered password hashes.
+/// Redis HASH key suffix for discovered password hashes (dedup_key → JSON).
 pub const KEY_HASHES: &str = "hashes";
-/// Redis SET key suffix for discovered hosts.
+/// Redis LIST key suffix for discovered hosts (JSON per entry).
 pub const KEY_HOSTS: &str = "hosts";
-/// Redis SET key suffix for discovered user accounts.
+/// Redis LIST key suffix for discovered user accounts (JSON per entry).
 pub const KEY_USERS: &str = "users";
-/// Redis SET key suffix for discovered SMB shares.
+/// Redis HASH key suffix for discovered SMB shares (dedup_key → JSON).
 pub const KEY_SHARES: &str = "shares";
 /// Redis SET key suffix for discovered domain names.
 pub const KEY_DOMAINS: &str = "domains";
-/// Redis SET key suffix for discovered vulnerabilities.
+/// Redis HASH key suffix for discovered vulnerabilities (vuln_id → JSON).
 pub const KEY_VULNS: &str = "vulns";
-/// Redis SET key suffix for exploited targets.
+/// Redis SET key suffix for exploited vulnerability IDs.
 pub const KEY_EXPLOITED: &str = "exploited";
 /// Redis HASH key suffix for operation metadata.
 pub const KEY_META: &str = "meta";

--- a/ares-tools/Cargo.toml
+++ b/ares-tools/Cargo.toml
@@ -25,3 +25,4 @@ blue = ["ares-core/blue"]
 [dev-dependencies]
 rstest = "0.26"
 approx = "0.5"
+ares-core = { path = "../ares-core", features = ["test-utils", "blue"] }

--- a/ares-tools/src/blue/learning/playbook.rs
+++ b/ares-tools/src/blue/learning/playbook.rs
@@ -78,18 +78,20 @@ pub async fn get_attack_playbook(args: &Value) -> anyhow::Result<ToolOutput> {
         });
     }
 
-    // Get credentials (compromised accounts)
+    // Get credentials (compromised accounts) — stored as HASH (dedup_key -> JSON)
     let creds_key = format!("ares:op:{op_id}:credentials");
-    let creds: Vec<String> = redis::AsyncCommands::lrange(&mut conn, &creds_key, 0, -1)
-        .await
-        .unwrap_or_default();
-
-    // Get discovered hosts
-    let hosts_key = format!("ares:op:{op_id}:hosts");
-    let hosts: std::collections::HashSet<String> =
-        redis::AsyncCommands::smembers(&mut conn, &hosts_key)
+    let creds_map: std::collections::HashMap<String, String> =
+        redis::AsyncCommands::hgetall(&mut conn, &creds_key)
             .await
             .unwrap_or_default();
+    let creds: Vec<String> = creds_map.into_values().collect();
+
+    // Get discovered hosts — stored as LIST (JSON per entry)
+    let hosts_key = format!("ares:op:{op_id}:hosts");
+    let hosts_list: Vec<String> = redis::AsyncCommands::lrange(&mut conn, &hosts_key, 0, -1)
+        .await
+        .unwrap_or_default();
+    let hosts: std::collections::HashSet<String> = hosts_list.into_iter().collect();
 
     // Get loot/techniques
     let loot_key = format!("ares:op:{op_id}:loot");

--- a/ares-tools/src/blue/learning/playbook.rs
+++ b/ares-tools/src/blue/learning/playbook.rs
@@ -78,32 +78,7 @@ pub async fn get_attack_playbook(args: &Value) -> anyhow::Result<ToolOutput> {
         });
     }
 
-    // Get credentials (compromised accounts) — stored as HASH (dedup_key -> JSON)
-    let creds_key = format!("ares:op:{op_id}:credentials");
-    let creds_map: std::collections::HashMap<String, String> =
-        redis::AsyncCommands::hgetall(&mut conn, &creds_key)
-            .await
-            .unwrap_or_default();
-    let creds: Vec<String> = creds_map.into_values().collect();
-
-    // Get discovered hosts — stored as LIST (JSON per entry)
-    let hosts_key = format!("ares:op:{op_id}:hosts");
-    let hosts_list: Vec<String> = redis::AsyncCommands::lrange(&mut conn, &hosts_key, 0, -1)
-        .await
-        .unwrap_or_default();
-    let hosts: std::collections::HashSet<String> = hosts_list.into_iter().collect();
-
-    // Get loot/techniques
-    let loot_key = format!("ares:op:{op_id}:loot");
-    let loot: Vec<String> = redis::AsyncCommands::lrange(&mut conn, &loot_key, 0, -1)
-        .await
-        .unwrap_or_default();
-
-    // Get operation metadata
-    let meta: std::collections::HashMap<String, String> =
-        redis::AsyncCommands::hgetall(&mut conn, &meta_key)
-            .await
-            .unwrap_or_default();
+    let (creds, hosts, loot, meta) = load_op_collections(&mut conn, &op_id).await;
 
     // Build playbook
     let mut lines = Vec::new();
@@ -384,6 +359,48 @@ pub async fn get_detection_queries_for_technique(args: &Value) -> anyhow::Result
     })
 }
 
+/// Load credentials, hosts, loot, and metadata for an operation from Redis.
+///
+/// Credentials are stored as a HASH (dedup_key → JSON), hosts as a LIST,
+/// loot as a LIST, and metadata as a HASH.
+async fn load_op_collections(
+    conn: &mut (impl redis::AsyncCommands + Send),
+    op_id: &str,
+) -> (
+    Vec<String>,
+    std::collections::HashSet<String>,
+    Vec<String>,
+    HashMap<String, String>,
+) {
+    // Credentials — stored as HASH (dedup_key -> JSON)
+    let creds_key = format!("ares:op:{op_id}:credentials");
+    let creds_map: HashMap<String, String> = redis::AsyncCommands::hgetall(conn, &creds_key)
+        .await
+        .unwrap_or_default();
+    let creds: Vec<String> = creds_map.into_values().collect();
+
+    // Hosts — stored as LIST (JSON per entry)
+    let hosts_key = format!("ares:op:{op_id}:hosts");
+    let hosts_list: Vec<String> = redis::AsyncCommands::lrange(conn, &hosts_key, 0, -1)
+        .await
+        .unwrap_or_default();
+    let hosts: std::collections::HashSet<String> = hosts_list.into_iter().collect();
+
+    // Loot/techniques
+    let loot_key = format!("ares:op:{op_id}:loot");
+    let loot: Vec<String> = redis::AsyncCommands::lrange(conn, &loot_key, 0, -1)
+        .await
+        .unwrap_or_default();
+
+    // Operation metadata
+    let meta_key = format!("ares:op:{op_id}:meta");
+    let meta: HashMap<String, String> = redis::AsyncCommands::hgetall(conn, &meta_key)
+        .await
+        .unwrap_or_default();
+
+    (creds, hosts, loot, meta)
+}
+
 /// Find the latest operation ID in Redis by scanning `ares:op:*:meta` keys.
 async fn find_latest_operation(conn: &mut redis::aio::MultiplexedConnection) -> Option<String> {
     let mut cursor: u64 = 0;
@@ -510,5 +527,93 @@ mod tests {
         let args = json!({});
         let result = lookup_technique(&args);
         assert!(result.is_err());
+    }
+
+    // -- load_op_collections tests (mock Redis) --
+
+    use super::load_op_collections;
+    use ares_core::state::mock_redis::MockRedisConnection;
+    use redis::AsyncCommands;
+
+    #[tokio::test]
+    async fn load_op_collections_empty() {
+        let mut conn = MockRedisConnection::new();
+        let (creds, hosts, loot, meta) = load_op_collections(&mut conn, "op-test").await;
+        assert!(creds.is_empty());
+        assert!(hosts.is_empty());
+        assert!(loot.is_empty());
+        assert!(meta.is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_op_collections_reads_credentials_as_hash() {
+        let mut conn = MockRedisConnection::new();
+        let key = "ares:op:op-test:credentials";
+        let cred_json = json!({
+            "username": "admin",
+            "password": "P@ssw0rd!",  // pragma: allowlist secret
+            "domain": "contoso.local"
+        })
+        .to_string();
+        conn.hset::<_, _, _, ()>(key, "cred:contoso.local:admin:abc123", &cred_json)
+            .await
+            .unwrap();
+
+        let (creds, _, _, _) = load_op_collections(&mut conn, "op-test").await;
+        assert_eq!(creds.len(), 1);
+        assert!(creds[0].contains("admin"));
+    }
+
+    #[tokio::test]
+    async fn load_op_collections_reads_hosts_as_list() {
+        let mut conn = MockRedisConnection::new();
+        let key = "ares:op:op-test:hosts";
+        let host_json = json!({
+            "ip": "192.168.58.10",
+            "hostname": "dc01.contoso.local"
+        })
+        .to_string();
+        conn.rpush::<_, _, ()>(key, &host_json).await.unwrap();
+
+        let (_, hosts, _, _) = load_op_collections(&mut conn, "op-test").await;
+        assert_eq!(hosts.len(), 1);
+        assert!(hosts.iter().next().unwrap().contains("192.168.58.10"));
+    }
+
+    #[tokio::test]
+    async fn load_op_collections_reads_meta_as_hash() {
+        let mut conn = MockRedisConnection::new();
+        let key = "ares:op:op-test:meta";
+        conn.hset::<_, _, _, ()>(key, "target_domain", "contoso.local")
+            .await
+            .unwrap();
+        conn.hset::<_, _, _, ()>(key, "started_at", "2025-01-28T12:00:00Z")
+            .await
+            .unwrap();
+
+        let (_, _, _, meta) = load_op_collections(&mut conn, "op-test").await;
+        assert_eq!(meta.get("target_domain").unwrap(), "contoso.local");
+        assert_eq!(meta.get("started_at").unwrap(), "2025-01-28T12:00:00Z");
+    }
+
+    #[tokio::test]
+    async fn load_op_collections_multiple_credentials_deduped_by_hash_field() {
+        let mut conn = MockRedisConnection::new();
+        let key = "ares:op:op-test:credentials";
+        let cred1 = json!({"username": "alice", "domain": "contoso.local"}).to_string();
+        let cred2 = json!({"username": "bob", "domain": "contoso.local"}).to_string();
+        conn.hset::<_, _, _, ()>(key, "cred:contoso.local:alice:aaa", &cred1)
+            .await
+            .unwrap();
+        conn.hset::<_, _, _, ()>(key, "cred:contoso.local:bob:bbb", &cred2)
+            .await
+            .unwrap();
+        // Duplicate field — should overwrite, not duplicate
+        conn.hset::<_, _, _, ()>(key, "cred:contoso.local:alice:aaa", &cred1)
+            .await
+            .unwrap();
+
+        let (creds, _, _, _) = load_op_collections(&mut conn, "op-test").await;
+        assert_eq!(creds.len(), 2);
     }
 }

--- a/ares-tools/src/blue/learning/playbook.rs
+++ b/ares-tools/src/blue/learning/playbook.rs
@@ -364,7 +364,7 @@ pub async fn get_detection_queries_for_technique(args: &Value) -> anyhow::Result
 /// Credentials are stored as a HASH (dedup_key → JSON), hosts as a LIST,
 /// loot as a LIST, and metadata as a HASH.
 async fn load_op_collections(
-    conn: &mut (impl redis::AsyncCommands + Send),
+    conn: &mut impl redis::AsyncCommands,
     op_id: &str,
 ) -> (
     Vec<String>,


### PR DESCRIPTION
**Key Changes:**

- Standardized Redis key suffix documentation to reflect actual collection types
- Refactored collection loading in playbook logic to use a single async helper
- Added comprehensive tests for the new Redis collection loader function

**Added:**

- Helper function `load_op_collections` to fetch credentials, hosts, loot, and meta in a unified way from Redis in `blue/learning/playbook.rs`
- Unit tests for `load_op_collections`, covering empty, populated, and deduplication scenarios using a mock Redis connection in `blue/learning/playbook.rs`
- Test-only dependency on `ares-core` with features enabled in `ares-tools/Cargo.toml`

**Changed:**

- Updated documentation in `ares-core/src/state/keys.rs` to clarify the actual Redis collection type used for each key suffix (e.g., credentials and hashes as HASH, hosts and users as LIST, shares and vulns as HASH)
- Modified playbook retrieval logic in `get_attack_playbook` to use `load_op_collections` instead of directly querying each Redis key with potentially inconsistent commands

**Removed:**

- Removed direct Redis commands for fetching credentials, hosts, loot, and meta in `get_attack_playbook`, consolidating them into the new helper function