### PR TITLE
feat: add token budget circuit breaker and session log to agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "reqwest 0.13.3",
  "serde",
  "serde_json",
+ "tempfile",
  "tera",
  "thiserror 2.0.18",
  "tokio",

--- a/ares-cli/src/orchestrator/blue/callbacks.rs
+++ b/ares-cli/src/orchestrator/blue/callbacks.rs
@@ -145,6 +145,9 @@ impl BlueCallbackHandler {
                 format!("Sub-agent hit max steps ({} steps)", outcome.steps)
             }
             ares_llm::LoopEndReason::MaxTokens => "Sub-agent hit max tokens".to_string(),
+            ares_llm::LoopEndReason::BudgetExceeded { reason } => {
+                format!("Sub-agent budget exceeded: {reason}")
+            }
             ares_llm::LoopEndReason::Error(e) => format!("Sub-agent error: {e}"),
         };
 

--- a/ares-cli/src/orchestrator/blue/investigation.rs
+++ b/ares-cli/src/orchestrator/blue/investigation.rs
@@ -425,6 +425,9 @@ fn process_outcome(outcome: &AgentLoopOutcome, investigation_id: &str) -> Invest
         LoopEndReason::MaxTokens => InvestigationOutcome::Failed {
             error: format!("Investigation {investigation_id} hit max tokens"),
         },
+        LoopEndReason::BudgetExceeded { reason } => InvestigationOutcome::Failed {
+            error: format!("Investigation {investigation_id} budget exceeded: {reason}"),
+        },
         LoopEndReason::Error(err) => InvestigationOutcome::Failed { error: err.clone() },
     }
 }

--- a/ares-cli/src/orchestrator/dispatcher/submission.rs
+++ b/ares-cli/src/orchestrator/dispatcher/submission.rs
@@ -399,6 +399,28 @@ impl Dispatcher {
                                 agent_name: Some(tt.clone()),
                             }
                         }
