### PR TITLE
fix: improve acl vuln routing and certipy_shadow hash handling

### DIFF
--- a/ares-llm/src/tool_registry/privesc/adcs.rs
+++ b/ares-llm/src/tool_registry/privesc/adcs.rs
@@ -131,8 +131,10 @@ pub fn definitions() -> Vec<ToolDefinition> {
             name: "certipy_shadow".into(),
             description: "Exploit Shadow Credentials by adding a Key Credential to a target \
                 account's msDS-KeyCredentialLink attribute via Certipy, then authenticating \
-                with the resulting certificate. Provide either `password` or `hashes` for \
-                authentication."
+                with the resulting certificate. You MUST provide exactly one of `password` \
+                OR `hashes` — never pass an empty string for the unused field; omit it \
+                entirely. If the orchestrator handed you a plaintext password, pass \
+                `password` and DO NOT include `hashes` at all."
                 .into(),
             input_schema: json!({
                 "type": "object",
@@ -147,11 +149,11 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     },
                     "password": {
                         "type": "string",
-                        "description": "Password for authentication. Optional if `hashes` is provided."
+                        "description": "Plaintext password for the source account. Use this when the orchestrator provides a `password` field — do NOT also pass `hashes`."
                     },
                     "hashes": {
                         "type": "string",
-                        "description": "NTLM hash for pass-the-hash (format: 'lmhash:nthash' or just ':nthash'). Use instead of password."
+                        "description": "NTLM hash for pass-the-hash (format: 'lmhash:nthash' or ':nthash'). Use ONLY when the orchestrator provides a `hash` / `nt_hash` field and NO password. Omit this field entirely — do not pass an empty string — when using `password`."
                     },
                     "dc_ip": {
                         "type": "string",

--- a/ares-tools/src/privesc/adcs.rs
+++ b/ares-tools/src/privesc/adcs.rs
@@ -142,7 +142,11 @@ pub async fn certipy_shadow(args: &Value) -> Result<ToolOutput> {
     let domain = required_str(args, "domain")?;
     let target = required_str(args, "target")?;
     let dc_ip = required_str(args, "dc_ip")?;
-    let hashes = optional_str(args, "hashes");
+    // Treat an empty-string `hashes` as missing so the password fallback
+    // fires. The LLM agent has been observed passing `hashes=""` when only
+    // a password is available — without this guard the `-hashes ''` flag
+    // is forwarded to certipy and certipy rejects the empty value.
+    let hashes = optional_str(args, "hashes").filter(|s| !s.is_empty());
 
     let user_at_domain = format!("{username}@{domain}");
 
@@ -1075,6 +1079,44 @@ mod tests {
         let domain = required_str(&args, "domain").unwrap();
         let user_at_domain = format!("{username}@{domain}");
         assert_eq!(user_at_domain, "admin@contoso.local");
+    }
+
+    #[test]
+    fn certipy_shadow_empty_hashes_falls_back_to_password() {
+        // The LLM has been observed sending `hashes=""` when only a password
+        // is available — without the empty-string filter, certipy receives
+        // `-hashes ''` and bails with "invalid hash format". The filter at
+        // the top of `certipy_shadow` must treat empty hashes as missing so
+        // the password branch runs.
+        let args = json!({
+            "username": "alice",
+            "domain": "contoso.local",
+            "password": "P@ssw0rd!",
+            "hashes": "",
+            "target": "Administrator",
+            "dc_ip": "192.168.58.10"
+        });
+        // Mirror the same filter used in `certipy_shadow` itself.
+        let hashes = optional_str(&args, "hashes").filter(|s| !s.is_empty());
+        assert!(
+            hashes.is_none(),
+            "empty hashes should be treated as missing"
+        );
+        // password fallback must still resolve.
+        assert!(required_str(&args, "password").is_ok());
+    }
+
+    #[test]
+    fn certipy_shadow_present_hashes_used() {
+        let args = json!({
+            "username": "alice",
+            "domain": "contoso.local",
+            "hashes": "aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c",
+            "target": "Administrator",
+            "dc_ip": "192.168.58.10"
+        });
+        let hashes = optional_str(&args, "hashes").filter(|s| !s.is_empty());
+        assert!(hashes.is_some());
     }
 
     // --- certipy_template_esc4 ---


### PR DESCRIPTION
**Key Changes:**

- Refined dispatcher logic to correctly route ACL-based vulnerabilities to the `acl` worker instead of defaulting to `privesc`
- Added robust detection for ACL-style vuln types to support correct worker selection
- Improved `certipy_shadow` tool to ignore empty-string hashes, preventing failures
- Enhanced documentation and validation for `certipy_shadow` input handling

**Added:**

- ACL-style vuln detection - Introduced `is_acl_style_vuln_type` function in `task_builders.rs` to identify and route ACL-based vulnerabilities to the appropriate worker
- Unit tests for ACL vuln type detection - Ensured correct matching and rejection for bare and prefixed ACL types in `task_builders.rs`
- Unit tests for `certipy_shadow` hash handling - Verified that empty-string hashes are ignored and password fallback works in `adcs.rs`

**Changed:**

- Vulnerability routing in dispatcher - Updated logic in `Dispatcher::submit_exploit_task` to use the new ACL detection and route vulnerabilities with ACL primitives to the `acl` worker when `recommended_agent` is empty
- `certipy_shadow` argument handling - Modified `adcs.rs` to treat empty-string `hashes` as missing, ensuring Certipy does not receive invalid hash arguments and the password fallback is used correctly
- Tool definition documentation - Clarified input schema and parameter requirements for `certipy_shadow` in the tool registry to prevent misuse of `password` and `hashes` fields

**Removed:**

- Legacy default behavior that always routed empty `recommended_agent` exploits to the `privesc` worker, which led to toolset mismatches for ACL-based vulnerabilities