### PR TITLE
fix: improve exploit success detection for agent stalls with parser evidence

### DIFF
--- a/ares-cli/src/orchestrator/result_processing/mod.rs
+++ b/ares-cli/src/orchestrator/result_processing/mod.rs
@@ -225,9 +225,25 @@ pub async fn process_completed_task(
             // primitive on getST exit-0.
             let has_ticket_evidence =
                 is_ticket_grant_vuln(&vuln_id) && result_has_ccache_evidence(&result.result);
-            let actually_succeeded = result.success
+            // Stall-tolerance: when the LLM ends its turn without calling
+            // task_complete (LoopEndReason::MaxSteps or budget exhaustion),
+            // submission.rs stamps `success=false` with an error string
+            // identifying the stall. The exploit may still have landed —
+            // certipy_shadow, secretsdump, getST routinely produce parser-
+            // grounded credentials/hashes/tickets before the LLM stalls on
+            // the wrap-up call. Without this carve-out, every stalled
+            // exploit appears as "failed" even when the primitive worked.
+            // The carve-out is narrow: only stalls (recognised by the
+            // canonical error strings) bypass the `success` check, and the
+            // parser-evidence gate still has to pass.
+            let stalled_with_evidence = !result.success
+                && error_indicates_stall(result.error.as_deref())
                 && !result_text_indicates_failure(&result.result)
                 && (result_has_parser_evidence(&result.result) || has_ticket_evidence);
+            let actually_succeeded = (result.success
+                && !result_text_indicates_failure(&result.result)
+                && (result_has_parser_evidence(&result.result) || has_ticket_evidence))
+                || stalled_with_evidence;
 
             if actually_succeeded {
                 info!(vuln_id = %vuln_id, task_id = %task_id, "Marking vulnerability as exploited");
@@ -821,6 +837,25 @@ fn result_has_ccache_evidence(result: &Option<Value>) -> bool {
         }
     }
     false
+}
+
+/// Returns `true` when the task's error string is one of the agent-loop
+/// stall conditions (LoopEndReason::MaxSteps, MaxTokens, BudgetExceeded,
+/// or "ended turn without task_complete"). These conditions indicate the
+/// LLM ran out of budget mid-task — they're not failures of the primitive
+/// itself. Used to relax the `success` gate in mark_exploited so an
+/// exploit that produced parser evidence before the agent stalled still
+/// gets scoreboard credit.
+fn error_indicates_stall(err: Option<&str>) -> bool {
+    let Some(e) = err else {
+        return false;
+    };
+    let lower = e.to_lowercase();
+    lower.contains("ended turn without task_complete")
+        || lower.contains("agent hit max steps")
+        || lower.contains("max steps")
+        || lower.contains("agent hit max tokens")
+        || lower.contains("budget exceeded")
 }
 
 fn result_has_parser_evidence(result: &Option<Value>) -> bool {

--- a/ares-cli/src/orchestrator/result_processing/tests.rs
+++ b/ares-cli/src/orchestrator/result_processing/tests.rs
@@ -1466,3 +1466,34 @@ fn ntlmv1_signal_detects_in_tool_outputs_array() {
     });
     assert!(result_has_ntlmv1_signal(&Some(payload)));
 }
+
+#[test]
+fn error_indicates_stall_recognises_canonical_strings() {
+    use super::error_indicates_stall;
+    assert!(error_indicates_stall(Some(
+        "Agent ended turn without task_complete or request_assistance"
+    )));
+    assert!(error_indicates_stall(Some("Agent hit max steps")));
+    assert!(error_indicates_stall(Some("Agent hit max tokens")));
+    assert!(error_indicates_stall(Some(
+        "Budget exceeded: input_tokens=1000000"
+    )));
+    // Case-insensitive
+    assert!(error_indicates_stall(Some(
+        "AGENT ENDED TURN WITHOUT TASK_COMPLETE"
+    )));
+}
+
+#[test]
+fn error_indicates_stall_rejects_real_failures() {
+    use super::error_indicates_stall;
+    // Substantive failures must not be treated as stalls — the underlying
+    // primitive really did fail and the vuln must stay unexplodited.
+    assert!(!error_indicates_stall(Some("rpc_s_access_denied")));
+    assert!(!error_indicates_stall(Some(
+        "KDC_ERR_PREAUTH_FAILED — credential rejected"
+    )));
+    assert!(!error_indicates_stall(Some("LDAP bind failed: 0x52e")));
+    assert!(!error_indicates_stall(Some("")));
+    assert!(!error_indicates_stall(None));
+}


### PR DESCRIPTION
**Key Changes:**

- Refined success criteria to recognize exploits as successful when agent stalls but parser evidence is present
- Introduced new error_indicates_stall function to identify agent loop stall conditions
- Updated tests to cover stall detection and ensure only genuine stalls are treated as non-failures

**Added:**

- error_indicates_stall function to detect canonical agent stall error strings and relax the success gate accordingly
- Unit tests for error_indicates_stall covering both recognized stall strings and real failure cases

**Changed:**

- Exploit success logic in process_completed_task to consider tasks as succeeded if they stalled with parser or ticket evidence, ensuring valid exploits are not marked as failed due to agent loop limits