### PR TITLE
chore: group opentelemetry and tracing-opentelemetry updates in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,17 @@
       automerge: true,
       automergeType: 'pr',
     },
+    {
+      description: 'Group opentelemetry-rust monorepo with tracing-opentelemetry so version bumps land together (tracing-opentelemetry pins a specific opentelemetry minor version, so they must update atomically)',
+      matchPackageNames: [
+        'opentelemetry',
+        'opentelemetry_sdk',
+        'opentelemetry-otlp',
+        'opentelemetry-semantic-conventions',
+        'tracing-opentelemetry',
+      ],
+      groupName: 'opentelemetry',
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
**Key Changes:**

- Added a new Renovate group for opentelemetry-rust and tracing-opentelemetry packages
- Ensured atomic version bumping for interdependent telemetry packages

**Added:**

- Renovate grouping configuration to update `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`, `opentelemetry-semantic-conventions`, and `tracing-opentelemetry` together, preventing dependency mismatches due to version pinning