### PR TITLE
feat: emit exploit tokens for kerberoast and asrep roast hash captures

### DIFF
--- a/ares-cli/src/orchestrator/result_processing/mod.rs
+++ b/ares-cli/src/orchestrator/result_processing/mod.rs
@@ -1003,6 +1003,38 @@ async fn resolve_domain_from_ip(dispatcher: &Arc<Dispatcher>, target_ip: Option<
     state.domains.first().cloned().unwrap_or_default()
 }
 
+/// `kerberoast_{username}` or `asrep_roast_{domain}` token when the
+/// captured hash carries the canonical impacket / hashcat prefix
+/// (`$krb5tgs$`, `$krb5asrep$`). Returns `None` for other hash types so
+/// the caller emits exactly one token per captured roast hash. Token
+/// values match dreadgoad's `transport_ares.aresExploitedToTechniqueIDs`
+/// prefix matchers — anything starting with `kerberoast_` / `asrep_roast_`
+/// credits the corresponding scoreboard primitive.
+fn roast_exploit_token(hash_value: &str, username: &str, domain: &str) -> Option<String> {
+    let user_lc = username.trim().to_lowercase();
+    let dom_lc = domain.trim().to_lowercase();
+    if hash_value.starts_with("$krb5tgs$") {
+        // Kerberoast: token-per-account so multiple SPN hashes don't
+        // collapse on a single entry.
+        if user_lc.is_empty() {
+            return None;
+        }
+        Some(format!("kerberoast_{user_lc}"))
+    } else if hash_value.starts_with("$krb5asrep$") {
+        // AS-REP roast: dreadgoad's objective is per-domain (any
+        // preauth-disabled account demonstrates the primitive); token-
+        // per-domain lets the inferred-hint path and the explicit-capture
+        // path converge on the same entry.
+        let key = if !dom_lc.is_empty() { dom_lc } else { user_lc };
+        if key.is_empty() {
+            return None;
+        }
+        Some(format!("asrep_roast_{key}"))
+    } else {
+        None
+    }
+}
+
 /// S4U auto-chain: detect .ccache ticket in task output and dispatch secretsdump.
 ///
 /// Mirrors Python's `_auto_chain_s4u_lateral_movement` — when a task produces a
@@ -1449,6 +1481,35 @@ async fn extract_discoveries(
 
                 emit_gmsa_exploit_token_if_gmsa(&dispatcher.state, &dispatcher.queue, &username)
                     .await;
+
+                // AS-REP / Kerberoast primitive credit on hash capture.
+                // dreadgoad's scoreboard otherwise infers `asrep_roast` /
+                // `kerberoast` from the cracked-credential hint, which only
+                // fires AFTER the hash crack succeeds. The crack may fail
+                // (insufficient wordlist coverage, AES instead of RC4) yet
+                // the capture itself already proves the primitive. Emit the
+                // token at capture time so credit is independent of crack
+                // outcome.
+                if let Some(token) = roast_exploit_token(&hash_value, &username, &domain) {
+                    if let Err(e) = dispatcher
+                        .state
+                        .mark_exploited(&dispatcher.queue, &token)
+                        .await
+                    {
+                        warn!(
+                            err = %e,
+                            vuln_id = %token,
+                            "Failed to mark roast hash as exploited"
+                        );
+                    } else {
+                        info!(
+                            vuln_id = %token,
+                            account = %username,
+                            domain = %domain,
+                            "Kerberos roast hash captured — emitted exploit token"
+                        );
+                    }
+                }
             }
             Ok(false) => {}
             Err(e) => warn!(err = %e, "Failed to publish hash"),

--- a/ares-cli/src/orchestrator/result_processing/tests.rs
+++ b/ares-cli/src/orchestrator/result_processing/tests.rs
@@ -1545,3 +1545,74 @@ fn error_indicates_stall_rejects_real_failures() {
     assert!(!error_indicates_stall(Some("")));
     assert!(!error_indicates_stall(None));
 }
+
+#[test]
+fn roast_token_recognises_kerberoast_hash() {
+    use super::roast_exploit_token;
+    assert_eq!(
+        roast_exploit_token(
+            "$krb5tgs$23$*sql_svc$CONTOSO.LOCAL$cifs/dc01...",
+            "sql_svc",
+            "contoso.local",
+        ),
+        Some("kerberoast_sql_svc".to_string())
+    );
+}
+
+#[test]
+fn roast_token_recognises_asrep_hash() {
+    use super::roast_exploit_token;
+    assert_eq!(
+        roast_exploit_token(
+            "$krb5asrep$23$alice@CONTOSO.LOCAL:abc...",
+            "alice",
+            "contoso.local",
+        ),
+        Some("asrep_roast_contoso.local".to_string())
+    );
+}
+
+#[test]
+fn roast_token_falls_back_to_username_when_domain_empty() {
+    use super::roast_exploit_token;
+    assert_eq!(
+        roast_exploit_token("$krb5asrep$23$alice@DOMAIN:abc...", "alice", "",),
+        Some("asrep_roast_alice".to_string())
+    );
+}
+
+#[test]
+fn roast_token_ignores_non_roast_hashes() {
+    use super::roast_exploit_token;
+    // NTLM hash from secretsdump — not a roast, no token.
+    assert_eq!(
+        roast_exploit_token(
+            "aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c",
+            "administrator",
+            "contoso.local",
+        ),
+        None
+    );
+    // Empty hash value
+    assert_eq!(roast_exploit_token("", "user", "dom"), None);
+}
+
+#[test]
+fn roast_token_returns_none_when_both_user_and_domain_empty() {
+    use super::roast_exploit_token;
+    assert_eq!(roast_exploit_token("$krb5asrep$23$...", "", ""), None);
+    assert_eq!(roast_exploit_token("$krb5tgs$23$...", "", "dom"), None);
+}
+
+#[test]
+fn roast_token_lowercases_account_and_domain() {
+    use super::roast_exploit_token;
+    assert_eq!(
+        roast_exploit_token("$krb5tgs$23$*", "SQL_SVC", "CONTOSO.LOCAL"),
+        Some("kerberoast_sql_svc".to_string())
+    );
+    assert_eq!(
+        roast_exploit_token("$krb5asrep$23$", "Alice", "Contoso.Local"),
+        Some("asrep_roast_contoso.local".to_string())
+    );
+}


### PR DESCRIPTION
**Key Changes:**

- Emit exploit tokens for Kerberoast and AS-REP roast hash captures at the time of hash capture
- Add roast_exploit_token function to consistently generate technique-specific tokens
- Ensure tokens are only emitted for canonical hash types and are case-normalized
- Introduce comprehensive tests validating token emission logic and edge cases

**Added:**

- roast_exploit_token function to generate technique IDs for Kerberoast and AS-REP roast hash captures in result_processing/mod.rs
- Logic in extract_discoveries to emit exploit tokens immediately when a Kerberoast or AS-REP roast hash is captured, ensuring scoreboard credit even if hash cracking fails
- Extensive unit tests for roast_exploit_token covering Kerberoast, AS-REP roast, fallback and edge cases in result_processing/tests.rs

**Changed:**

- Updated extract_discoveries to call roast_exploit_token and dispatch exploit tokens upon Kerberoast or AS-REP roast hash capture, ensuring the primitive is credited independently of hash cracking success