### PR TITLE
feat: switch ares-golden-image to local source and bump warpgate to v4.7.0

### DIFF
--- a/.github/workflows/build-and-push-templates.yaml
+++ b/.github/workflows/build-and-push-templates.yaml
@@ -30,7 +30,7 @@ env:
   PYTHON_VERSION: 3.13.7
   TASK_VERSION: 3.45.5
   TASK_X_REMOTE_TASKFILES: 1
-  WARPGATE_VERSION: "v4.6.0"
+  WARPGATE_VERSION: "v4.7.0"
 
 jobs:
   discover-templates:

--- a/.github/workflows/test-template-builds.yaml
+++ b/.github/workflows/test-template-builds.yaml
@@ -24,7 +24,7 @@ concurrency:
 env:
   DEBIAN_FRONTEND: noninteractive
   PYTHON_VERSION: "3.13.7"
-  WARPGATE_VERSION: "v4.6.0"
+  WARPGATE_VERSION: "v4.7.0"
 
 jobs:
   detect-changes:

--- a/.github/workflows/validate-templates.yaml
+++ b/.github/workflows/validate-templates.yaml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 env:
-  WARPGATE_VERSION: "v4.6.0"
+  WARPGATE_VERSION: "v4.7.0"
   PYTHON_VERSION: "3.13.7"
   TASK_VERSION: "3.45.5"
   TASK_X_REMOTE_TASKFILES: 1

--- a/warpgate-templates/templates/ares-golden-image/warpgate.yaml
+++ b/warpgate-templates/templates/ares-golden-image/warpgate.yaml
@@ -33,13 +33,12 @@ base:
     most_recent: true
 
 sources:
+  # Use the in-repo ansible/ tree directly so builds match the working copy
+  # (no GITHUB_TOKEN, no branch ref drift). Path is relative to this template's
+  # directory; requires warpgate >= v4.7.0 (local source type).
   - name: ares
-    git:
-      repository: https://github.com/dreadnode/ares.git
-      ref: feat/more-attack-cov
-      depth: 1
-      auth:
-        token: ${GITHUB_TOKEN}
+    local:
+      path: ../../../ansible
 
 provisioners:
   # Install pipx and Ansible
@@ -52,7 +51,7 @@ provisioners:
       - pipx install --force ansible-core
       - pipx ensurepath
 
-  # Copy ansible collection from source (cloned securely by warpgate without embedding token in shell commands).
+  # Copy ansible collection from the local source (the in-repo ansible/ tree).
   # The destination keeps the `nimbus_range` name because the ansible collection is published as
   # `dreadnode.nimbus_range`; subsequent steps install it under that namespace.
   - type: file
@@ -62,7 +61,7 @@ provisioners:
   - type: shell
     inline:
       - mkdir -p /root/.ansible/collections/ansible_collections/dreadnode/nimbus_range
-      - cp -r /tmp/nimbus_range/ansible/. /root/.ansible/collections/ansible_collections/dreadnode/nimbus_range/
+      - cp -r /tmp/nimbus_range/. /root/.ansible/collections/ansible_collections/dreadnode/nimbus_range/
       - rm -rf /tmp/nimbus_range
 
   # Install NVIDIA drivers for GPU-accelerated hashcat on g4dn (T4 GPU)


### PR DESCRIPTION
**Key Changes:**

- Replace git-based source for ares-golden-image with a warpgate `local` source pointing at the in-repo `ansible/` tree, eliminating GITHUB_TOKEN usage and branch ref drift at build time
- Bump WARPGATE_VERSION from v4.6.0 to v4.7.0 across all three template workflows so CI uses a binary that supports the `local` source type
- Adjust the in-VM collection copy path to match the new source layout (`/tmp/nimbus_range/.` instead of `/tmp/nimbus_range/ansible/.`)

**Changed:**

- Switch `warpgate-templates/templates/ares-golden-image/warpgate.yaml` from a `git` source (cloning dreadnode/ares.git@feat/more-attack-cov via GITHUB_TOKEN) to a `local` source at `../../../ansible`, so builds always match the working copy and ship only the ansible tree
- Update the post-copy provisioner shell step to `cp -r /tmp/nimbus_range/. /root/.ansible/collections/ansible_collections/dreadnode/nimbus_range/` to reflect that the local source is rooted at `ansible/` rather than the full repo
- Bump `WARPGATE_VERSION` to `v4.7.0` in `.github/workflows/build-and-push-templates.yaml`, `.github/workflows/test-template-builds.yaml`, and `.github/workflows/validate-templates.yaml`, since the `local` source type was added in CowDogMoo/warpgate#1841 and released in v4.7.0
- Refresh the inline comments in `warpgate.yaml` to describe the local-source setup instead of the prior secure-clone behavior