### PR TITLE
feat: wrap provider.chat in llm.call span with timing and tokens

### DIFF
--- a/ares-llm/src/agent_loop/retry.rs
+++ b/ares-llm/src/agent_loop/retry.rs
@@ -1,4 +1,6 @@
-use tracing::warn;
+use std::time::Instant;
+
+use tracing::{field::Empty, info_span, warn, Instrument};
 
 use crate::provider::{LlmError, LlmProvider, LlmRequest, LlmResponse};
 
@@ -18,7 +20,51 @@ pub(super) async fn call_with_retry(
     let mut last_err: Option<LlmError> = None;
 
     for attempt in 0..=config.max_retries {
-        match provider.chat(request).await {
+        // One span per attempt: durations and token counts have to be on the
+        // attempt that produced them, otherwise rate-limit retries inflate
+        // the wall-clock attributed to the successful call.
+        let span = info_span!(
+            "llm.call",
+            "llm.model" = %request.model,
+            "llm.attempt" = attempt,
+            "llm.input_tokens" = Empty,
+            "llm.output_tokens" = Empty,
+            "llm.cache_read_tokens" = Empty,
+            "llm.cache_creation_tokens" = Empty,
+            "llm.tool_count" = request.tools.len(),
+            "llm.message_count" = request.messages.len(),
+            "llm.duration_ms" = Empty,
+            "llm.stop_reason" = Empty,
+            "llm.error" = Empty,
+            "task.id" = task_id,
+        );
+        let start = Instant::now();
+        let result = provider.chat(request).instrument(span.clone()).await;
+        let duration_ms = start.elapsed().as_millis() as u64;
+        span.record("llm.duration_ms", duration_ms);
+        match &result {
+            Ok(response) => {
+                span.record("llm.input_tokens", response.usage.input_tokens);
+                span.record("llm.output_tokens", response.usage.output_tokens);
+                span.record(
+                    "llm.cache_read_tokens",
+                    response.usage.cache_read_input_tokens,
+                );
+                span.record(
+                    "llm.cache_creation_tokens",
+                    response.usage.cache_creation_input_tokens,
+                );
+                span.record(
+                    "llm.stop_reason",
+                    format!("{:?}", response.stop_reason).as_str(),
+                );
+            }
+            Err(e) => {
+                span.record("llm.error", format!("{e}").as_str());
+            }
+        }
+
+        match result {
             Ok(response) => return Ok(response),
             Err(e) => {
                 if !e.is_retryable() || attempt == config.max_retries {


### PR DESCRIPTION
**Key Changes:**

- Wrapped each `provider.chat()` call inside `call_with_retry` in its own `llm.call` info span so timing and token usage are attributed to the attempt that produced them
- Captured per-attempt input, output, and cache token counts, duration, stop reason, and error message as span fields
- Recorded `task.id`, `llm.model`, `llm.attempt`, `llm.tool_count`, and `llm.message_count` at span creation for filterable Tempo queries

**Added:**

- Per-attempt `llm.call` `info_span!` in `ares-llm/src/agent_loop/retry.rs` with `Empty` placeholders for fields that are only known after the call returns (`llm.input_tokens`, `llm.output_tokens`, `llm.cache_read_tokens`, `llm.cache_creation_tokens`, `llm.duration_ms`, `llm.stop_reason`, `llm.error`)
- Wall-clock duration measurement via `std::time::Instant` recorded into `llm.duration_ms` so retry waits are not folded into the successful call's latency
- `tracing::Instrument` instrumentation of the `provider.chat()` future so async work runs inside the span context

**Changed:**

- `ares-llm/src/agent_loop/retry.rs` `use` line now imports `std::time::Instant` plus `tracing::{field::Empty, info_span, Instrument}` alongside the existing `warn`
- Result handling in `call_with_retry` was split: the call result is first inspected to record token usage / stop reason / error on the span, then the existing retry decision logic runs on that same result