### PR TITLE
docs: improve ansible development documentation and harden goad attack box

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -196,10 +196,11 @@ Installs and configures the **Mythic C2 framework** and optional agent packages.
 
 ## Development
 
-### Release Process
-
-For information on creating new releases of this collection, see our
-[Release Process Documentation](docs/releases.md).
+This collection lives inside the [ares](https://github.com/dreadnode/ares)
+repository and is consumed directly from this subdirectory — it is not
+published to Ansible Galaxy. See [docs/development.md](docs/development.md)
+for layout, pre-commit hooks (including the architecture-diagram regen),
+molecule usage, and CI details.
 
 ## Support
 

--- a/ansible/docs/development.md
+++ b/ansible/docs/development.md
@@ -1,0 +1,116 @@
+# Ansible Collection Development
+
+This collection lives inside the [ares](https://github.com/dreadnode/ares)
+repository and is consumed directly from the `ansible/` subdirectory — it is
+**not** published to Ansible Galaxy. Changes ship as part of normal ares pull
+requests; there is no separate release tag, changelog generation, or
+`galaxy.yml` version bump flow.
+
+## Layout
+
+- `ansible/roles/` — role implementations (each with `defaults/`, `tasks/`,
+  `meta/`, optional `molecule/` scenarios, and a generated `README.md`).
+- `ansible/playbooks/ares/` — playbooks that wire roles together for the ares
+  attack box (e.g. `goad_attack_box.yml`, `recon.yml`, `lateral_movement.yml`).
+- `ansible/playbooks/{linux,windows}/` — generic provisioning playbooks for
+  range hosts.
+- `ansible/plugins/modules/` — custom modules (`vnc_pw`,
+  `merge_list_dicts_into_list`, `getent_passwd`).
+- `ansible/changelogs/` — retained from the upstream collection; no longer
+  updated as part of the ares workflow.
+
+## Local Development
+
+### Prerequisites
+
+- Ansible (>= 2.18.4)
+- [Molecule](https://molecule.readthedocs.io/) + Docker for role tests
+- [pre-commit](https://pre-commit.com/) for linting and doc/diagram regen
+- [act](https://github.com/nektos/act) (optional) to run the molecule workflow
+  locally
+
+Install the Python tooling used by the hooks and the molecule workflow:
+
+```bash
+pip install -r .hooks/requirements.txt
+```
+
+### Pre-Commit Hooks
+
+`.pre-commit-config.yaml` runs the following on any change under `ansible/`:
+
+- `ansible-lint` — config at `.hooks/ansible/ansible-lint.yaml`.
+- `yamllint` / `markdownlint` / `codespell` / `detect-secrets` — repo-wide.
+- `docsible` (`.hooks/ansible/docsible-hook.sh`) — regenerates each
+  `roles/*/README.md` from role metadata.
+- `update-architecture-diagram` (`.hooks/ansible/gen-arch-diagram.py`) —
+  scans `ansible/{roles,plugins,playbooks}` and rewrites the Mermaid block
+  in `ansible/README.md` between the `## Architecture Diagram` and
+  `## Requirements` markers. Roles/playbooks with a `molecule/` directory get a
+  trailing `*` in the diagram.
+
+Install hooks once, then they run on every commit:
+
+```bash
+pre-commit install
+pre-commit run --all-files   # one-off run across the repo
+```
+
+If the diagram hook updates `ansible/README.md`, it exits non-zero so you can
+stage the regenerated README and re-commit.
+
+### Running Molecule Locally
+
+Each role/playbook with a `molecule/` directory can be exercised directly:
+
+```bash
+cd ansible/roles/<role_name>
+molecule test                       # full create / converge / verify / destroy
+molecule converge                   # iterate on tasks against a live container
+molecule verify                     # re-run assertions only
+```
+
+To reproduce the GitHub Actions matrix locally, use `act` against
+`.github/workflows/molecule.yaml`:
+
+```bash
+act -W .github/workflows/molecule.yaml \
+    --input ROLE=<role_name> \
+    --input SCENARIO=default
+```
+
+ARM64 macOS hosts should pass `--container-architecture linux/amd64` to `act`.
+
+## CI
+
+Two workflows guard ansible changes:
+
+- `.github/workflows/pre-commit.yaml` — runs the full pre-commit suite on PRs.
+- `.github/workflows/molecule.yaml` — runs molecule scenarios on changes under
+  `ansible/**`, `.github/workflows/molecule.yaml`, or `.hooks/requirements.txt`.
+  Also runs weekly (Sunday 04:00 UTC) and supports `workflow_dispatch` with
+  `ROLE` / `SCENARIO` inputs to target a single scenario.
+
+## Adding a New Role or Playbook
+
+1. Scaffold under `ansible/roles/<name>/` (or `ansible/playbooks/<group>/`).
+2. Add a `meta/main.yml` with `argument_specs` so `docsible` can generate the
+   role README on commit.
+3. Add a `molecule/default/` scenario; `verify.yml` should assert the
+   end-state your role guarantees.
+4. Wire the role into the relevant ares playbook under
+   `ansible/playbooks/ares/` if it should run as part of the attack box build.
+5. Commit — the architecture diagram in `ansible/README.md` will regenerate
+   automatically.
+
+## Consuming the Collection
+
+Within ares, playbooks reference roles via the fully-qualified
+`dreadnode.nimbus_range.<role>` name. Ansible resolves the collection from the
+`ansible/` subdirectory using `ansible.cfg`'s `collections_path` /
+`ANSIBLE_COLLECTIONS_PATH`; no `ansible-galaxy collection install` step is
+required for in-repo use.
+
+## License
+
+Covered by the repository-wide [LICENSE](../../LICENSE) at the ares root.

--- a/ansible/playbooks/ares/goad_attack_box.yml
+++ b/ansible/playbooks/ares/goad_attack_box.yml
@@ -88,6 +88,30 @@
     privesc_tools_install_runascs: true
     privesc_tools_install_powerupsql: true
 
+  pre_tasks:
+    # Disable Transparent Huge Pages. Default Kali setting (`always`) caused
+    # khugepaged to lock up under heavy fork/exec from impacket/nxc workloads,
+    # producing RCU stalls and unrecoverable instance freezes that took SSM
+    # down with them. Bake the kernel cmdline into the AMI and turn it off
+    # for the rest of this run so the build itself isn't at risk.
+    - name: Disable THP via kernel cmdline (persists across reboot)
+      ansible.builtin.lineinfile:
+        path: /etc/default/grub
+        regexp: '^GRUB_CMDLINE_LINUX_DEFAULT='
+        line: 'GRUB_CMDLINE_LINUX_DEFAULT="quiet transparent_hugepage=never"'
+      notify: Update grub
+
+    - name: Disable THP at runtime so the bake itself is safe
+      ansible.builtin.shell: |
+        echo never > /sys/kernel/mm/transparent_hugepage/enabled
+        echo never > /sys/kernel/mm/transparent_hugepage/defrag
+      changed_when: false
+
+  handlers:
+    - name: Update grub
+      ansible.builtin.command: update-grub
+      changed_when: true
+
   roles:
     # AWS infrastructure agents
     - role: dreadnode.nimbus_range.aws_ssm_agent


### PR DESCRIPTION
**Key Changes:**

- Added comprehensive development guide for Ansible collection workflow
- Updated README to clarify in-repo usage and development references
- Hardened attack box provisioning by disabling Transparent Huge Pages (THP)
- Improved maintainability by automating documentation and diagram regeneration

**Added:**

- Detailed `docs/development.md` covering collection layout, development,
  pre-commit hooks, molecule usage, CI workflows, and role/playbook
  authoring
- Pre-task and handler in `goad_attack_box.yml` to disable THP at runtime
  and persistently via kernel cmdline, mitigating instance lockups during
  heavy workloads

**Changed:**

- Updated `ansible/README.md` development section to reference the new
  development guide, clarify the collection is not published to Galaxy, and
  point to local development and CI details
- Inserted pre-commit, molecule, and architecture diagram documentation
  references to improve onboarding and contributor experience

**Removed:**

- Obsolete release process section and Galaxy release guidance from
  `ansible/README.md`, replaced with current in-repo workflow details