### PR TITLE
feat: add systemd memory and OOM protection for SSM agent and Redis worker

### DIFF
--- a/ansible/roles/aws_ssm_agent/README.md
+++ b/ansible/roles/aws_ssm_agent/README.md
@@ -18,6 +18,8 @@ Install and configure AWS SSM Agent
 | -------- | ---- | ------- | ----------- |
 | `aws_ssm_agent_temp_dir` | str | <code>/tmp/ssm_install</code> | No description |
 | `aws_ssm_agent_aws_region` | str | <code>us-east-1</code> | No description |
+| `aws_ssm_agent_oom_protect` | bool | <code>True</code> | No description |
+| `aws_ssm_agent_memory_max` | str | <code>512M</code> | No description |
 
 ### Role Variables (main.yml)
 
@@ -42,6 +44,8 @@ Install and configure AWS SSM Agent
 - **Create temporary directory for SSM installation** (ansible.builtin.file) - Conditional
 - **Download SSM agent** (ansible.builtin.get_url) - Conditional
 - **Install SSM agent (Debian/Ubuntu)** (ansible.builtin.apt) - Conditional
+- **Create SSM agent systemd override directory** (ansible.builtin.file) - Conditional
+- **Deploy SSM agent OOM protection override** (ansible.builtin.template) - Conditional
 - **Reload systemd** (ansible.builtin.systemd) - Conditional
 - **Enable and start SSM agent** (ansible.builtin.systemd) - Conditional
 - **Refresh snap SSM agent** (ansible.builtin.command) - Conditional

--- a/ansible/roles/aws_ssm_agent/defaults/main.yml
+++ b/ansible/roles/aws_ssm_agent/defaults/main.yml
@@ -2,3 +2,8 @@
 # General settings
 aws_ssm_agent_temp_dir: "/tmp/ssm_install"
 aws_ssm_agent_aws_region: "us-east-1"
+
+# OOM protection — cap SSM agent memory and lower its OOM score so the kernel
+# kills worker tool processes (netexec, hashcat, nmap) instead of SSM.
+aws_ssm_agent_oom_protect: true
+aws_ssm_agent_memory_max: "512M"

--- a/ansible/roles/aws_ssm_agent/tasks/linux.yml
+++ b/ansible/roles/aws_ssm_agent/tasks/linux.yml
@@ -68,6 +68,28 @@
     - aws_ssm_agent_snap_check.rc != 0
     - aws_ssm_agent_dpkg_check.rc != 0
 
+- name: Create SSM agent systemd override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/amazon-ssm-agent.service.d
+    state: directory
+    mode: '0755'
+  become: true
+  when:
+    - aws_ssm_agent_snap_check.rc != 0
+    - aws_ssm_agent_oom_protect | default(true)
+
+- name: Deploy SSM agent OOM protection override
+  ansible.builtin.template:
+    src: ssm-oom-protect.conf.j2
+    dest: /etc/systemd/system/amazon-ssm-agent.service.d/oom-protect.conf
+    mode: '0644'
+  become: true
+  when:
+    - aws_ssm_agent_snap_check.rc != 0
+    - aws_ssm_agent_oom_protect | default(true)
+  notify:
+    - Restart ssm_agent (Linux)
+
 - name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true

--- a/ansible/roles/aws_ssm_agent/templates/ssm-oom-protect.conf.j2
+++ b/ansible/roles/aws_ssm_agent/templates/ssm-oom-protect.conf.j2
@@ -1,0 +1,7 @@
+# Protect SSM agent from the OOM killer.
+# Ares workers spawn many tool subprocesses (netexec, hashcat, nmap) that can
+# exhaust memory. Without this override, the OOM killer targets the SSM agent's
+# cgroup and kills it, making the instance unreachable.
+[Service]
+OOMScoreAdjust=-900
+MemoryMax={{ aws_ssm_agent_memory_max }}

--- a/ansible/roles/aws_ssm_agent/templates/ssm-oom-protect.conf.j2
+++ b/ansible/roles/aws_ssm_agent/templates/ssm-oom-protect.conf.j2
@@ -1,7 +1,8 @@
-# Protect SSM agent from the OOM killer.
-# Ares workers spawn many tool subprocesses (netexec, hashcat, nmap) that can
-# exhaust memory. Without this override, the OOM killer targets the SSM agent's
-# cgroup and kills it, making the instance unreachable.
+# OOMScoreAdjust: survive system-wide OOM when Ares workers exhaust memory.
+# Children (RunCommand, Session Manager) inherit this — fine here since heavy
+# subprocesses run under a separate unit.
+# MemoryMax: cgroup self-cap (containment for SSM leaks). Cgroup-local OOM
+# ignores OOMScoreAdjust, so the two are independent protections.
 [Service]
 OOMScoreAdjust=-900
 MemoryMax={{ aws_ssm_agent_memory_max }}

