### PR TITLE
feat: add CLI commands for inspecting and replaying session logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/ares-cli/Cargo.toml
+++ b/ares-cli/Cargo.toml
@@ -40,4 +40,5 @@ serde_yaml = "0.9"
 [dev-dependencies]
 tokio = { workspace = true }
 rstest = "0.26"
+tempfile = "3"
 ares-core = { path = "../ares-core", features = ["test-utils", "blue", "telemetry"] }

--- a/ares-cli/src/cli/mod.rs
+++ b/ares-cli/src/cli/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod blue;
 
 pub(crate) use config::ConfigCommands;
 pub(crate) use history::HistoryCommands;
-pub(crate) use ops::OpsCommands;
+pub(crate) use ops::{OpsCommands, SessionsCommands};
 
 #[cfg(feature = "blue")]
 pub(crate) use blue::BlueCommands;

--- a/ares-cli/src/cli/ops.rs
+++ b/ares-cli/src/cli/ops.rs
@@ -1,6 +1,37 @@
 use clap::Subcommand;
 
 #[derive(Subcommand)]
+pub(crate) enum SessionsCommands {
+    /// List operation IDs (and optionally task IDs) that have session logs
+    List {
+        /// Operation ID; when set, lists task IDs under that operation
+        operation_id: Option<String>,
+    },
+
+    /// Print a session log file (raw JSONL or pretty-printed)
+    Show {
+        /// Operation ID
+        operation_id: String,
+        /// Task ID
+        task_id: String,
+        /// Pretty-print each event instead of raw JSONL
+        #[arg(long)]
+        pretty: bool,
+    },
+
+    /// Replay the conversation messages from a session log
+    Replay {
+        /// Operation ID
+        operation_id: String,
+        /// Task ID
+        task_id: String,
+        /// Output as JSON array instead of human-readable transcript
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
 pub(crate) enum OpsCommands {
     /// List all operations
     List {
@@ -250,6 +281,12 @@ pub(crate) enum OpsCommands {
         /// Max age in hours
         #[arg(long, default_value = "24")]
         max_age_hours: u64,
+    },
+
+    /// Inspect or replay JSONL session logs from the agent loop
+    Sessions {
+        #[command(subcommand)]
+        cmd: SessionsCommands,
     },
 
     /// Persist token usage from Redis to PostgreSQL for an operation

--- a/ares-cli/src/ops/mod.rs
+++ b/ares-cli/src/ops/mod.rs
@@ -12,6 +12,7 @@ mod queue;
 mod report;
 pub(crate) mod resolve;
 mod runtime;
+mod sessions;
 mod status;
 mod stop;
 pub(crate) mod submit;
@@ -185,6 +186,7 @@ pub(crate) async fn run_ops(cmd: OpsCommands, redis_url: Option<String>) -> Resu
         OpsCommands::Cleanup { max_age_hours } => {
             delete::ops_cleanup(redis_url, max_age_hours).await
         }
+        OpsCommands::Sessions { cmd } => sessions::run_sessions(cmd).await,
         #[cfg(feature = "blue")]
         OpsCommands::Correlate {
             reports_dir,

--- a/ares-cli/src/ops/sessions.rs
+++ b/ares-cli/src/ops/sessions.rs
@@ -62,7 +62,10 @@ fn list_operation_ids(root: &Path) -> Result<()> {
 fn list_task_ids(root: &Path, op_id: &str) -> Result<()> {
     let dir = root.join(op_id);
     if !dir.exists() {
-        return Err(anyhow!("no session logs for operation {op_id} at {}", dir.display()));
+        return Err(anyhow!(
+            "no session logs for operation {op_id} at {}",
+            dir.display()
+        ));
     }
     let mut entries: Vec<(String, u64)> = std::fs::read_dir(&dir)
         .with_context(|| format!("reading {}", dir.display()))?
@@ -105,8 +108,8 @@ fn sessions_show(op_id: &str, task_id: &str, pretty: bool) -> Result<()> {
                 let ts = v.get("ts").and_then(|t| t.as_str()).unwrap_or("?");
                 println!("[{ts}] step={step} kind={kind}");
                 if let Some(data) = v.get("data") {
-                    let pretty_data = serde_json::to_string_pretty(data)
-                        .unwrap_or_else(|_| data.to_string());
+                    let pretty_data =
+                        serde_json::to_string_pretty(data).unwrap_or_else(|_| data.to_string());
                     for ln in pretty_data.lines() {
                         println!("    {ln}");
                     }
@@ -167,8 +170,8 @@ fn print_message(index: usize, msg: &ChatMessage) {
                     content,
                 } => println!("<tool_result id={tool_use_id}>\n{content}"),
                 ContentPart::ToolUse { id, name, input } => {
-                    let pretty = serde_json::to_string_pretty(input)
-                        .unwrap_or_else(|_| input.to_string());
+                    let pretty =
+                        serde_json::to_string_pretty(input).unwrap_or_else(|_| input.to_string());
                     println!("<tool_use id={id} name={name}>\n{pretty}");
                 }
             }

--- a/ares-cli/src/ops/sessions.rs
+++ b/ares-cli/src/ops/sessions.rs
@@ -1,0 +1,258 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+
+use ares_llm::{replay_messages, ChatMessage, ContentPart, Role, SessionLogConfig};
+
+use crate::cli::SessionsCommands;
+
+pub(crate) async fn run_sessions(cmd: SessionsCommands) -> Result<()> {
+    match cmd {
+        SessionsCommands::List { operation_id } => sessions_list(operation_id),
+        SessionsCommands::Show {
+            operation_id,
+            task_id,
+            pretty,
+        } => sessions_show(&operation_id, &task_id, pretty),
+        SessionsCommands::Replay {
+            operation_id,
+            task_id,
+            json,
+        } => sessions_replay(&operation_id, &task_id, json),
+    }
+}
+
+fn session_root() -> Result<PathBuf> {
+    SessionLogConfig::default_root()
+        .ok_or_else(|| anyhow!("session log root unset (set ARES_SESSION_LOG_DIR or HOME)"))
+}
+
+fn sessions_list(operation_id: Option<String>) -> Result<()> {
+    let root = session_root()?;
+    if !root.exists() {
+        println!("No session logs at {}", root.display());
+        return Ok(());
+    }
+
+    match operation_id {
+        None => list_operation_ids(&root),
+        Some(op_id) => list_task_ids(&root, &op_id),
+    }
+}
+
+fn list_operation_ids(root: &Path) -> Result<()> {
+    let mut entries: Vec<String> = std::fs::read_dir(root)
+        .with_context(|| format!("reading session log root {}", root.display()))?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+    entries.sort();
+    if entries.is_empty() {
+        println!("No session logs at {}", root.display());
+        return Ok(());
+    }
+    println!("Operations with session logs ({}):", root.display());
+    for op_id in entries {
+        println!("  {op_id}");
+    }
+    Ok(())
+}
+
+fn list_task_ids(root: &Path, op_id: &str) -> Result<()> {
+    let dir = root.join(op_id);
+    if !dir.exists() {
+        return Err(anyhow!("no session logs for operation {op_id} at {}", dir.display()));
+    }
+    let mut entries: Vec<(String, u64)> = std::fs::read_dir(&dir)
+        .with_context(|| format!("reading {}", dir.display()))?
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().into_string().ok()?;
+            let stem = name.strip_suffix(".jsonl")?.to_string();
+            let size = e.metadata().ok()?.len();
+            Some((stem, size))
+        })
+        .collect();
+    entries.sort();
+    if entries.is_empty() {
+        println!("No session logs for operation {op_id}");
+        return Ok(());
+    }
+    println!("Tasks for {op_id}:");
+    for (task_id, size) in entries {
+        println!("  {task_id}  ({size} bytes)");
+    }
+    Ok(())
+}
+
+fn sessions_show(op_id: &str, task_id: &str, pretty: bool) -> Result<()> {
+    let path = session_path(op_id, task_id)?;
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading session log {}", path.display()))?;
+    if !pretty {
+        print!("{raw}");
+        return Ok(());
+    }
+    for line in raw.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(v) => {
+                let kind = v.get("kind").and_then(|k| k.as_str()).unwrap_or("?");
+                let step = v.get("step").and_then(|s| s.as_u64()).unwrap_or(0);
+                let ts = v.get("ts").and_then(|t| t.as_str()).unwrap_or("?");
+                println!("[{ts}] step={step} kind={kind}");
+                if let Some(data) = v.get("data") {
+                    let pretty_data = serde_json::to_string_pretty(data)
+                        .unwrap_or_else(|_| data.to_string());
+                    for ln in pretty_data.lines() {
+                        println!("    {ln}");
+                    }
+                }
+            }
+            Err(_) => println!("[unparsable] {line}"),
+        }
+    }
+    Ok(())
+}
+
+fn sessions_replay(op_id: &str, task_id: &str, json: bool) -> Result<()> {
+    let path = session_path(op_id, task_id)?;
+    let messages = replay_messages(&path)
+        .with_context(|| format!("replaying session log {}", path.display()))?;
+    if json {
+        let out = serde_json::to_string_pretty(&messages)?;
+        println!("{out}");
+        return Ok(());
+    }
+    if messages.is_empty() {
+        println!("No replayable messages in {}", path.display());
+        return Ok(());
+    }
+    for (i, msg) in messages.iter().enumerate() {
+        print_message(i, msg);
+    }
+    Ok(())
+}
+
+fn session_path(op_id: &str, task_id: &str) -> Result<PathBuf> {
+    let root = session_root()?;
+    let mut path = root.join(op_id);
+    path.push(format!("{task_id}.jsonl"));
+    if !path.exists() {
+        return Err(anyhow!("no session log at {}", path.display()));
+    }
+    Ok(path)
+}
+
+fn print_message(index: usize, msg: &ChatMessage) {
+    let role = match msg.role {
+        Role::System => "system",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    };
+    println!("--- [{index}] {role} ---");
+    if let Some(text) = msg.content.as_deref() {
+        println!("{text}");
+    }
+    if let Some(parts) = msg.parts.as_ref() {
+        for part in parts {
+            match part {
+                ContentPart::Text { text } => println!("{text}"),
+                ContentPart::ToolResult {
+                    tool_use_id,
+                    content,
+                } => println!("<tool_result id={tool_use_id}>\n{content}"),
+                ContentPart::ToolUse { id, name, input } => {
+                    let pretty = serde_json::to_string_pretty(input)
+                        .unwrap_or_else(|_| input.to_string());
+                    println!("<tool_use id={id} name={name}>\n{pretty}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ares_llm::SessionLog;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    /// Serializes tests that mutate `ARES_SESSION_LOG_DIR` so the parallel
+    /// scheduler does not interleave them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_root<F: FnOnce(&Path) -> Result<()>>(f: F) -> Result<()> {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = tempdir().unwrap();
+        let prev_dir = std::env::var_os("ARES_SESSION_LOG_DIR");
+        std::env::set_var("ARES_SESSION_LOG_DIR", dir.path());
+        let result = f(dir.path());
+        match prev_dir {
+            Some(v) => std::env::set_var("ARES_SESSION_LOG_DIR", v),
+            None => std::env::remove_var("ARES_SESSION_LOG_DIR"),
+        }
+        result
+    }
+
+    fn write_session(root: &Path, op_id: &str, task_id: &str) {
+        let cfg = SessionLogConfig {
+            dir: Some(root.to_path_buf()),
+        };
+        let log = SessionLog::open(&cfg, op_id, task_id, "recon", "test-model");
+        log.record_start("sys", "task", &[]);
+        log.record_message(1, &ChatMessage::text(Role::User, "hello"));
+        log.record_message(1, &ChatMessage::text(Role::Assistant, "hi"));
+        log.record_outcome(1, "EndTurn", serde_json::json!({}));
+    }
+
+    #[test]
+    fn list_operations_finds_jsonl_dirs() {
+        with_root(|root| {
+            write_session(root, "op-aaa", "task-1");
+            write_session(root, "op-bbb", "task-2");
+            sessions_list(None)?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn list_tasks_for_operation_errors_when_missing() {
+        with_root(|_root| {
+            let err = sessions_list(Some("nope".into())).unwrap_err();
+            assert!(err.to_string().contains("nope"));
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn replay_returns_user_and_assistant_messages() {
+        with_root(|root| {
+            write_session(root, "op-x", "task-x");
+            // exercise both replay and show paths
+            sessions_replay("op-x", "task-x", false)?;
+            sessions_replay("op-x", "task-x", true)?;
+            sessions_show("op-x", "task-x", true)?;
+            sessions_show("op-x", "task-x", false)?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn show_missing_session_errors() {
+        with_root(|_root| {
+            let err = sessions_show("op-missing", "task", false).unwrap_err();
+            assert!(err.to_string().contains("no session log"));
+            Ok(())
+        })
+        .unwrap();
+    }
+}

--- a/ares-llm/src/agent_loop/config.rs
+++ b/ares-llm/src/agent_loop/config.rs
@@ -222,6 +222,7 @@ impl SessionLogConfig {
     /// Construct from env vars:
     /// - `ARES_SESSION_LOG_DIR` (explicit path; takes precedence)
     /// - `ARES_SESSION_LOG_ENABLED=0` opts out (default is enabled)
+    ///
     /// When enabled with no explicit dir, defaults to `~/.ares/sessions`.
     pub fn from_env() -> Self {
         if let Ok(dir) = std::env::var("ARES_SESSION_LOG_DIR") {

--- a/ares-llm/src/agent_loop/config.rs
+++ b/ares-llm/src/agent_loop/config.rs
@@ -221,7 +221,8 @@ pub struct SessionLogConfig {
 impl SessionLogConfig {
     /// Construct from env vars:
     /// - `ARES_SESSION_LOG_DIR` (explicit path; takes precedence)
-    /// - `ARES_SESSION_LOG_ENABLED=1` enables a default `~/.ares/sessions` path
+    /// - `ARES_SESSION_LOG_ENABLED=0` opts out (default is enabled)
+    /// When enabled with no explicit dir, defaults to `~/.ares/sessions`.
     pub fn from_env() -> Self {
         if let Ok(dir) = std::env::var("ARES_SESSION_LOG_DIR") {
             if !dir.trim().is_empty() {
@@ -230,7 +231,7 @@ impl SessionLogConfig {
                 };
             }
         }
-        if parse_env_bool("ARES_SESSION_LOG_ENABLED", false) {
+        if parse_env_bool("ARES_SESSION_LOG_ENABLED", true) {
             if let Some(home) = std::env::var_os("HOME") {
                 let mut p = PathBuf::from(home);
                 p.push(".ares");
@@ -239,6 +240,23 @@ impl SessionLogConfig {
             }
         }
         Self { dir: None }
+    }
+
+    /// Default session-log root used when `ARES_SESSION_LOG_DIR` is unset.
+    /// Mirrors the path resolution in `from_env` so external callers (e.g.
+    /// the `ares ops sessions` CLI) can find logs without re-implementing
+    /// the lookup. Returns `None` when `HOME` is unset.
+    pub fn default_root() -> Option<PathBuf> {
+        if let Ok(dir) = std::env::var("ARES_SESSION_LOG_DIR") {
+            if !dir.trim().is_empty() {
+                return Some(PathBuf::from(dir));
+            }
+        }
+        let home = std::env::var_os("HOME")?;
+        let mut p = PathBuf::from(home);
+        p.push(".ares");
+        p.push("sessions");
+        Some(p)
     }
 
     pub fn enabled(&self) -> bool {
@@ -302,6 +320,11 @@ fn parse_env_bool(key: &str, default: bool) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate ARES_SESSION_LOG_* / HOME to keep
+    /// `cargo test`'s parallel scheduler from observing partial states.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn agent_loop_config_defaults() {
@@ -493,8 +516,16 @@ mod tests {
         std::env::remove_var("ARES_CONTEXT_MIN_RECENT_MESSAGES");
     }
 
+    // Consolidated to avoid cross-test races on the shared ARES_SESSION_LOG_*
+    // environment variables — running each behavior in its own #[test] would
+    // let `cargo test`'s parallel scheduler observe one test's mutations
+    // mid-flight in another.
     #[test]
-    fn session_log_config_from_env_explicit_dir() {
+    fn session_log_config_from_env_behaviors() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved_home = std::env::var_os("HOME");
+
+        // 1. Explicit ARES_SESSION_LOG_DIR wins regardless of ENABLED.
         std::env::set_var("ARES_SESSION_LOG_DIR", "/tmp/ares-test-sessions");
         std::env::remove_var("ARES_SESSION_LOG_ENABLED");
         let cfg = SessionLogConfig::from_env();
@@ -503,16 +534,34 @@ mod tests {
             cfg.dir.as_deref(),
             Some(std::path::Path::new("/tmp/ares-test-sessions"))
         );
-        std::env::remove_var("ARES_SESSION_LOG_DIR");
-    }
 
-    #[test]
-    fn session_log_config_from_env_empty_dir_disabled() {
-        std::env::remove_var("ARES_SESSION_LOG_ENABLED");
+        // 2. Explicit opt-out (ENABLED=0) with whitespace dir → disabled.
+        std::env::set_var("ARES_SESSION_LOG_ENABLED", "0");
         std::env::set_var("ARES_SESSION_LOG_DIR", "   ");
         let cfg = SessionLogConfig::from_env();
         assert!(!cfg.enabled());
+
+        // 3. Default-on: no env vars set, HOME → `~/.ares/sessions`.
+        std::env::remove_var("ARES_SESSION_LOG_ENABLED");
         std::env::remove_var("ARES_SESSION_LOG_DIR");
+        std::env::set_var("HOME", "/tmp/ares-test-home");
+        let cfg = SessionLogConfig::from_env();
+        assert!(cfg.enabled(), "session log should default to on");
+        assert_eq!(
+            cfg.dir.as_deref(),
+            Some(std::path::Path::new("/tmp/ares-test-home/.ares/sessions"))
+        );
+
+        // 4. default_root mirrors from_env's path resolution.
+        assert_eq!(
+            SessionLogConfig::default_root().as_deref(),
+            Some(std::path::Path::new("/tmp/ares-test-home/.ares/sessions"))
+        );
+
+        match saved_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Key Changes:**

- Introduced `ares ops sessions` CLI commands for listing, showing, and replaying session logs
- Added `SessionsCommands` enum and integrated it with the CLI and ops command dispatch
- Implemented session log directory detection and defaulting logic for consistent CLI/file access
- Updated dependencies and tests to support new session log features

**Added:**

- `SessionsCommands` enum to the CLI, enabling subcommands for listing operation/task IDs, showing session logs, and replaying conversations from logs
- `sessions.rs` module in `ares-cli/src/ops` implementing the logic for the new CLI commands, including pretty-printing and JSON output
- Integration of the new `ops sessions` subcommand into the main ops command handler
- Test coverage for the new session log CLI features, including environment isolation and replay behavior
- `tempfile` as a dev-dependency for test isolation and temporary directory management

**Changed:**

- Updated session log directory resolution in `ares-llm` to provide a `default_root()` helper for external consumers (such as CLI commands), ensuring consistent directory lookup
- Improved environment variable handling for session log enablement in `SessionLogConfig`, making logging enabled by default unless explicitly disabled
- Refactored and consolidated session log environment variable tests for thread safety and correctness
- Updated action versions in GitHub workflow files for `actions/upload-artifact` and `actions/setup-go` to new commit SHAs
- Bumped the Semgrep analysis container image to a newer version in CI workflow