### PR TITLE
ci: automate pre-commit autofix application for renovate bot PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 * @l50
 
-# Changes to this workflow MUST be reviewed carefully.
+# Workflow and CI configuration changes (.github/**) require maintainer
+# review, since these files run with repo secrets (incl. the renovate
+# bot's GitHub App private key). Already covered by the wildcard above;
+# this comment documents the reason so future edits don't loosen it.
 .github/workflows/meta-labeler.yaml @l50

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -39,9 +39,14 @@ jobs:
   pre-commit:
     name: Pre-commit
     runs-on: ubuntu-latest
+    outputs:
+      has-fixes: ${{ steps.capture.outputs.has-fixes }}
     steps:
       - name: Checkout git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          persist-credentials: false
 
       - name: Set up Python ${{ env.PYTHON_VERSION_ANSIBLE_LINT }} (for ansible-lint pre-commit hook)
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -105,4 +110,73 @@ jobs:
           task --version
 
       - name: Run pre-commit
+        id: precommit
         run: task -y run-pre-commit
+
+      - name: Capture autofix patch
+        id: capture
+        if: ${{ failure() && steps.precommit.outcome == 'failure' }}
+        run: |
+          if git diff --quiet HEAD; then
+            echo "pre-commit failed without modifying tracked files; no autofix possible"
+            echo "has-fixes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git diff --binary HEAD > autofix.patch
+          echo "has-fixes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload autofix patch
+        if: ${{ steps.capture.outputs.has-fixes == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: autofix-patch
+          path: autofix.patch
+          retention-days: 1
+          if-no-files-found: error
+
+  autocommit:
+    name: Apply pre-commit autofixes to bot PR
+    needs: pre-commit
+    if: >-
+      failure() &&
+      needs.pre-commit.outputs.has-fixes == 'true' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login == 'dreadnode-renovate-bot[bot]' &&
+      !github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    environment: pre-commit-autofix
+    permissions:
+      contents: read
+    steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: "${{ secrets.BOT_APP_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+
+      - name: Download autofix patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: autofix-patch
+
+      - name: Apply patch and push
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_AUTHOR_NAME: "${{ secrets.BOT_USERNAME }}[bot]"
+          GIT_AUTHOR_EMAIL: "${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "${{ secrets.BOT_USERNAME }}[bot]"
+          GIT_COMMITTER_EMAIL: "${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com"
+        run: |
+          git apply --index autofix.patch
+          git commit -m "chore: apply pre-commit autofixes"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf 'x-access-token:%s' "${APP_TOKEN}" | base64 -w0)"
+          git -c http.https://github.com/.extraheader="${AUTH_HEADER}" \
+            push "https://github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"


### PR DESCRIPTION
**Key Changes:**

- Added an `autocommit` job to automatically apply pre-commit autofixes to Renovate bot PRs
- Enhanced the `pre-commit` job to capture and upload autofix patches when pre-commit fails and fixes are available
- Improved artifact handling and job outputs to support the new automation flow

**Added:**

- Automated autofix workflow - Introduced an `autocommit` job in `pre-commit.yaml` that detects when a Renovate bot PR fails pre-commit checks, downloads the autofix patch, and pushes the fixes back to the PR using a GitHub App token
- Patch artifact management - Implemented steps to upload the autofix patch as an artifact and download it in the new job for application

**Changed:**

- Pre-commit job logic - Modified `pre-commit` job to output a `has-fixes` flag and capture autofix patches when available
- Checkout step configuration - Updated checkout steps to use the correct PR ref and to disable credential persistence for increased security
- Documentation in CODEOWNERS - Clarified the rationale for strict review requirements on workflow and CI configuration files