--- a/ansible/roles/privesc_tools/README.md
+++ b/ansible/roles/privesc_tools/README.md
@@ -194,6 +194,7 @@ Install and configure privilege escalation tools for Ares agents
 - **Clone SCMUACBypass from GitHub** (ansible.builtin.git) - Conditional
 - **Clone noPac from GitHub** (ansible.builtin.git) - Conditional
 - **Create virtual environment for noPac** (ansible.builtin.command) - Conditional
+- **Install setuptools in noPac venv (provides pkg_resources)** (ansible.builtin.pip) - Conditional
 - **Install noPac dependencies in venv** (ansible.builtin.pip) - Conditional
 - **Create wrapper script for noPac** (ansible.builtin.copy) - Conditional
 - **Clone PrintNightmare from GitHub** (ansible.builtin.git) - Conditional

--- a/ansible/roles/privesc_tools/tasks/linux.yml
+++ b/ansible/roles/privesc_tools/tasks/linux.yml
@@ -297,6 +297,14 @@
     creates: "{{ privesc_tools_nopac_install_dir }}/venv"
   when: privesc_tools_install_nopac
 
+- name: Install setuptools in noPac venv (provides pkg_resources)
+  ansible.builtin.pip:
+    # setuptools 81 dropped pkg_resources; impacket 0.9.24 still imports it.
+    name: "setuptools<81"
+    virtualenv: "{{ privesc_tools_nopac_install_dir }}/venv"
+  become: true
+  when: privesc_tools_install_nopac
+
 - name: Install noPac dependencies in venv
   ansible.builtin.pip:
     requirements: "{{ privesc_tools_nopac_install_dir }}/requirements.txt"

--- a/ansible/roles/redis/README.md
+++ b/ansible/roles/redis/README.md
@@ -24,6 +24,9 @@ Redis server for Ares worker message broker
 | `redis_ares_worker_binary` | str | <code>/usr/local/bin/ares</code> | No description |
 | `redis_ares_log_dir` | str | <code>/var/log/ares</code> | No description |
 | `redis_ares_config_dir` | str | <code>/etc/ares</code> | No description |
+| `redis_ares_worker_memory_high` | str | <code>2G</code> | No description |
+| `redis_ares_worker_memory_max` | str | <code>3G</code> | No description |
+| `redis_ares_worker_tasks_max` | int | <code>256</code> | No description |
 | `redis_verify_install` | bool | <code>False</code> | No description |
 
 ## Tasks

--- a/ansible/roles/redis/defaults/main.yml
+++ b/ansible/roles/redis/defaults/main.yml
@@ -11,5 +11,13 @@ redis_ares_worker_binary: "/usr/local/bin/ares"
 redis_ares_log_dir: "/var/log/ares"
 redis_ares_config_dir: "/etc/ares"
 
+# Worker cgroup resource limits (per-role instance).
+# Workers spawn tool subprocesses (netexec, hashcat, nmap) that inherit the
+# service cgroup. Without limits these can exhaust system memory and OOM-kill
+# unrelated services like the SSM agent.
+redis_ares_worker_memory_high: "2G"
+redis_ares_worker_memory_max: "3G"
+redis_ares_worker_tasks_max: 256
+
 # Verification
 redis_verify_install: false

--- a/ansible/roles/redis/templates/ares@.service.j2
+++ b/ansible/roles/redis/templates/ares@.service.j2
@@ -15,5 +15,13 @@ RestartSec=5
 StandardOutput=append:{{ redis_ares_log_dir }}/%i.log
 StandardError=append:{{ redis_ares_log_dir }}/%i.log
 
+# Contain child processes (netexec, hashcat, nmap, etc.) within this cgroup.
+# Without these limits, runaway tool processes can OOM the entire system and
+# take down the SSM agent (see: Apr 2026 incident).
+Delegate=yes
+MemoryHigh={{ redis_ares_worker_memory_high }}
+MemoryMax={{ redis_ares_worker_memory_max }}
+TasksMax={{ redis_ares_worker_tasks_max }}
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Key Changes:**

- Added systemd overrides to protect AWS SSM agent from OOM killer and cap its memory usage
- Introduced cgroup resource limits for Redis worker processes to prevent system memory exhaustion
- Ensured compatibility of noPac tool dependencies by pinning setuptools version in its virtual environment

**Added:**

- Systemd OOM protection template for SSM agent (`ssm-oom-protect.conf.j2`) and related Ansible tasks to deploy it, including variables for enabling protection and setting memory limits
- Role variables for Redis worker service memory and task limits (`redis_ares_worker_memory_high`, `redis_ares_worker_memory_max`, `redis_ares_worker_tasks_max`) with defaults and documentation
- Task to install a compatible version of setuptools in the noPac virtual environment to provide `pkg_resources` for impacket

**Changed:**

- Updated AWS SSM Agent role documentation and defaults to describe and enable OOM protection, including new variables and tasks for systemd overrides
- Modified Redis worker systemd service template to apply memory and task limits, and updated documentation and defaults to reflect these changes
- Updated noPac installation workflow to ensure `pkg_resources` is available by explicitly installing `setuptools<81` before installing requirements