+                        LoopEndReason::BudgetExceeded { reason } => {
+                            let mut result_json = json!({
+                                "steps": outcome.steps,
+                                "tool_calls": outcome.tool_calls_dispatched,
+                            });
+                            if let Some(disc) = merged_discoveries {
+                                result_json["discoveries"] = disc;
+                            }
+                            if !tool_outputs_json.is_empty() {
+                                result_json["tool_outputs"] =
+                                    Value::Array(tool_outputs_json.clone());
+                            }
+                            TaskResult {
+                                task_id: tid.clone(),
+                                success: false,
+                                result: Some(result_json),
+                                error: Some(format!("Budget exceeded: {reason}")),
+                                completed_at: Some(Utc::now()),
+                                worker_pod: Some("rust-llm-runner".into()),
+                                agent_name: Some(tt.clone()),
+                            }
+                        }
                         LoopEndReason::Error(err) => TaskResult {
                             task_id: tid.clone(),
                             success: false,

--- a/ares-cli/src/orchestrator/llm_runner.rs
+++ b/ares-cli/src/orchestrator/llm_runner.rs
@@ -45,11 +45,10 @@ impl LlmTaskRunner {
         temperature: Option<f32>,
         technique_priorities: Vec<(String, i32)>,
     ) -> Self {
-        let config = AgentLoopConfig {
-            model: model_name,
-            temperature,
-            ..AgentLoopConfig::default()
-        };
+        // Layer env-var overrides (ARES_AGENT_*, ARES_CONTEXT_*, ARES_BUDGET_*,
+        // ARES_SESSION_LOG_*) on top of compiled defaults so operators can
+        // tune the loop without a code change.
+        let config = AgentLoopConfig::from_env(model_name, temperature);
         Self {
             provider,
             dispatcher,
@@ -285,6 +284,13 @@ fn log_outcome(task_id: &str, outcome: &AgentLoopOutcome) {
                 task_id = task_id,
                 steps = outcome.steps,
                 "LLM agent hit max tokens"
+            );
+        }
+        LoopEndReason::BudgetExceeded { reason } => {
+            warn!(
+                task_id = task_id,
+                steps = outcome.steps,
+                "LLM agent budget circuit breaker tripped: {reason}"
             );
         }
         LoopEndReason::Error(err) => {

--- a/ares-cli/src/worker/blue_task_loop.rs
+++ b/ares-cli/src/worker/blue_task_loop.rs
@@ -282,6 +282,12 @@ async fn execute_blue_task(
             "Hit max tokens".into(),
             agent_name,
         ),
+        LoopEndReason::BudgetExceeded { reason } => BlueTaskResult::failure(
+            &task.task_id,
+            &task.investigation_id,
+            format!("Budget exceeded: {reason}"),
+            agent_name,
+        ),
         LoopEndReason::Error(err) => {
             error!(task_id = %task.task_id, err = %err, "Blue task error");
             BlueTaskResult::failure(

--- a/ares-llm/Cargo.toml
+++ b/ares-llm/Cargo.toml
@@ -27,3 +27,4 @@ blue = []
 tokio = { workspace = true }
 serde_json = { workspace = true }
 async-trait = "0.1"
+tempfile = "3"

--- a/ares-llm/examples/smoke_test.rs
+++ b/ares-llm/examples/smoke_test.rs
@@ -164,6 +164,7 @@ async fn main() -> Result<()> {
         retry: RetryConfig::default(),
         context: ContextConfig::default(),
         max_tool_calls_per_name: 10,
+        ..AgentLoopConfig::default()
     };
 
     let outcome = run_agent_loop(

--- a/ares-llm/src/agent_loop/config.rs
+++ b/ares-llm/src/agent_loop/config.rs
@@ -398,4 +398,139 @@ mod tests {
         let cfg = SessionLogConfig::default();
         assert!(!cfg.enabled());
     }
+
+    #[test]
+    fn parse_env_u32_uses_default_when_unset() {
+        std::env::remove_var("ARES_TEST_PARSE_U32_UNSET");
+        assert_eq!(parse_env_u32("ARES_TEST_PARSE_U32_UNSET", 42), 42);
+    }
+
+    #[test]
+    fn parse_env_u32_parses_and_falls_back() {
+        std::env::set_var("ARES_TEST_PARSE_U32_VALID", "  123 ");
+        assert_eq!(parse_env_u32("ARES_TEST_PARSE_U32_VALID", 0), 123);
+        std::env::remove_var("ARES_TEST_PARSE_U32_VALID");
+
+        std::env::set_var("ARES_TEST_PARSE_U32_BAD", "not-a-number");
+        assert_eq!(parse_env_u32("ARES_TEST_PARSE_U32_BAD", 7), 7);
+        std::env::remove_var("ARES_TEST_PARSE_U32_BAD");
+    }
+
+    #[test]
+    fn parse_env_usize_parses_and_falls_back() {
+        std::env::set_var("ARES_TEST_PARSE_USIZE_VALID", "999");
+        assert_eq!(parse_env_usize("ARES_TEST_PARSE_USIZE_VALID", 0), 999);
+        std::env::remove_var("ARES_TEST_PARSE_USIZE_VALID");
+
+        std::env::set_var("ARES_TEST_PARSE_USIZE_BAD", "xx");
+        assert_eq!(parse_env_usize("ARES_TEST_PARSE_USIZE_BAD", 5), 5);
+        std::env::remove_var("ARES_TEST_PARSE_USIZE_BAD");
+    }
+
+    #[test]
+    fn parse_env_f32_parses_and_falls_back() {
+        std::env::set_var("ARES_TEST_PARSE_F32_VALID", "0.75");
+        let v = parse_env_f32("ARES_TEST_PARSE_F32_VALID", 1.0);
+        assert!((v - 0.75).abs() < 1e-6);
+        std::env::remove_var("ARES_TEST_PARSE_F32_VALID");
+
+        std::env::set_var("ARES_TEST_PARSE_F32_BAD", "abc");
+        let v = parse_env_f32("ARES_TEST_PARSE_F32_BAD", 0.5);
+        assert!((v - 0.5).abs() < 1e-6);
+        std::env::remove_var("ARES_TEST_PARSE_F32_BAD");
+    }
+
+    #[test]
+    fn parse_env_bool_recognizes_truthy_falsy() {
+        for v in &["1", "true", "yes", "on", "TRUE", "Yes"] {
+            std::env::set_var("ARES_TEST_PARSE_BOOL", v);
+            assert!(parse_env_bool("ARES_TEST_PARSE_BOOL", false), "case {v}");
+        }
+        for v in &["0", "false", "no", "off", ""] {
+            std::env::set_var("ARES_TEST_PARSE_BOOL", v);
+            assert!(!parse_env_bool("ARES_TEST_PARSE_BOOL", true), "case {v:?}");
+        }
+        std::env::set_var("ARES_TEST_PARSE_BOOL", "junk");
+        assert!(parse_env_bool("ARES_TEST_PARSE_BOOL", true));
+        assert!(!parse_env_bool("ARES_TEST_PARSE_BOOL", false));
+        std::env::remove_var("ARES_TEST_PARSE_BOOL");
+
+        std::env::remove_var("ARES_TEST_PARSE_BOOL_UNSET");
+        assert!(parse_env_bool("ARES_TEST_PARSE_BOOL_UNSET", true));
+    }
+
+    #[test]
+    fn budget_config_from_env_reads_all_keys() {
+        std::env::set_var("ARES_BUDGET_MAX_INPUT_TOKENS", "11");
+        std::env::set_var("ARES_BUDGET_MAX_OUTPUT_TOKENS", "22");
+        std::env::set_var("ARES_BUDGET_MAX_TOTAL_TOKENS", "33");
+        let cfg = BudgetConfig::from_env();
+        assert_eq!(cfg.max_input_tokens, 11);
+        assert_eq!(cfg.max_output_tokens, 22);
+        assert_eq!(cfg.max_total_tokens, 33);
+        std::env::remove_var("ARES_BUDGET_MAX_INPUT_TOKENS");
+        std::env::remove_var("ARES_BUDGET_MAX_OUTPUT_TOKENS");
+        std::env::remove_var("ARES_BUDGET_MAX_TOTAL_TOKENS");
+    }
+
+    #[test]
+    fn context_config_from_env_clamps_threshold() {
+        std::env::set_var("ARES_CONTEXT_MAX_TOKENS", "12345");
+        std::env::set_var("ARES_CONTEXT_COMPACTION_THRESHOLD", "5.0"); // clamp to 1.0
+        std::env::set_var("ARES_CONTEXT_COMPACTION_CHECK_EVERY", "0"); // bumped to 1
+        std::env::set_var("ARES_CONTEXT_MAX_TOOL_OUTPUT_CHARS", "9999");
+        std::env::set_var("ARES_CONTEXT_MIN_RECENT_MESSAGES", "8");
+        let cfg = ContextConfig::from_env();
+        assert_eq!(cfg.max_context_tokens, 12345);
+        assert!((cfg.compaction_threshold_ratio - 1.0).abs() < 1e-6);
+        assert_eq!(cfg.compaction_check_every, 1);
+        assert_eq!(cfg.max_tool_output_chars, 9999);
+        assert_eq!(cfg.min_recent_messages, 8);
+        std::env::remove_var("ARES_CONTEXT_MAX_TOKENS");
+        std::env::remove_var("ARES_CONTEXT_COMPACTION_THRESHOLD");
+        std::env::remove_var("ARES_CONTEXT_COMPACTION_CHECK_EVERY");
+        std::env::remove_var("ARES_CONTEXT_MAX_TOOL_OUTPUT_CHARS");
+        std::env::remove_var("ARES_CONTEXT_MIN_RECENT_MESSAGES");
+    }
+
+    #[test]
+    fn session_log_config_from_env_explicit_dir() {
+        std::env::set_var("ARES_SESSION_LOG_DIR", "/tmp/ares-test-sessions");
+        std::env::remove_var("ARES_SESSION_LOG_ENABLED");
+        let cfg = SessionLogConfig::from_env();
+        assert!(cfg.enabled());
+        assert_eq!(
+            cfg.dir.as_deref(),
+            Some(std::path::Path::new("/tmp/ares-test-sessions"))
+        );
+        std::env::remove_var("ARES_SESSION_LOG_DIR");
+    }
+
+    #[test]
+    fn session_log_config_from_env_empty_dir_disabled() {
+        std::env::remove_var("ARES_SESSION_LOG_ENABLED");
+        std::env::set_var("ARES_SESSION_LOG_DIR", "   ");
+        let cfg = SessionLogConfig::from_env();
+        assert!(!cfg.enabled());
+        std::env::remove_var("ARES_SESSION_LOG_DIR");
+    }
+
+    #[test]
+    fn agent_loop_config_from_env_layers_overrides() {
+        std::env::set_var("ARES_AGENT_MAX_STEPS", "13");
+        std::env::set_var("ARES_AGENT_MAX_TOKENS", "8192");
+        std::env::set_var("ARES_AGENT_MAX_TOOL_CALLS_PER_NAME", "3");
+        std::env::set_var("ARES_AGENT_ENABLE_PROMPT_CACHE", "false");
+        let cfg = AgentLoopConfig::from_env("test-model".into(), Some(0.25));
+        assert_eq!(cfg.model, "test-model");
+        assert_eq!(cfg.temperature, Some(0.25));
+        assert_eq!(cfg.max_steps, 13);
+        assert_eq!(cfg.max_tokens, 8192);
+        assert_eq!(cfg.max_tool_calls_per_name, 3);
+        assert!(!cfg.enable_prompt_cache);
+        std::env::remove_var("ARES_AGENT_MAX_STEPS");
+        std::env::remove_var("ARES_AGENT_MAX_TOKENS");
+        std::env::remove_var("ARES_AGENT_MAX_TOOL_CALLS_PER_NAME");
+        std::env::remove_var("ARES_AGENT_ENABLE_PROMPT_CACHE");
+    }
 }

--- a/ares-llm/src/agent_loop/config.rs
+++ b/ares-llm/src/agent_loop/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 /// Configuration for an agent loop execution.
 #[derive(Debug, Clone)]
 pub struct AgentLoopConfig {
@@ -13,11 +15,19 @@ pub struct AgentLoopConfig {
     pub retry: RetryConfig,
     /// Context window management configuration.
     pub context: ContextConfig,
+    /// Token budget circuit breaker; when exceeded the loop ends with
+    /// `LoopEndReason::BudgetExceeded` rather than calling the LLM again.
+    pub budget: BudgetConfig,
+    /// Append-only session log configuration.
+    pub session_log: SessionLogConfig,
     /// Maximum times a single tool can be called within one agent loop before
     /// it is removed from the tool definitions to force the LLM to try
     /// a different approach. Blue investigations need higher limits since
     /// detection queries are the primary tool.
     pub max_tool_calls_per_name: u32,
+    /// Whether to attach Anthropic prompt-cache breakpoints to the stable
+    /// prefix (system + tool definitions). No-op for non-Anthropic providers.
+    pub enable_prompt_cache: bool,
 }
 
 impl Default for AgentLoopConfig {
@@ -29,7 +39,44 @@ impl Default for AgentLoopConfig {
             temperature: None,
             retry: RetryConfig::default(),
             context: ContextConfig::default(),
+            budget: BudgetConfig::default(),
+            session_log: SessionLogConfig::default(),
             max_tool_calls_per_name: 10,
+            enable_prompt_cache: true,
+        }
+    }
+}
+
+impl AgentLoopConfig {
+    /// Build an `AgentLoopConfig` with the given model + temperature, layered
+    /// over env-var overrides for the remaining fields.
+    ///
+    /// Env vars (all optional, fall back to default values):
+    /// - `ARES_AGENT_MAX_STEPS`
+    /// - `ARES_AGENT_MAX_TOKENS`
+    /// - `ARES_AGENT_MAX_TOOL_CALLS_PER_NAME`
+    /// - `ARES_AGENT_ENABLE_PROMPT_CACHE` (`true`/`false`/`1`/`0`)
+    /// - everything from `ContextConfig::from_env`, `BudgetConfig::from_env`,
+    ///   `SessionLogConfig::from_env`
+    pub fn from_env(model: String, temperature: Option<f32>) -> Self {
+        let defaults = Self::default();
+        Self {
+            model,
+            temperature,
+            max_steps: parse_env_u32("ARES_AGENT_MAX_STEPS", defaults.max_steps),
+            max_tokens: parse_env_u32("ARES_AGENT_MAX_TOKENS", defaults.max_tokens),
+            max_tool_calls_per_name: parse_env_u32(
+                "ARES_AGENT_MAX_TOOL_CALLS_PER_NAME",
+                defaults.max_tool_calls_per_name,
+            ),
+            enable_prompt_cache: parse_env_bool(
+                "ARES_AGENT_ENABLE_PROMPT_CACHE",
+                defaults.enable_prompt_cache,
+            ),
+            retry: defaults.retry,
+            context: ContextConfig::from_env(),
+            budget: BudgetConfig::from_env(),
+            session_log: SessionLogConfig::from_env(),
         }
     }
 }
@@ -38,8 +85,17 @@ impl Default for AgentLoopConfig {
 #[derive(Debug, Clone)]
 pub struct ContextConfig {
     /// Maximum context budget in estimated tokens (0 = no limit).
-    /// When the conversation exceeds this, older messages in the middle are dropped.
+    /// When the conversation exceeds this hard ceiling, older messages in the
+    /// middle are dropped regardless of cadence (defensive cliff).
     pub max_context_tokens: u32,
+    /// Compact when `estimated_tokens / max_context_tokens` reaches this ratio
+    /// (e.g. 0.6 → compact at 60% utilization). Set to 1.0 to keep the old
+    /// reactive-at-the-wall behavior. Ignored when `max_context_tokens == 0`.
+    pub compaction_threshold_ratio: f32,
+    /// Only check the threshold every N agent loop iterations (1 = every step).
+    /// The hard ceiling is always checked. Higher values reduce overhead at
+    /// the cost of slightly later compaction.
+    pub compaction_check_every: u32,
     /// Maximum chars for a single tool result before truncation.
     /// Large tool outputs (nmap scans, secretsdump) are truncated to this limit.
     pub max_tool_output_chars: usize,
@@ -51,9 +107,142 @@ impl Default for ContextConfig {
     fn default() -> Self {
         Self {
             max_context_tokens: 180_000,   // Conservative for 200k models
+            compaction_threshold_ratio: 0.6, // Compact proactively at 60%
+            compaction_check_every: 5,
             max_tool_output_chars: 30_000, // ~7,500 tokens per tool output
             min_recent_messages: 10,
         }
+    }
+}
+
+impl ContextConfig {
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        Self {
+            max_context_tokens: parse_env_u32(
+                "ARES_CONTEXT_MAX_TOKENS",
+                defaults.max_context_tokens,
+            ),
+            compaction_threshold_ratio: parse_env_f32(
+                "ARES_CONTEXT_COMPACTION_THRESHOLD",
+                defaults.compaction_threshold_ratio,
+            )
+            .clamp(0.1, 1.0),
+            compaction_check_every: parse_env_u32(
+                "ARES_CONTEXT_COMPACTION_CHECK_EVERY",
+                defaults.compaction_check_every,
+            )
+            .max(1),
+            max_tool_output_chars: parse_env_usize(
+                "ARES_CONTEXT_MAX_TOOL_OUTPUT_CHARS",
+                defaults.max_tool_output_chars,
+            ),
+            min_recent_messages: parse_env_usize(
+                "ARES_CONTEXT_MIN_RECENT_MESSAGES",
+                defaults.min_recent_messages,
+            ),
+        }
+    }
+
+    /// Token threshold at which proactive compaction fires. Returns 0 when
+    /// either the ceiling is disabled or the ratio is at the wall (1.0).
+    pub fn compaction_trigger_tokens(&self) -> u32 {
+        if self.max_context_tokens == 0 {
+            return 0;
+        }
+        let scaled =
+            (self.max_context_tokens as f32 * self.compaction_threshold_ratio).round() as u32;
+        scaled.min(self.max_context_tokens)
+    }
+}
+
+/// Per-loop token budget enforcement (circuit breaker).
+///
+/// Budgets cap the *cumulative* input + output tokens a single agent loop
+/// invocation may consume. A zero value disables that specific check, so
+/// the default-constructed config is fully disabled and operators opt in
+/// via env vars.
+#[derive(Debug, Clone, Default)]
+pub struct BudgetConfig {
+    /// Maximum cumulative input tokens (0 = no limit).
+    pub max_input_tokens: u32,
+    /// Maximum cumulative output tokens (0 = no limit).
+    pub max_output_tokens: u32,
+    /// Maximum cumulative input + output tokens (0 = no limit).
+    pub max_total_tokens: u32,
+}
+
+impl BudgetConfig {
+    pub fn from_env() -> Self {
+        Self {
+            max_input_tokens: parse_env_u32("ARES_BUDGET_MAX_INPUT_TOKENS", 0),
+            max_output_tokens: parse_env_u32("ARES_BUDGET_MAX_OUTPUT_TOKENS", 0),
+            max_total_tokens: parse_env_u32("ARES_BUDGET_MAX_TOTAL_TOKENS", 0),
+        }
+    }
+
+    /// Returns the first budget violation (if any) given the cumulative usage so far.
+    pub fn check(&self, input: u32, output: u32) -> Option<String> {
+        if self.max_input_tokens > 0 && input >= self.max_input_tokens {
+            return Some(format!(
+                "input token budget exhausted ({input} >= {})",
+                self.max_input_tokens
+            ));
+        }
+        if self.max_output_tokens > 0 && output >= self.max_output_tokens {
+            return Some(format!(
+                "output token budget exhausted ({output} >= {})",
+                self.max_output_tokens
+            ));
+        }
+        let total = input.saturating_add(output);
+        if self.max_total_tokens > 0 && total >= self.max_total_tokens {
+            return Some(format!(
+                "total token budget exhausted ({total} >= {})",
+                self.max_total_tokens
+            ));
+        }
+        None
+    }
+}
+
+/// Append-only JSONL session log configuration.
+///
+/// When enabled, every conversation event (user prompt, assistant turn,
+/// tool result, terminal outcome) is appended as a JSON line under
+/// `dir/{op_id}/{task_id}.jsonl`. The log is the primary source of truth
+/// for crash recovery / `--resume` and post-hoc debugging.
+#[derive(Debug, Clone, Default)]
+pub struct SessionLogConfig {
+    /// Root directory for session logs. `None` disables logging.
+    pub dir: Option<PathBuf>,
+}
+
+impl SessionLogConfig {
+    /// Construct from env vars:
+    /// - `ARES_SESSION_LOG_DIR` (explicit path; takes precedence)
+    /// - `ARES_SESSION_LOG_ENABLED=1` enables a default `~/.ares/sessions` path
+    pub fn from_env() -> Self {
+        if let Ok(dir) = std::env::var("ARES_SESSION_LOG_DIR") {
+            if !dir.trim().is_empty() {
+                return Self {
+                    dir: Some(PathBuf::from(dir)),
+                };
+            }
+        }
+        if parse_env_bool("ARES_SESSION_LOG_ENABLED", false) {
+            if let Some(home) = std::env::var_os("HOME") {
+                let mut p = PathBuf::from(home);
+                p.push(".ares");
+                p.push("sessions");
+                return Self { dir: Some(p) };
+            }
+        }
+        Self { dir: None }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.dir.is_some()
     }
 }
 
@@ -78,6 +267,38 @@ impl Default for RetryConfig {
     }
 }
 
+fn parse_env_u32(key: &str, default: u32) -> u32 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(default)
+}
+
+fn parse_env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn parse_env_f32(key: &str, default: f32) -> f32 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse::<f32>().ok())
+        .unwrap_or(default)
+}
+
+fn parse_env_bool(key: &str, default: bool) -> bool {
+    match std::env::var(key) {
+        Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" | "" => false,
+            _ => default,
+        },
+        Err(_) => default,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,6 +311,7 @@ mod tests {
         assert_eq!(cfg.max_tokens, 4096);
         assert!(cfg.temperature.is_none());
         assert_eq!(cfg.max_tool_calls_per_name, 10);
+        assert!(cfg.enable_prompt_cache);
     }
 
     #[test]
@@ -98,6 +320,8 @@ mod tests {
         assert_eq!(cfg.max_context_tokens, 180_000);
         assert_eq!(cfg.max_tool_output_chars, 30_000);
         assert_eq!(cfg.min_recent_messages, 10);
+        assert!((cfg.compaction_threshold_ratio - 0.6).abs() < 1e-6);
+        assert_eq!(cfg.compaction_check_every, 5);
     }
 
     #[test]
@@ -106,5 +330,72 @@ mod tests {
         assert_eq!(cfg.max_retries, 5);
         assert_eq!(cfg.base_delay_ms, 1_000);
         assert_eq!(cfg.max_delay_ms, 60_000);
+    }
+
+    #[test]
+    fn budget_config_disabled_by_default() {
+        let cfg = BudgetConfig::default();
+        assert_eq!(cfg.max_input_tokens, 0);
+        assert_eq!(cfg.max_output_tokens, 0);
+        assert_eq!(cfg.max_total_tokens, 0);
+        assert!(cfg.check(u32::MAX, u32::MAX).is_none());
+    }
+
+    #[test]
+    fn budget_config_check_input() {
+        let cfg = BudgetConfig {
+            max_input_tokens: 1000,
+            ..Default::default()
+        };
+        assert!(cfg.check(999, 0).is_none());
+        let v = cfg.check(1000, 0).expect("should trip");
+        assert!(v.contains("input"));
+    }
+
+    #[test]
+    fn budget_config_check_output() {
+        let cfg = BudgetConfig {
+            max_output_tokens: 500,
+            ..Default::default()
+        };
+        assert!(cfg.check(0, 499).is_none());
+        let v = cfg.check(0, 500).expect("should trip");
+        assert!(v.contains("output"));
+    }
+
+    #[test]
+    fn budget_config_check_total() {
+        let cfg = BudgetConfig {
+            max_total_tokens: 100,
+            ..Default::default()
+        };
+        assert!(cfg.check(40, 50).is_none());
+        let v = cfg.check(60, 40).expect("should trip");
+        assert!(v.contains("total"));
+    }
+
+    #[test]
+    fn compaction_trigger_tokens_at_60pct() {
+        let cfg = ContextConfig {
+            max_context_tokens: 100_000,
+            compaction_threshold_ratio: 0.6,
+            ..ContextConfig::default()
+        };
+        assert_eq!(cfg.compaction_trigger_tokens(), 60_000);
+    }
+
+    #[test]
+    fn compaction_trigger_tokens_disabled() {
+        let cfg = ContextConfig {
+            max_context_tokens: 0,
+            ..ContextConfig::default()
+        };
+        assert_eq!(cfg.compaction_trigger_tokens(), 0);
+    }
+
+    #[test]
+    fn session_log_disabled_by_default() {
+        let cfg = SessionLogConfig::default();
+        assert!(!cfg.enabled());
     }
 }

--- a/ares-llm/src/agent_loop/config.rs
+++ b/ares-llm/src/agent_loop/config.rs
@@ -106,7 +106,7 @@ pub struct ContextConfig {
 impl Default for ContextConfig {
     fn default() -> Self {
         Self {
-            max_context_tokens: 180_000,   // Conservative for 200k models
+            max_context_tokens: 180_000,     // Conservative for 200k models
             compaction_threshold_ratio: 0.6, // Compact proactively at 60%
             compaction_check_every: 5,
             max_tool_output_chars: 30_000, // ~7,500 tokens per tool output

--- a/ares-llm/src/agent_loop/context.rs
+++ b/ares-llm/src/agent_loop/context.rs
@@ -157,7 +157,13 @@ pub(super) fn trim_conversation(
     // step=cadence ensures the cadence branch fires; the threshold logic
     // inside still gates on `total > max_context_tokens`-style conditions
     // when the threshold is at the wall (1.0).
-    let _ = maybe_compact(messages, system, tools, config, config.compaction_check_every);
+    let _ = maybe_compact(
+        messages,
+        system,
+        tools,
+        config,
+        config.compaction_check_every,
+    );
 }
 
 /// Perform the actual compaction. Returns `Some(())` when a trim happened.

--- a/ares-llm/src/agent_loop/context.rs
+++ b/ares-llm/src/agent_loop/context.rs
@@ -1,4 +1,4 @@
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::provider::{ChatMessage, ContentPart, Role};
 
@@ -82,40 +82,106 @@ pub(super) fn truncate_tool_output(output: &str, max_chars: usize) -> String {
     )
 }
 
-/// Trim the conversation to fit within the token budget.
+/// Why `maybe_compact` decided to (or not to) trim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CompactionDecision {
+    /// Nothing to do; under the proactive threshold (or disabled).
+    Skipped,
+    /// Compacted because the proactive threshold (e.g. 60%) was crossed.
+    Proactive,
+    /// Compacted because the hard ceiling was hit; this is the last-resort path.
+    Reactive,
+}
+
+/// Decide whether to compact and, if so, perform the trim.
 ///
-/// Strategy: keep the first message (task prompt) and the last N messages
-/// (most recent context). Drop messages in the middle, replacing them with
-/// a summary marker.
-///
-/// Tool-call groups (an assistant message with tool_calls followed by its
-/// tool-result messages) are treated as atomic units — we never split them,
-/// since OpenAI rejects orphaned tool_call_ids with a 400 "invalid JSON" error.
+/// Strategy:
+/// 1. Cheap path: if `step % compaction_check_every != 0` AND we are below
+///    the hard ceiling, skip token estimation entirely.
+/// 2. Otherwise estimate the context. If we cross the proactive threshold
+///    (e.g. 60% utilization) we compact early — better than waiting until
+///    the wall and risking a truncated tool-call/result pair.
+/// 3. The hard ceiling check still runs every step regardless of cadence;
+///    a runaway tool output should never escape the trim.
+pub(super) fn maybe_compact(
+    messages: &mut Vec<ChatMessage>,
+    system: &str,
+    tools: &[crate::ToolDefinition],
+    config: &ContextConfig,
+    step: u32,
+) -> CompactionDecision {
+    if config.max_context_tokens == 0 {
+        return CompactionDecision::Skipped;
+    }
+
+    let trigger = config.compaction_trigger_tokens();
+    let on_cadence = step.is_multiple_of(config.compaction_check_every);
+
+    // Cheap fast path: skip estimation entirely when neither the cadence
+    // tick nor the wall would do anything.
+    if !on_cadence && messages.len() < config.min_recent_messages * 4 {
+        return CompactionDecision::Skipped;
+    }
+
+    let total = estimate_context_tokens(system, messages, tools);
+    let over_ceiling = total > config.max_context_tokens;
+    let over_threshold = trigger > 0 && total >= trigger;
+
+    if !(over_ceiling || (on_cadence && over_threshold)) {
+        return CompactionDecision::Skipped;
+    }
+
+    let decision = if over_ceiling {
+        CompactionDecision::Reactive
+    } else {
+        CompactionDecision::Proactive
+    };
+
+    if compact_messages(messages, total, system, tools, config, decision).is_some() {
+        decision
+    } else {
+        CompactionDecision::Skipped
+    }
+}
+
+/// Trim the conversation. Public wrapper retained for the existing tests
+/// and any external callers; equivalent to `maybe_compact` at step 0,
+/// which forces the cadence tick.
+#[allow(dead_code)]
 pub(super) fn trim_conversation(
     messages: &mut Vec<ChatMessage>,
     system: &str,
     tools: &[crate::ToolDefinition],
     config: &ContextConfig,
 ) {
-    if config.max_context_tokens == 0 {
-        return;
-    }
+    // step=cadence ensures the cadence branch fires; the threshold logic
+    // inside still gates on `total > max_context_tokens`-style conditions
+    // when the threshold is at the wall (1.0).
+    let _ = maybe_compact(messages, system, tools, config, config.compaction_check_every);
+}
 
-    let total = estimate_context_tokens(system, messages, tools);
-    if total <= config.max_context_tokens {
-        return;
-    }
-
+/// Perform the actual compaction. Returns `Some(())` when a trim happened.
+///
+/// Tool-call groups (an assistant message with tool_calls followed by its
+/// tool-result messages) are treated as atomic units — we never split them,
+/// since OpenAI rejects orphaned tool_call_ids with a 400 "invalid JSON" error.
+fn compact_messages(
+    messages: &mut Vec<ChatMessage>,
+    total_before: u32,
+    system: &str,
+    tools: &[crate::ToolDefinition],
+    config: &ContextConfig,
+    decision: CompactionDecision,
+) -> Option<()> {
     let min_keep = config.min_recent_messages;
     if messages.len() <= min_keep + 1 {
-        // Not enough messages to trim
-        return;
+        return None;
     }
 
     // Keep first message + last min_keep messages, drop the middle
     let mut drop_end = messages.len().saturating_sub(min_keep);
     if drop_end <= 1 {
-        return;
+        return None;
     }
 
     // Adjust drop_end so we don't sever tool-call / tool-result pairs.
@@ -125,9 +191,8 @@ pub(super) fn trim_conversation(
         drop_end -= 1;
     }
 
-    // If after adjustment there's nothing left to drop, bail out.
     if drop_end <= 1 {
-        return;
+        return None;
     }
 
     // If the last dropped message (at drop_end - 1) is an assistant message
@@ -140,27 +205,133 @@ pub(super) fn trim_conversation(
     }
 
     if drop_end <= 1 || drop_end >= messages.len() {
-        return;
+        return None;
     }
 
+    // Score the about-to-be-dropped slice and surface a short semantic recap
+    // alongside the count, so the LLM still has a pointer to what it just
+    // worked on. This is the lightweight "semantic scoring" version: we
+    // pick the highest-signal text fragments rather than a separate
+    // summarization LLM call.
+    let recap = semantic_recap(&messages[1..drop_end]);
     let dropped = drop_end - 1;
-    let summary = format!(
-        "[Context trimmed: {dropped} earlier messages removed to stay within token budget. \
-         The conversation continues from the most recent exchanges.]"
-    );
+    let kind = match decision {
+        CompactionDecision::Proactive => "proactive",
+        CompactionDecision::Reactive => "reactive",
+        CompactionDecision::Skipped => "skipped",
+    };
+    let summary = if recap.is_empty() {
+        format!(
+            "[Context compacted ({kind}): {dropped} earlier messages removed to stay within token \
+             budget. The conversation continues from the most recent exchanges.]"
+        )
+    } else {
+        format!(
+            "[Context compacted ({kind}): {dropped} earlier messages removed to stay within token \
+             budget. Salient highlights:\n{recap}\nThe conversation continues from the most recent \
+             exchanges.]"
+        )
+    };
 
-    // Replace middle section with summary
     messages.splice(
         1..drop_end,
         std::iter::once(ChatMessage::text(Role::User, &summary)),
     );
 
-    debug!(
-        dropped = dropped,
-        remaining = messages.len(),
-        estimated_tokens = estimate_context_tokens(system, messages, tools),
-        "Trimmed conversation context"
-    );
+    let total_after = estimate_context_tokens(system, messages, tools);
+    let log_msg = "Compacted conversation context";
+    match decision {
+        CompactionDecision::Proactive => {
+            info!(
+                kind = "proactive",
+                dropped = dropped,
+                remaining = messages.len(),
+                tokens_before = total_before,
+                tokens_after = total_after,
+                log_msg
+            );
+        }
+        CompactionDecision::Reactive | CompactionDecision::Skipped => {
+            debug!(
+                kind = kind,
+                dropped = dropped,
+                remaining = messages.len(),
+                tokens_before = total_before,
+                tokens_after = total_after,
+                log_msg
+            );
+        }
+    }
+
+    Some(())
+}
+
+/// Pick a few high-signal lines from a slice of messages. Heuristic: prefer
+/// the first line of any tool-result (often the most informative summary
+/// line of a scan/dump) and the first sentence of any assistant text. Cap
+/// the recap to avoid re-introducing context bloat.
+fn semantic_recap(slice: &[ChatMessage]) -> String {
+    const MAX_LINES: usize = 6;
+    const MAX_LINE_CHARS: usize = 160;
+    let mut out: Vec<String> = Vec::with_capacity(MAX_LINES);
+
+    for msg in slice {
+        if out.len() >= MAX_LINES {
+            break;
+        }
+        if let Some(parts) = &msg.parts {
+            for part in parts {
+                if out.len() >= MAX_LINES {
+                    break;
+                }
+                match part {
+                    ContentPart::ToolResult { content, .. } => {
+                        if let Some(line) = first_signal_line(content) {
+                            out.push(format!("- tool: {}", clip(&line, MAX_LINE_CHARS)));
+                        }
+                    }
+                    ContentPart::Text { text } => {
+                        if let Some(line) = first_signal_line(text) {
+                            out.push(format!("- llm: {}", clip(&line, MAX_LINE_CHARS)));
+                        }
+                    }
+                    ContentPart::ToolUse { name, .. } => {
+                        out.push(format!("- call: {name}"));
+                    }
+                }
+            }
+        } else if let Some(content) = &msg.content {
+            if let Some(line) = first_signal_line(content) {
+                let role = match msg.role {
+                    Role::User => "user",
+                    Role::Assistant => "llm",
+                    _ => "msg",
+                };
+                out.push(format!("- {role}: {}", clip(&line, MAX_LINE_CHARS)));
+            }
+        }
+    }
+
+    out.join("\n")
+}
+
+fn first_signal_line(text: &str) -> Option<String> {
+    text.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#') && !l.starts_with("```"))
+        .map(|s| s.to_string())
+}
+
+fn clip(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let cut = s
+        .char_indices()
+        .nth(max_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    format!("{}…", &s[..cut])
 }
 
 /// Check if a message is a tool result (role=Tool or User with ToolResult parts).
@@ -333,6 +504,8 @@ mod tests {
     fn trim_conversation_no_limit() {
         let config = ContextConfig {
             max_context_tokens: 0,
+            compaction_threshold_ratio: 0.6,
+            compaction_check_every: 1,
             max_tool_output_chars: 30_000,
             min_recent_messages: 10,
         };
@@ -348,6 +521,8 @@ mod tests {
     fn trim_conversation_under_budget_unchanged() {
         let config = ContextConfig {
             max_context_tokens: 100_000,
+            compaction_threshold_ratio: 0.6,
+            compaction_check_every: 1,
             max_tool_output_chars: 30_000,
             min_recent_messages: 2,
         };
@@ -357,5 +532,83 @@ mod tests {
         ];
         trim_conversation(&mut msgs, "sys", &[], &config);
         assert_eq!(msgs.len(), 2);
+    }
+
+    #[test]
+    fn maybe_compact_proactive_at_60_percent() {
+        let config = ContextConfig {
+            max_context_tokens: 1000,
+            compaction_threshold_ratio: 0.6,
+            compaction_check_every: 1,
+            max_tool_output_chars: 0,
+            min_recent_messages: 2,
+        };
+        let mut messages: Vec<ChatMessage> = Vec::new();
+        messages.push(ChatMessage::text(Role::User, "task prompt"));
+        // Each message ~ 250 chars -> ~ 62 tokens. Add enough to cross 600 tokens.
+        for i in 0..15 {
+            messages.push(ChatMessage::text(
+                Role::Assistant,
+                format!("step {i} {}", "x".repeat(240)),
+            ));
+        }
+        let decision = maybe_compact(&mut messages, "sys", &[], &config, 1);
+        assert_eq!(decision, CompactionDecision::Proactive);
+        assert!(messages.len() < 16);
+        assert!(messages[1]
+            .text_content()
+            .unwrap()
+            .contains("Context compacted"));
+    }
+
+    #[test]
+    fn maybe_compact_reactive_when_over_ceiling() {
+        let config = ContextConfig {
+            max_context_tokens: 200,
+            compaction_threshold_ratio: 1.0, // disable proactive
+            compaction_check_every: 100,     // off-cadence
+            max_tool_output_chars: 0,
+            min_recent_messages: 2,
+        };
+        let mut messages: Vec<ChatMessage> = Vec::new();
+        messages.push(ChatMessage::text(Role::User, "task"));
+        for i in 0..10 {
+            messages.push(ChatMessage::text(
+                Role::Assistant,
+                format!("step {i} {}", "x".repeat(200)),
+            ));
+        }
+        // Off-cadence step=1, but the hard ceiling must still trip.
+        let decision = maybe_compact(&mut messages, "sys", &[], &config, 1);
+        assert_eq!(decision, CompactionDecision::Reactive);
+    }
+
+    #[test]
+    fn maybe_compact_skips_when_under_threshold() {
+        let config = ContextConfig {
+            max_context_tokens: 1_000_000,
+            compaction_threshold_ratio: 0.6,
+            compaction_check_every: 1,
+            max_tool_output_chars: 0,
+            min_recent_messages: 4,
+        };
+        let mut messages = vec![
+            ChatMessage::text(Role::User, "first"),
+            ChatMessage::text(Role::Assistant, "second"),
+        ];
+        let decision = maybe_compact(&mut messages, "sys", &[], &config, 1);
+        assert_eq!(decision, CompactionDecision::Skipped);
+        assert_eq!(messages.len(), 2);
+    }
+
+    #[test]
+    fn semantic_recap_picks_first_signal_lines() {
+        let messages = vec![
+            ChatMessage::text(Role::Assistant, "I'll start by scanning.\nDetails follow."),
+            ChatMessage::tool_result("c1", "Host 192.168.58.10 is up.\n22/tcp open ssh"),
+        ];
+        let recap = semantic_recap(&messages);
+        assert!(recap.contains("scanning"));
+        assert!(recap.contains("192.168.58.10"));
     }
 }

--- a/ares-llm/src/agent_loop/mod.rs
+++ b/ares-llm/src/agent_loop/mod.rs
@@ -15,12 +15,14 @@ mod config;
 mod context;
 mod retry;
 mod runner;
+mod session_log;
 
 #[cfg(test)]
 mod tests;
 
-pub use config::{AgentLoopConfig, ContextConfig, RetryConfig};
+pub use config::{AgentLoopConfig, BudgetConfig, ContextConfig, RetryConfig, SessionLogConfig};
 pub use runner::{run_agent_loop, HostnameMap};
+pub use session_log::{replay_messages, SessionLog};
 pub use types::{
     AgentLoopOutcome, CallbackHandler, CallbackResult, LoopEndReason, ToolDispatcher,
     ToolExecResult,

--- a/ares-llm/src/agent_loop/runner.rs
+++ b/ares-llm/src/agent_loop/runner.rs
@@ -100,7 +100,9 @@ pub async fn run_agent_loop(
         .and_then(|v| {
             // ARES_OPERATION_ID may be a plain ID or a JSON envelope; try
             // to extract `operation_id` if it parses as JSON, else use raw.
-            if let Ok(serde_json::Value::Object(map)) = serde_json::from_str::<serde_json::Value>(&v) {
+            if let Ok(serde_json::Value::Object(map)) =
+                serde_json::from_str::<serde_json::Value>(&v)
+            {
                 map.get("operation_id")
                     .and_then(|x| x.as_str())
                     .map(|s| s.to_string())
@@ -176,8 +178,13 @@ pub async fn run_agent_loop(
 
         // Proactive compaction (rolling): fires at the configured utilization
         // ratio (default 60%) on the cadence tick, with a hard ceiling fallback.
-        let decision =
-            maybe_compact(&mut messages, system_prompt, &active_tools, &config.context, steps);
+        let decision = maybe_compact(
+            &mut messages,
+            system_prompt,
+            &active_tools,
+            &config.context,
+            steps,
+        );
         match decision {
             CompactionDecision::Proactive | CompactionDecision::Reactive => {
                 if session_log.enabled() {
@@ -528,10 +535,8 @@ pub async fn run_agent_loop(
                                 result,
                             }) => {
                                 info!(task_id = %tid, steps = steps, "Task completed");
-                                let tr = ChatMessage::tool_result(
-                                    &call_id,
-                                    "Task marked as complete.",
-                                );
+                                let tr =
+                                    ChatMessage::tool_result(&call_id, "Task marked as complete.");
                                 if session_log.enabled() {
                                     session_log.record_message(steps, &tr);
                                 }
@@ -605,10 +610,7 @@ pub async fn run_agent_loop(
                             result,
                         }) => {
                             info!(task_id = %tid, steps = steps, "Task completed");
-                            let tr = ChatMessage::tool_result(
-                                &call.id,
-                                "Task marked as complete.",
-                            );
+                            let tr = ChatMessage::tool_result(&call.id, "Task marked as complete.");
                             if session_log.enabled() {
                                 session_log.record_message(steps, &tr);
                             }
@@ -646,10 +648,8 @@ pub async fn run_agent_loop(
                             messages.push(tr);
                         }
                         Err(e) => {
-                            let tr = ChatMessage::tool_result(
-                                &call.id,
-                                format!("Callback error: {e}"),
-                            );
+                            let tr =
+                                ChatMessage::tool_result(&call.id, format!("Callback error: {e}"));
                             if session_log.enabled() {
                                 session_log.record_message(steps, &tr);
                             }
@@ -720,8 +720,7 @@ pub async fn run_agent_loop(
                         messages.push(tr);
                     }
                     Err(e) => {
-                        let tr =
-                            ChatMessage::tool_result(&call.id, format!("Callback error: {e}"));
+                        let tr = ChatMessage::tool_result(&call.id, format!("Callback error: {e}"));
                         if session_log.enabled() {
                             session_log.record_message(steps, &tr);
                         }
@@ -769,9 +768,7 @@ fn describe_reason(reason: &LoopEndReason) -> (&'static str, serde_json::Value) 
             serde_json::json!({"issue": issue, "context": context}),
         ),
         LoopEndReason::MaxSteps => ("MaxSteps", serde_json::Value::Null),
-        LoopEndReason::EndTurn { content } => {
-            ("EndTurn", serde_json::json!({"content": content}))
-        }
+        LoopEndReason::EndTurn { content } => ("EndTurn", serde_json::json!({"content": content})),
         LoopEndReason::MaxTokens => ("MaxTokens", serde_json::Value::Null),
         LoopEndReason::BudgetExceeded { reason } => {
             ("BudgetExceeded", serde_json::json!({"reason": reason}))

--- a/ares-llm/src/agent_loop/runner.rs
+++ b/ares-llm/src/agent_loop/runner.rs
@@ -776,3 +776,74 @@ fn describe_reason(reason: &LoopEndReason) -> (&'static str, serde_json::Value) 
         LoopEndReason::Error(err) => ("Error", serde_json::json!({"err": err})),
     }
 }
+
+#[cfg(test)]
+mod runner_tests {
+    use super::*;
+
+    #[test]
+    fn describe_reason_task_complete() {
+        let r = LoopEndReason::TaskComplete {
+            task_id: "t-1".into(),
+            result: "done".into(),
+        };
+        let (kind, payload) = describe_reason(&r);
+        assert_eq!(kind, "TaskComplete");
+        assert_eq!(payload["task_id"], "t-1");
+        assert_eq!(payload["result"], "done");
+    }
+
+    #[test]
+    fn describe_reason_request_assistance() {
+        let r = LoopEndReason::RequestAssistance {
+            issue: "stuck".into(),
+            context: "tried 3 things".into(),
+        };
+        let (kind, payload) = describe_reason(&r);
+        assert_eq!(kind, "RequestAssistance");
+        assert_eq!(payload["issue"], "stuck");
+        assert_eq!(payload["context"], "tried 3 things");
+    }
+
+    #[test]
+    fn describe_reason_max_steps_and_max_tokens() {
+        let (k, p) = describe_reason(&LoopEndReason::MaxSteps);
+        assert_eq!(k, "MaxSteps");
+        assert!(p.is_null());
+
+        let (k, p) = describe_reason(&LoopEndReason::MaxTokens);
+        assert_eq!(k, "MaxTokens");
+        assert!(p.is_null());
+    }
+
+    #[test]
+    fn describe_reason_end_turn_carries_content() {
+        let r = LoopEndReason::EndTurn {
+            content: "all done".into(),
+        };
+        let (k, p) = describe_reason(&r);
+        assert_eq!(k, "EndTurn");
+        assert_eq!(p["content"], "all done");
+    }
+
+    #[test]
+    fn describe_reason_budget_exceeded_carries_reason() {
+        let r = LoopEndReason::BudgetExceeded {
+            reason: "input token budget exhausted (12000 >= 10000)".into(),
+        };
+        let (k, p) = describe_reason(&r);
+        assert_eq!(k, "BudgetExceeded");
+        assert!(p["reason"]
+            .as_str()
+            .unwrap()
+            .contains("input token budget exhausted"));
+    }
+
+    #[test]
+    fn describe_reason_error_carries_message() {
+        let r = LoopEndReason::Error("network timeout".into());
+        let (k, p) = describe_reason(&r);
+        assert_eq!(k, "Error");
+        assert_eq!(p["err"], "network timeout");
+    }
+}

--- a/ares-llm/src/agent_loop/runner.rs
+++ b/ares-llm/src/agent_loop/runner.rs
@@ -17,10 +17,12 @@ use crate::tool_registry;
 
 use super::callbacks::handle_callback;
 use super::config::AgentLoopConfig;
-use super::context::{trim_conversation, truncate_tool_output};
+use super::context::{maybe_compact, truncate_tool_output, CompactionDecision};
 use super::retry::call_with_retry;
+use super::session_log::SessionLog;
 use super::types::{
     AgentLoopOutcome, CallbackHandler, CallbackResult, LoopEndReason, ToolDispatcher,
+    ToolExecResult,
 };
 
 /// Result of dispatching a single tool call.
@@ -39,15 +41,20 @@ async fn dispatch_one(
 ) -> DispatchResult {
     match dispatcher.dispatch_tool(&role, &task_id, &call).await {
         Ok(result) => {
-            let output = if let Some(err) = &result.error {
-                format!("Error: {err}\n\nPartial output:\n{}", result.output)
+            let ToolExecResult {
+                output,
+                error,
+                discoveries,
+            } = result;
+            let output = if let Some(err) = error {
+                format!("Error: {err}\n\nPartial output:\n{output}")
             } else {
-                result.output
+                output
             };
             DispatchResult {
                 call_id: call.id,
                 output,
-                discoveries: result.discoveries,
+                discoveries,
             }
         }
         Err(e) => {
@@ -88,7 +95,31 @@ pub async fn run_agent_loop(
     callback_handler: Option<Arc<dyn CallbackHandler>>,
     hostname_map: Option<HostnameMap>,
 ) -> AgentLoopOutcome {
+    let op_id = std::env::var("ARES_OPERATION_ID")
+        .ok()
+        .and_then(|v| {
+            // ARES_OPERATION_ID may be a plain ID or a JSON envelope; try
+            // to extract `operation_id` if it parses as JSON, else use raw.
+            if let Ok(serde_json::Value::Object(map)) = serde_json::from_str::<serde_json::Value>(&v) {
+                map.get("operation_id")
+                    .and_then(|x| x.as_str())
+                    .map(|s| s.to_string())
+            } else {
+                Some(v)
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let session_log = SessionLog::open(&config.session_log, &op_id, task_id, role, &config.model);
+    if session_log.enabled() {
+        let tool_names: Vec<String> = tools.iter().map(|t| t.name.clone()).collect();
+        session_log.record_start(system_prompt, task_prompt, &tool_names);
+    }
+
     let mut messages: Vec<ChatMessage> = vec![ChatMessage::text(Role::User, task_prompt)];
+    if session_log.enabled() {
+        session_log.record_message(0, &messages[0]);
+    }
 
     let mut total_usage = TokenUsage::default();
     let mut steps: u32 = 0;
@@ -106,20 +137,60 @@ pub async fn run_agent_loop(
     loop {
         if steps >= config.max_steps {
             warn!(task_id = task_id, steps = steps, "Agent loop hit max steps");
-            return AgentLoopOutcome {
-                reason: LoopEndReason::MaxSteps,
-                total_usage,
+            return finish(
+                &session_log,
                 steps,
+                LoopEndReason::MaxSteps,
+                total_usage,
                 tool_calls_dispatched,
-                discoveries: all_discoveries,
-                tool_outputs: all_tool_outputs,
-            };
+                all_discoveries,
+                all_tool_outputs,
+            );
+        }
+
+        // Token budget circuit breaker: gate every iteration on cumulative usage.
+        // This is the per-call gate squad has via MaxCost / ErrBudgetExceeded.
+        if let Some(reason) = config
+            .budget
+            .check(total_usage.input_tokens, total_usage.output_tokens)
+        {
+            warn!(
+                task_id = task_id,
+                steps = steps,
+                input_tokens = total_usage.input_tokens,
+                output_tokens = total_usage.output_tokens,
+                "Agent loop tripped budget breaker: {reason}"
+            );
+            return finish(
+                &session_log,
+                steps,
+                LoopEndReason::BudgetExceeded { reason },
+                total_usage,
+                tool_calls_dispatched,
+                all_discoveries,
+                all_tool_outputs,
+            );
         }
 
         steps += 1;
 
-        // Trim conversation if approaching context limit
-        trim_conversation(&mut messages, system_prompt, &active_tools, &config.context);
+        // Proactive compaction (rolling): fires at the configured utilization
+        // ratio (default 60%) on the cadence tick, with a hard ceiling fallback.
+        let decision =
+            maybe_compact(&mut messages, system_prompt, &active_tools, &config.context, steps);
+        match decision {
+            CompactionDecision::Proactive | CompactionDecision::Reactive => {
+                if session_log.enabled() {
+                    let kind = match decision {
+                        CompactionDecision::Proactive => "proactive",
+                        CompactionDecision::Reactive => "reactive",
+                        CompactionDecision::Skipped => "skipped",
+                    };
+                    session_log.record_compaction(steps, kind, 0, 0);
+                }
+            }
+            CompactionDecision::Skipped => {}
+        }
 
         // Build LLM request
         let mut request = LlmRequest::new(&config.model);
@@ -128,6 +199,7 @@ pub async fn run_agent_loop(
         request.tools = active_tools.clone();
         request.max_tokens = config.max_tokens;
         request.temperature = config.temperature;
+        request.enable_prompt_cache = config.enable_prompt_cache;
 
         debug!(
             task_id = task_id,
@@ -141,14 +213,15 @@ pub async fn run_agent_loop(
             Ok(r) => r,
             Err(e) => {
                 warn!(err = %e, task_id = task_id, "LLM call failed after retries");
-                return AgentLoopOutcome {
-                    reason: LoopEndReason::Error(e.to_string()),
-                    total_usage,
+                return finish(
+                    &session_log,
                     steps,
+                    LoopEndReason::Error(e.to_string()),
+                    total_usage,
                     tool_calls_dispatched,
-                    discoveries: all_discoveries,
-                    tool_outputs: all_tool_outputs,
-                };
+                    all_discoveries,
+                    all_tool_outputs,
+                );
             }
         };
 
@@ -158,6 +231,10 @@ pub async fn run_agent_loop(
         total_usage.cache_creation_input_tokens += response.usage.cache_creation_input_tokens;
         total_usage.cache_read_input_tokens += response.usage.cache_read_input_tokens;
 
+        if session_log.enabled() {
+            session_log.record_usage(steps, &response.usage);
+        }
+
         // Report incremental token usage to callback handler (persists to Redis)
         if let Some(ref handler) = callback_handler {
             handler.on_token_usage(&response.usage, &config.model).await;
@@ -166,44 +243,58 @@ pub async fn run_agent_loop(
         // Handle based on stop reason
         match response.stop_reason {
             StopReason::EndTurn if response.tool_calls.is_empty() => {
-                return AgentLoopOutcome {
-                    reason: LoopEndReason::EndTurn {
+                let assistant_msg = ChatMessage::text(Role::Assistant, &response.content);
+                if session_log.enabled() {
+                    session_log.record_message(steps, &assistant_msg);
+                }
+                return finish(
+                    &session_log,
+                    steps,
+                    LoopEndReason::EndTurn {
                         content: response.content,
                     },
                     total_usage,
-                    steps,
                     tool_calls_dispatched,
-                    discoveries: all_discoveries,
-                    tool_outputs: all_tool_outputs,
-                };
+                    all_discoveries,
+                    all_tool_outputs,
+                );
             }
             StopReason::MaxTokens if response.tool_calls.is_empty() => {
-                return AgentLoopOutcome {
-                    reason: LoopEndReason::MaxTokens,
-                    total_usage,
+                return finish(
+                    &session_log,
                     steps,
+                    LoopEndReason::MaxTokens,
+                    total_usage,
                     tool_calls_dispatched,
-                    discoveries: all_discoveries,
-                    tool_outputs: all_tool_outputs,
-                };
+                    all_discoveries,
+                    all_tool_outputs,
+                );
             }
             _ => {}
         }
 
         if response.tool_calls.is_empty() {
             // No tool calls and not EndTurn/MaxTokens — add as assistant message and continue
-            messages.push(ChatMessage::text(Role::Assistant, &response.content));
+            let m = ChatMessage::text(Role::Assistant, &response.content);
+            if session_log.enabled() {
+                session_log.record_message(steps, &m);
+            }
+            messages.push(m);
             continue;
         }
 
-        messages.push(ChatMessage::assistant_tool_use(
+        let assistant_msg = ChatMessage::assistant_tool_use(
             if response.content.is_empty() {
                 None
             } else {
                 Some(response.content.clone())
             },
             response.tool_calls.clone(),
-        ));
+        );
+        if session_log.enabled() {
+            session_log.record_message(steps, &assistant_msg);
+        }
+        messages.push(assistant_msg);
 
         // Record LLM tool selection decisions for observability
         {
@@ -308,7 +399,11 @@ pub async fn run_agent_loop(
                         truncate_tool_output(&dr.output, config.context.max_tool_output_chars);
                     // Collect raw tool output for secondary regex extraction
                     all_tool_outputs.push(dr.output.clone());
-                    messages.push(ChatMessage::tool_result(&call.id, &output));
+                    let tr = ChatMessage::tool_result(&call.id, &output);
+                    if session_log.enabled() {
+                        session_log.record_message(steps, &tr);
+                    }
+                    messages.push(tr);
                     if let Some(disc) = &dr.discoveries {
                         all_discoveries.push(disc.clone());
                     }
@@ -322,10 +417,14 @@ pub async fn run_agent_loop(
                         task_id = task_id,
                         "No dispatch result for tool call — inserting error placeholder"
                     );
-                    messages.push(ChatMessage::tool_result(
+                    let tr = ChatMessage::tool_result(
                         &call.id,
                         "Tool execution failed: no result received (dispatch error)",
-                    ));
+                    );
+                    if session_log.enabled() {
+                        session_log.record_message(steps, &tr);
+                    }
+                    messages.push(tr);
                 }
 
                 // Check if tool has exceeded max call count
@@ -356,14 +455,18 @@ pub async fn run_agent_loop(
                     );
                     // Inject a system-like message so the LLM knows these tools are gone
                     let removed_list = tools_to_remove.join(", ");
-                    messages.push(ChatMessage::text(
+                    let m = ChatMessage::text(
                         Role::User,
                         format!(
                             "[SYSTEM] The following tools have been removed and are no longer \
                              available: {removed_list}. Do not attempt to call them. \
                              Use alternative approaches or different tools."
                         ),
-                    ));
+                    );
+                    if session_log.enabled() {
+                        session_log.record_message(steps, &m);
+                    }
+                    messages.push(m);
                 }
             }
         }
@@ -425,41 +528,55 @@ pub async fn run_agent_loop(
                                 result,
                             }) => {
                                 info!(task_id = %tid, steps = steps, "Task completed");
-                                messages.push(ChatMessage::tool_result(
+                                let tr = ChatMessage::tool_result(
                                     &call_id,
                                     "Task marked as complete.",
-                                ));
-                                return AgentLoopOutcome {
-                                    reason: LoopEndReason::TaskComplete {
+                                );
+                                if session_log.enabled() {
+                                    session_log.record_message(steps, &tr);
+                                }
+                                messages.push(tr);
+                                return finish(
+                                    &session_log,
+                                    steps,
+                                    LoopEndReason::TaskComplete {
                                         task_id: tid,
                                         result,
                                     },
                                     total_usage,
-                                    steps,
                                     tool_calls_dispatched,
-                                    discoveries: all_discoveries,
-                                    tool_outputs: all_tool_outputs,
-                                };
+                                    all_discoveries,
+                                    all_tool_outputs,
+                                );
                             }
                             Ok(CallbackResult::RequestAssistance { issue, context }) => {
                                 info!(issue = %issue, "Assistance requested");
-                                return AgentLoopOutcome {
-                                    reason: LoopEndReason::RequestAssistance { issue, context },
-                                    total_usage,
+                                return finish(
+                                    &session_log,
                                     steps,
+                                    LoopEndReason::RequestAssistance { issue, context },
+                                    total_usage,
                                     tool_calls_dispatched,
-                                    discoveries: all_discoveries,
-                                    tool_outputs: all_tool_outputs,
-                                };
+                                    all_discoveries,
+                                    all_tool_outputs,
+                                );
                             }
                             Ok(CallbackResult::Continue(msg)) => {
-                                messages.push(ChatMessage::tool_result(&call_id, &msg));
+                                let tr = ChatMessage::tool_result(&call_id, &msg);
+                                if session_log.enabled() {
+                                    session_log.record_message(steps, &tr);
+                                }
+                                messages.push(tr);
                             }
                             Err(e) => {
-                                messages.push(ChatMessage::tool_result(
+                                let tr = ChatMessage::tool_result(
                                     &call_id,
                                     format!("Callback error: {e}"),
-                                ));
+                                );
+                                if session_log.enabled() {
+                                    session_log.record_message(steps, &tr);
+                                }
+                                messages.push(tr);
                             }
                         }
                     }
@@ -488,41 +605,55 @@ pub async fn run_agent_loop(
                             result,
                         }) => {
                             info!(task_id = %tid, steps = steps, "Task completed");
-                            messages.push(ChatMessage::tool_result(
+                            let tr = ChatMessage::tool_result(
                                 &call.id,
                                 "Task marked as complete.",
-                            ));
-                            return AgentLoopOutcome {
-                                reason: LoopEndReason::TaskComplete {
+                            );
+                            if session_log.enabled() {
+                                session_log.record_message(steps, &tr);
+                            }
+                            messages.push(tr);
+                            return finish(
+                                &session_log,
+                                steps,
+                                LoopEndReason::TaskComplete {
                                     task_id: tid,
                                     result,
                                 },
                                 total_usage,
-                                steps,
                                 tool_calls_dispatched,
-                                discoveries: all_discoveries,
-                                tool_outputs: all_tool_outputs,
-                            };
+                                all_discoveries,
+                                all_tool_outputs,
+                            );
                         }
                         Ok(CallbackResult::RequestAssistance { issue, context }) => {
                             info!(issue = %issue, "Assistance requested");
-                            return AgentLoopOutcome {
-                                reason: LoopEndReason::RequestAssistance { issue, context },
-                                total_usage,
+                            return finish(
+                                &session_log,
                                 steps,
+                                LoopEndReason::RequestAssistance { issue, context },
+                                total_usage,
                                 tool_calls_dispatched,
-                                discoveries: all_discoveries,
-                                tool_outputs: all_tool_outputs,
-                            };
+                                all_discoveries,
+                                all_tool_outputs,
+                            );
                         }
                         Ok(CallbackResult::Continue(msg)) => {
-                            messages.push(ChatMessage::tool_result(&call.id, &msg));
+                            let tr = ChatMessage::tool_result(&call.id, &msg);
+                            if session_log.enabled() {
+                                session_log.record_message(steps, &tr);
+                            }
+                            messages.push(tr);
                         }
                         Err(e) => {
-                            messages.push(ChatMessage::tool_result(
+                            let tr = ChatMessage::tool_result(
                                 &call.id,
                                 format!("Callback error: {e}"),
-                            ));
+                            );
+                            if session_log.enabled() {
+                                session_log.record_message(steps, &tr);
+                            }
+                            messages.push(tr);
                         }
                     }
                 }
@@ -551,44 +682,100 @@ pub async fn run_agent_loop(
                         result,
                     }) => {
                         info!(task_id = %tid, steps = steps, "Task completed");
-                        messages.push(ChatMessage::tool_result(
-                            &call.id,
-                            "Task marked as complete.",
-                        ));
-                        return AgentLoopOutcome {
-                            reason: LoopEndReason::TaskComplete {
+                        let tr = ChatMessage::tool_result(&call.id, "Task marked as complete.");
+                        if session_log.enabled() {
+                            session_log.record_message(steps, &tr);
+                        }
+                        messages.push(tr);
+                        return finish(
+                            &session_log,
+                            steps,
+                            LoopEndReason::TaskComplete {
                                 task_id: tid,
                                 result,
                             },
                             total_usage,
-                            steps,
                             tool_calls_dispatched,
-                            discoveries: all_discoveries,
-                            tool_outputs: all_tool_outputs,
-                        };
+                            all_discoveries,
+                            all_tool_outputs,
+                        );
                     }
                     Ok(CallbackResult::RequestAssistance { issue, context }) => {
                         info!(issue = %issue, "Assistance requested");
-                        return AgentLoopOutcome {
-                            reason: LoopEndReason::RequestAssistance { issue, context },
-                            total_usage,
+                        return finish(
+                            &session_log,
                             steps,
+                            LoopEndReason::RequestAssistance { issue, context },
+                            total_usage,
                             tool_calls_dispatched,
-                            discoveries: all_discoveries,
-                            tool_outputs: all_tool_outputs,
-                        };
+                            all_discoveries,
+                            all_tool_outputs,
+                        );
                     }
                     Ok(CallbackResult::Continue(msg)) => {
-                        messages.push(ChatMessage::tool_result(&call.id, &msg));
+                        let tr = ChatMessage::tool_result(&call.id, &msg);
+                        if session_log.enabled() {
+                            session_log.record_message(steps, &tr);
+                        }
+                        messages.push(tr);
                     }
                     Err(e) => {
-                        messages.push(ChatMessage::tool_result(
-                            &call.id,
-                            format!("Callback error: {e}"),
-                        ));
+                        let tr =
+                            ChatMessage::tool_result(&call.id, format!("Callback error: {e}"));
+                        if session_log.enabled() {
+                            session_log.record_message(steps, &tr);
+                        }
+                        messages.push(tr);
                     }
                 }
             }
         }
+    }
+}
+
+/// Centralized exit path: writes the terminal `outcome` record to the
+/// session log and assembles the `AgentLoopOutcome`.
+fn finish(
+    session_log: &SessionLog,
+    steps: u32,
+    reason: LoopEndReason,
+    total_usage: TokenUsage,
+    tool_calls_dispatched: u32,
+    discoveries: Vec<serde_json::Value>,
+    tool_outputs: Vec<String>,
+) -> AgentLoopOutcome {
+    if session_log.enabled() {
+        let (label, detail) = describe_reason(&reason);
+        session_log.record_outcome(steps, label, detail);
+    }
+    AgentLoopOutcome {
+        reason,
+        total_usage,
+        steps,
+        tool_calls_dispatched,
+        discoveries,
+        tool_outputs,
+    }
+}
+
+fn describe_reason(reason: &LoopEndReason) -> (&'static str, serde_json::Value) {
+    match reason {
+        LoopEndReason::TaskComplete { task_id, result } => (
+            "TaskComplete",
+            serde_json::json!({"task_id": task_id, "result": result}),
+        ),
+        LoopEndReason::RequestAssistance { issue, context } => (
+            "RequestAssistance",
+            serde_json::json!({"issue": issue, "context": context}),
+        ),
+        LoopEndReason::MaxSteps => ("MaxSteps", serde_json::Value::Null),
+        LoopEndReason::EndTurn { content } => {
+            ("EndTurn", serde_json::json!({"content": content}))
+        }
+        LoopEndReason::MaxTokens => ("MaxTokens", serde_json::Value::Null),
+        LoopEndReason::BudgetExceeded { reason } => {
+            ("BudgetExceeded", serde_json::json!({"reason": reason}))
+        }
+        LoopEndReason::Error(err) => ("Error", serde_json::json!({"err": err})),
     }
 }

--- a/ares-llm/src/agent_loop/session_log.rs
+++ b/ares-llm/src/agent_loop/session_log.rs
@@ -338,4 +338,81 @@ mod tests {
         assert_eq!(replayed[1].role, Role::Assistant);
         assert_eq!(replayed[2].role, Role::User);
     }
+
+    #[test]
+    fn record_compaction_writes_event() {
+        let dir = tempdir().unwrap();
+        let cfg = SessionLogConfig {
+            dir: Some(dir.path().to_path_buf()),
+        };
+        let log = SessionLog::open(&cfg, "op-c", "t-c", "recon", "model");
+        log.record_compaction(7, "proactive", 60_000, 30_000);
+
+        let raw = std::fs::read_to_string(log.path()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(raw.trim()).unwrap();
+        assert_eq!(v["kind"], "compaction");
+        assert_eq!(v["step"], 7);
+        assert_eq!(v["data"]["kind"], "proactive");
+        assert_eq!(v["data"]["tokens_before"], 60_000);
+        assert_eq!(v["data"]["tokens_after"], 30_000);
+    }
+
+    #[test]
+    fn replay_skips_non_message_kinds() {
+        let dir = tempdir().unwrap();
+        let cfg = SessionLogConfig {
+            dir: Some(dir.path().to_path_buf()),
+        };
+        let log = SessionLog::open(&cfg, "op-r", "t-r", "recon", "m");
+        log.record_start("sys", "task", &[]);
+        log.record_message(1, &ChatMessage::text(Role::User, "hello"));
+        log.record_usage(
+            1,
+            &TokenUsage {
+                input_tokens: 1,
+                output_tokens: 2,
+                ..Default::default()
+            },
+        );
+        log.record_compaction(2, "reactive", 100, 50);
+        log.record_outcome(2, "EndTurn", serde_json::json!({}));
+
+        let replayed = replay_messages(log.path()).unwrap();
+        // Only the single user message is a replayable kind.
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].role, Role::User);
+    }
+
+    #[test]
+    fn replay_skips_unparsable_lines() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        // Mix valid + invalid lines + a record with unknown kind.
+        let mut f = std::fs::File::create(&path).unwrap();
+        use std::io::Write;
+        writeln!(f, "{{not json}}").unwrap();
+        writeln!(f).unwrap();
+        writeln!(
+            f,
+            r#"{{"ts":"t","op_id":"o","task_id":"t","role":"r","step":0,"model":"m","kind":"unknown","data":{{}}}}"#
+        )
+        .unwrap();
+        // A real user message
+        let msg = ChatMessage::text(Role::User, "real");
+        let entry = serde_json::json!({
+            "ts":"t","op_id":"o","task_id":"t","role":"r","step":1,"model":"m",
+            "kind":"user","data": serde_json::to_value(&msg).unwrap()
+        });
+        writeln!(f, "{entry}").unwrap();
+        drop(f);
+
+        let replayed = replay_messages(&path).unwrap();
+        assert_eq!(replayed.len(), 1);
+    }
+
+    #[test]
+    fn sanitize_collapses_empty_to_underscore() {
+        assert_eq!(sanitize(""), "_");
+        assert_eq!(sanitize("//"), "__");
+    }
 }

--- a/ares-llm/src/agent_loop/session_log.rs
+++ b/ares-llm/src/agent_loop/session_log.rs
@@ -1,0 +1,338 @@
+//! Append-only JSONL session log.
+//!
+//! Each agent loop invocation writes one record per turn (user prompt,
+//! assistant turn, tool result, terminal outcome) to
+//! `{dir}/{op_id}/{task_id}.jsonl`. The log is the source of truth for
+//! crash recovery and replay; the in-memory `Vec<ChatMessage>` is a cache.
+//!
+//! All write paths are best-effort: a failed disk write logs a warning
+//! but does not abort the agent loop. The session log is observability,
+//! not a hard requirement for correctness.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::Serialize;
+use tracing::warn;
+
+use super::config::SessionLogConfig;
+use crate::provider::{ChatMessage, ContentPart, Role, TokenUsage};
+
+/// A single line in the session log.
+#[derive(Debug, Serialize)]
+pub struct SessionLogEntry<'a> {
+    /// RFC3339 timestamp.
+    pub ts: String,
+    /// Operation ID (top-level Redis namespace).
+    pub op_id: &'a str,
+    /// Task ID within the operation.
+    pub task_id: &'a str,
+    /// Agent role (recon, lateral, ...).
+    pub role: &'a str,
+    /// Step counter (0 for boot/start, increments per LLM iteration).
+    pub step: u32,
+    /// Model identifier.
+    pub model: &'a str,
+    /// Event kind: `system_prompt`, `user`, `assistant`, `tool_result`,
+    /// `usage`, `compaction`, `outcome`.
+    pub kind: &'a str,
+    /// Free-form structured payload.
+    pub data: serde_json::Value,
+}
+
+/// Best-effort append-only writer for one task's session log.
+pub struct SessionLog {
+    path: PathBuf,
+    op_id: String,
+    task_id: String,
+    role: String,
+    model: String,
+    enabled: bool,
+}
+
+impl SessionLog {
+    /// Build a writer rooted at `config.dir/op_id/task_id.jsonl`. When the
+    /// config has no directory the writer is a no-op.
+    pub fn open(
+        config: &SessionLogConfig,
+        op_id: &str,
+        task_id: &str,
+        role: &str,
+        model: &str,
+    ) -> Self {
+        let Some(root) = config.dir.as_ref() else {
+            return Self::disabled(op_id, task_id, role, model);
+        };
+        let mut path = root.clone();
+        path.push(sanitize(op_id));
+        if let Err(e) = fs::create_dir_all(&path) {
+            warn!(error = %e, dir = %path.display(), "failed to create session log dir");
+            return Self::disabled(op_id, task_id, role, model);
+        }
+        path.push(format!("{}.jsonl", sanitize(task_id)));
+        Self {
+            path,
+            op_id: op_id.to_string(),
+            task_id: task_id.to_string(),
+            role: role.to_string(),
+            model: model.to_string(),
+            enabled: true,
+        }
+    }
+
+    fn disabled(op_id: &str, task_id: &str, role: &str, model: &str) -> Self {
+        Self {
+            path: PathBuf::new(),
+            op_id: op_id.to_string(),
+            task_id: task_id.to_string(),
+            role: role.to_string(),
+            model: model.to_string(),
+            enabled: false,
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn write_entry(&self, kind: &str, step: u32, data: serde_json::Value) {
+        if !self.enabled {
+            return;
+        }
+        let entry = SessionLogEntry {
+            ts: Utc::now().to_rfc3339(),
+            op_id: &self.op_id,
+            task_id: &self.task_id,
+            role: &self.role,
+            step,
+            model: &self.model,
+            kind,
+            data,
+        };
+        let line = match serde_json::to_string(&entry) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(error = %e, "failed to serialize session log entry");
+                return;
+            }
+        };
+        let mut file = match OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                warn!(error = %e, path = %self.path.display(), "failed to open session log");
+                return;
+            }
+        };
+        if let Err(e) = writeln!(file, "{line}") {
+            warn!(error = %e, path = %self.path.display(), "failed to append session log");
+            return;
+        }
+        // fsync is too expensive for hot-path turns; rely on append + OS
+        // buffering. On a hard crash we may lose the trailing few lines,
+        // which is the standard JSONL trade-off.
+        let _ = file.flush();
+    }
+
+    /// Boot record written at loop start.
+    pub fn record_start(&self, system_prompt: &str, task_prompt: &str, tools: &[String]) {
+        self.write_entry(
+            "start",
+            0,
+            serde_json::json!({
+                "system_prompt": system_prompt,
+                "task_prompt": task_prompt,
+                "tools": tools,
+            }),
+        );
+    }
+
+    /// One agent message (user / assistant / tool result).
+    pub fn record_message(&self, step: u32, msg: &ChatMessage) {
+        let kind = match msg.role {
+            Role::User => {
+                if has_tool_result(msg) {
+                    "tool_result"
+                } else {
+                    "user"
+                }
+            }
+            Role::Assistant => "assistant",
+            Role::Tool => "tool_result",
+            Role::System => "system",
+        };
+        let data = serde_json::to_value(msg).unwrap_or(serde_json::Value::Null);
+        self.write_entry(kind, step, data);
+    }
+
+    /// Per-call token usage.
+    pub fn record_usage(&self, step: u32, usage: &TokenUsage) {
+        self.write_entry(
+            "usage",
+            step,
+            serde_json::json!({
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+                "cache_read_input_tokens": usage.cache_read_input_tokens,
+            }),
+        );
+    }
+
+    /// A compaction event.
+    pub fn record_compaction(&self, step: u32, kind: &str, before: u32, after: u32) {
+        self.write_entry(
+            "compaction",
+            step,
+            serde_json::json!({
+                "kind": kind,
+                "tokens_before": before,
+                "tokens_after": after,
+            }),
+        );
+    }
+
+    /// Terminal outcome.
+    pub fn record_outcome(&self, step: u32, reason: &str, detail: serde_json::Value) {
+        self.write_entry(
+            "outcome",
+            step,
+            serde_json::json!({
+                "reason": reason,
+                "detail": detail,
+            }),
+        );
+    }
+}
+
+fn has_tool_result(msg: &ChatMessage) -> bool {
+    msg.parts
+        .as_ref()
+        .map(|p| p.iter().any(|p| matches!(p, ContentPart::ToolResult { .. })))
+        .unwrap_or(false)
+}
+
+/// Replace any character outside `[A-Za-z0-9._-]` with `_` so caller-supplied
+/// IDs are safe path segments (and not e.g. `..` or `/`).
+fn sanitize(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+            out.push(c);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        out.push('_');
+    }
+    out
+}
+
+/// Replay the messages from a previous session log, reconstructing the
+/// `Vec<ChatMessage>` portion. Returns the messages in order. Lines that
+/// cannot be parsed are skipped with a warning.
+pub fn replay_messages(path: &Path) -> std::io::Result<Vec<ChatMessage>> {
+    use std::io::{BufRead, BufReader};
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut out = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "skipping unparseable session log line");
+                continue;
+            }
+        };
+        let kind = value.get("kind").and_then(|k| k.as_str()).unwrap_or("");
+        if !matches!(kind, "user" | "assistant" | "tool_result" | "system") {
+            continue;
+        }
+        if let Some(data) = value.get("data") {
+            if let Ok(msg) = serde_json::from_value::<ChatMessage>(data.clone()) {
+                out.push(msg);
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sanitize_strips_path_separators() {
+        assert_eq!(sanitize("op-123"), "op-123");
+        assert_eq!(sanitize("../etc/passwd"), ".._etc_passwd");
+        assert_eq!(sanitize(""), "_");
+        assert_eq!(sanitize("a/b\\c"), "a_b_c");
+    }
+
+    #[test]
+    fn disabled_when_no_dir() {
+        let cfg = SessionLogConfig::default();
+        let log = SessionLog::open(&cfg, "op", "task", "recon", "model");
+        assert!(!log.enabled());
+        // No-op writes should not panic.
+        log.record_start("sys", "task", &[]);
+        log.record_outcome(0, "EndTurn", serde_json::json!({}));
+    }
+
+    #[test]
+    fn writes_jsonl_lines() {
+        let dir = tempdir().unwrap();
+        let cfg = SessionLogConfig {
+            dir: Some(dir.path().to_path_buf()),
+        };
+        let log = SessionLog::open(&cfg, "op-1", "t-1", "recon", "claude-sonnet-4-20250514");
+        assert!(log.enabled());
+        log.record_start("system", "do recon", &["nmap_scan".into()]);
+        log.record_message(1, &ChatMessage::text(Role::User, "go"));
+        log.record_message(1, &ChatMessage::text(Role::Assistant, "ok"));
+        log.record_message(2, &ChatMessage::tool_result("c1", "open ports: 22, 80"));
+        log.record_usage(
+            1,
+            &TokenUsage {
+                input_tokens: 100,
+                output_tokens: 20,
+                ..Default::default()
+            },
+        );
+        log.record_outcome(2, "EndTurn", serde_json::json!({"content": "done"}));
+
+        let path = log.path().to_path_buf();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = raw.lines().collect();
+        assert_eq!(lines.len(), 6);
+        for line in &lines {
+            let v: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(v["op_id"], "op-1");
+            assert_eq!(v["task_id"], "t-1");
+            assert_eq!(v["role"], "recon");
+            assert_eq!(v["model"], "claude-sonnet-4-20250514");
+            assert!(v.get("ts").is_some());
+        }
+        // Replay roundtrips just the message-shaped lines.
+        let replayed = replay_messages(&path).unwrap();
+        assert_eq!(replayed.len(), 3);
+        assert_eq!(replayed[0].role, Role::User);
+        assert_eq!(replayed[1].role, Role::Assistant);
+        assert_eq!(replayed[2].role, Role::User);
+    }
+}

--- a/ares-llm/src/agent_loop/session_log.rs
+++ b/ares-llm/src/agent_loop/session_log.rs
@@ -217,7 +217,10 @@ impl SessionLog {
 fn has_tool_result(msg: &ChatMessage) -> bool {
     msg.parts
         .as_ref()
-        .map(|p| p.iter().any(|p| matches!(p, ContentPart::ToolResult { .. })))
+        .map(|p| {
+            p.iter()
+                .any(|p| matches!(p, ContentPart::ToolResult { .. }))
+        })
         .unwrap_or(false)
 }
 
@@ -254,7 +257,7 @@ pub fn replay_messages(path: &Path) -> std::io::Result<Vec<ChatMessage>> {
         let value: serde_json::Value = match serde_json::from_str(&line) {
             Ok(v) => v,
             Err(e) => {
-                warn!(error = %e, "skipping unparseable session log line");
+                warn!(error = %e, "skipping unparsable session log line");
                 continue;
             }
         };

--- a/ares-llm/src/agent_loop/tests.rs
+++ b/ares-llm/src/agent_loop/tests.rs
@@ -200,6 +200,7 @@ fn trim_conversation_under_limit() {
         max_context_tokens: 1_000_000,
         max_tool_output_chars: 0,
         min_recent_messages: 10,
+        ..ContextConfig::default()
     };
     let original_len = messages.len();
     trim_conversation(&mut messages, "system", &[], &config);
@@ -216,6 +217,7 @@ fn trim_conversation_disabled() {
         max_context_tokens: 0, // Disabled
         max_tool_output_chars: 0,
         min_recent_messages: 10,
+        ..ContextConfig::default()
     };
     trim_conversation(&mut messages, "system", &[], &config);
     assert_eq!(messages.len(), 1);
@@ -241,6 +243,8 @@ fn trim_conversation_drops_middle() {
         max_context_tokens: 100, // Very low limit to force trimming
         max_tool_output_chars: 0,
         min_recent_messages: 4,
+        compaction_threshold_ratio: 1.0, // exercise the reactive ceiling path
+        compaction_check_every: 1,
     };
 
     trim_conversation(&mut messages, "system", &[], &config);
@@ -249,9 +253,9 @@ fn trim_conversation_drops_middle() {
     assert_eq!(messages.len(), 6);
     // First message preserved
     assert_eq!(messages[0].text_content().unwrap(), "task prompt");
-    // Summary marker inserted
+    // Compaction marker inserted (replaces older "Context trimmed" wording)
     assert!(messages[1]
         .text_content()
         .unwrap()
-        .contains("Context trimmed"));
+        .contains("Context compacted"));
 }

--- a/ares-llm/src/agent_loop/types.rs
+++ b/ares-llm/src/agent_loop/types.rs
@@ -96,6 +96,10 @@ pub enum LoopEndReason {
     EndTurn { content: String },
     /// LLM hit max_tokens.
     MaxTokens,
+    /// Cumulative token budget exceeded — circuit breaker tripped before
+    /// dispatching the next LLM call. Carries the human-readable reason
+    /// (e.g. "input token budget exhausted (12000 >= 10000)").
+    BudgetExceeded { reason: String },
     /// Error during execution.
     Error(String),
 }

--- a/ares-llm/src/lib.rs
+++ b/ares-llm/src/lib.rs
@@ -10,6 +10,7 @@ pub use provider::{
 };
 
 pub use agent_loop::{
-    run_agent_loop, AgentLoopConfig, AgentLoopOutcome, CallbackHandler, CallbackResult,
-    ContextConfig, HostnameMap, LoopEndReason, RetryConfig, ToolDispatcher, ToolExecResult,
+    replay_messages, run_agent_loop, AgentLoopConfig, AgentLoopOutcome, BudgetConfig,
+    CallbackHandler, CallbackResult, ContextConfig, HostnameMap, LoopEndReason, RetryConfig,
+    SessionLog, SessionLogConfig, ToolDispatcher, ToolExecResult,
 };

--- a/ares-llm/src/provider/anthropic.rs
+++ b/ares-llm/src/provider/anthropic.rs
@@ -37,8 +37,12 @@ struct ApiRequest {
     model: String,
     max_tokens: u32,
     messages: Vec<ApiMessage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<String>,
+    /// `system` is sent as an array of typed blocks when caching is enabled
+    /// (so we can attach `cache_control` to the trailing block) and as a
+    /// plain string otherwise. We always emit blocks for consistency — the
+    /// API accepts both forms but blocks are required for cache breakpoints.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    system: Vec<ApiSystemBlock>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<ApiTool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -77,10 +81,35 @@ enum ApiContentBlock {
 }
 
 #[derive(Serialize)]
+struct ApiSystemBlock {
+    #[serde(rename = "type")]
+    block_type: &'static str,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<ApiCacheControl>,
+}
+
+#[derive(Serialize)]
 struct ApiTool {
     name: String,
     description: String,
     input_schema: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<ApiCacheControl>,
+}
+
+#[derive(Serialize, Clone, Copy)]
+struct ApiCacheControl {
+    #[serde(rename = "type")]
+    cc_type: &'static str,
+}
+
+impl ApiCacheControl {
+    const fn ephemeral() -> Self {
+        Self {
+            cc_type: "ephemeral",
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -162,13 +191,45 @@ fn convert_message(msg: &ChatMessage) -> ApiMessage {
     }
 }
 
-fn convert_tools(tools: &[super::ToolDefinition]) -> Vec<ApiTool> {
+/// Build the system blocks for the request, attaching a single ephemeral
+/// cache breakpoint to the final block when caching is enabled. The system
+/// prompt is the longest stable prefix in our agent loops, so this is the
+/// highest-leverage cache hit.
+fn build_system_blocks(system: Option<&str>, cache: bool) -> Vec<ApiSystemBlock> {
+    let Some(text) = system else {
+        return Vec::new();
+    };
+    if text.is_empty() {
+        return Vec::new();
+    }
+    vec![ApiSystemBlock {
+        block_type: "text",
+        text: text.to_string(),
+        cache_control: cache.then(ApiCacheControl::ephemeral),
+    }]
+}
+
+/// Convert tool definitions, attaching a cache breakpoint to the *last*
+/// tool when caching is enabled. A breakpoint at the tail of the tools
+/// array caches the entire stable prefix (system + tools); subsequent
+/// requests with the same definitions read from cache.
+fn convert_tools(tools: &[super::ToolDefinition], cache: bool) -> Vec<ApiTool> {
+    let last_idx = tools.len().checked_sub(1);
     tools
         .iter()
-        .map(|t| ApiTool {
-            name: t.name.clone(),
-            description: t.description.clone(),
-            input_schema: t.input_schema.clone(),
+        .enumerate()
+        .map(|(i, t)| {
+            let cc = if cache && Some(i) == last_idx {
+                Some(ApiCacheControl::ephemeral())
+            } else {
+                None
+            };
+            ApiTool {
+                name: t.name.clone(),
+                description: t.description.clone(),
+                input_schema: t.input_schema.clone(),
+                cache_control: cc,
+            }
         })
         .collect()
 }
@@ -197,8 +258,8 @@ impl LlmProvider for AnthropicProvider {
             model: request.model.clone(),
             max_tokens: request.max_tokens,
             messages,
-            system: request.system.clone(),
-            tools: convert_tools(&request.tools),
+            system: build_system_blocks(request.system.as_deref(), request.enable_prompt_cache),
+            tools: convert_tools(&request.tools, request.enable_prompt_cache),
             temperature: request.temperature,
         };
 
@@ -206,6 +267,7 @@ impl LlmProvider for AnthropicProvider {
             model = %request.model,
             msg_count = request.messages.len(),
             tool_count = request.tools.len(),
+            cache = request.enable_prompt_cache,
             "Anthropic API request"
         );
 
@@ -286,6 +348,8 @@ impl LlmProvider for AnthropicProvider {
         debug!(
             input_tokens = usage.input_tokens,
             output_tokens = usage.output_tokens,
+            cache_creation = usage.cache_creation_input_tokens,
+            cache_read = usage.cache_read_input_tokens,
             tool_calls = tool_calls.len(),
             stop = ?stop_reason,
             "Anthropic API response"
@@ -354,7 +418,7 @@ mod tests {
     }
 
     #[test]
-    fn converts_tools() {
+    fn converts_tools_no_cache() {
         let tools = vec![super::super::ToolDefinition {
             name: "nmap_scan".into(),
             description: "Run nmap".into(),
@@ -364,9 +428,55 @@ mod tests {
                 "required": ["target"]
             }),
         }];
-        let api_tools = convert_tools(&tools);
+        let api_tools = convert_tools(&tools, false);
         assert_eq!(api_tools.len(), 1);
         assert_eq!(api_tools[0].name, "nmap_scan");
+        // No cache_control when caching disabled.
+        let json = serde_json::to_value(&api_tools[0]).unwrap();
+        assert!(json.get("cache_control").is_none());
+    }
+
+    #[test]
+    fn converts_tools_cache_breakpoint_on_last() {
+        let tools = vec![
+            super::super::ToolDefinition {
+                name: "tool_a".into(),
+                description: "first".into(),
+                input_schema: serde_json::json!({}),
+            },
+            super::super::ToolDefinition {
+                name: "tool_b".into(),
+                description: "second".into(),
+                input_schema: serde_json::json!({}),
+            },
+        ];
+        let api_tools = convert_tools(&tools, true);
+        let first = serde_json::to_value(&api_tools[0]).unwrap();
+        let last = serde_json::to_value(&api_tools[1]).unwrap();
+        assert!(first.get("cache_control").is_none());
+        assert_eq!(last["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn build_system_blocks_with_cache() {
+        let blocks = build_system_blocks(Some("you are a recon agent"), true);
+        assert_eq!(blocks.len(), 1);
+        let json = serde_json::to_value(&blocks[0]).unwrap();
+        assert_eq!(json["type"], "text");
+        assert_eq!(json["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn build_system_blocks_without_cache() {
+        let blocks = build_system_blocks(Some("hello"), false);
+        let json = serde_json::to_value(&blocks[0]).unwrap();
+        assert!(json.get("cache_control").is_none());
+    }
+
+    #[test]
+    fn build_system_blocks_empty() {
+        assert!(build_system_blocks(None, true).is_empty());
+        assert!(build_system_blocks(Some(""), true).is_empty());
     }
 
     #[test]
@@ -385,7 +495,7 @@ mod tests {
     }
 
     #[test]
-    fn serialize_api_request() {
+    fn serialize_api_request_with_cache() {
         let req = ApiRequest {
             model: "claude-sonnet-4-20250514".to_string(),
             max_tokens: 4096,
@@ -393,13 +503,29 @@ mod tests {
                 role: "user".to_string(),
                 content: ApiContent::Text("hello".to_string()),
             }],
-            system: Some("You are a recon agent.".to_string()),
+            system: build_system_blocks(Some("You are a recon agent."), true),
             tools: vec![],
             temperature: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["model"], "claude-sonnet-4-20250514");
-        assert_eq!(json["system"], "You are a recon agent.");
-        assert!(json.get("tools").is_none()); // empty vec skipped
+        assert!(json["system"].is_array());
+        assert_eq!(json["system"][0]["text"], "You are a recon agent.");
+        assert_eq!(json["system"][0]["cache_control"]["type"], "ephemeral");
+        assert!(json.get("tools").is_none());
+    }
+
+    #[test]
+    fn serialize_api_request_no_cache_no_breakpoints() {
+        let req = ApiRequest {
+            model: "claude-sonnet-4-20250514".to_string(),
+            max_tokens: 4096,
+            messages: vec![],
+            system: build_system_blocks(Some("hi"), false),
+            tools: vec![],
+            temperature: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json["system"][0].get("cache_control").is_none());
     }
 }

--- a/ares-llm/src/provider/mod.rs
+++ b/ares-llm/src/provider/mod.rs
@@ -212,6 +212,10 @@ pub struct LlmRequest {
     pub tools: Vec<ToolDefinition>,
     pub max_tokens: u32,
     pub temperature: Option<f32>,
+    /// Hint to providers that support prompt caching (Anthropic) to attach
+    /// a cache breakpoint to the stable prefix (system + tools). Other
+    /// providers ignore this flag.
+    pub enable_prompt_cache: bool,
 }
 
 impl LlmRequest {
@@ -223,6 +227,7 @@ impl LlmRequest {
             tools: Vec::new(),
             max_tokens: 4096,
             temperature: None,
+            enable_prompt_cache: false,
         }
     }
 }

--- a/ares-llm/tests/integration_agent_loop.rs
+++ b/ares-llm/tests/integration_agent_loop.rs
@@ -92,8 +92,10 @@ fn default_config(max_steps: u32) -> AgentLoopConfig {
             max_context_tokens: 0,    // No limit in tests by default
             max_tool_output_chars: 0, // No truncation in tests
             min_recent_messages: 10,
+            ..ares_llm::agent_loop::ContextConfig::default()
         },
         max_tool_calls_per_name: 10,
+        ..AgentLoopConfig::default()
     }
 }
 


### PR DESCRIPTION
**Key Changes:**

- Introduced token budget circuit breaker to halt agent loop when cumulative input/output token limits are exceeded
- Added append-only JSONL session log for crash recovery and debugging
- Enhanced context compaction with proactive and reactive trimming and semantic recap
- Exposed new configuration options for budget, logging, and prompt cache through environment variables

**Added:**

- Token budget enforcement (`BudgetConfig`) that ends loops with `BudgetExceeded` reason when input, output, or total token budgets are reached; configurable via env vars
- Append-only JSONL session log (`SessionLog` and `SessionLogConfig`) that records all conversation events, tool results, usage stats, and outcomes for each agent loop in a crash-tolerant manner
- Proactive context compaction logic, including semantic recap of trimmed messages, with configurability for compaction cadence and thresholds
- New public exports for session logging and budget configs in agent loop modules and library root

**Changed:**

- Agent loop runner now checks token budgets each iteration and exits early if limits are exceeded
- Context compaction upgraded to support both proactive (threshold-based) and reactive (hard ceiling) trimming, with detailed logging and semantic recaps of dropped content
- Anthropic provider now attaches prompt-cache breakpoints to system/tool blocks when enabled, improving cache hit rates and efficiency
- Configuration loading for agent loop now layers environment variable overrides on top of defaults for agent, context, budget, and session log settings
- All agent loop terminal paths (success, error, budget, assistance) now consistently log outcomes to the session log if enabled

**Removed:**

- Previous static context trimming that lacked proactive compaction and semantic recaps
- Unused or redundant context compaction code paths in favor of unified `maybe_compact` and semantic recap mechanism