### PR TITLE
fix: improve automation-owned vuln detection and prevent duplicate gpo exploitation

### DIFF
--- a/ares-cli/src/orchestrator/exploitation.rs
+++ b/ares-cli/src/orchestrator/exploitation.rs
@@ -21,23 +21,44 @@ use crate::orchestrator::dispatcher::Dispatcher;
 
 fn is_automation_owned_vuln(vtype: &str) -> bool {
     let vtype = vtype.to_lowercase();
-    vtype == "constrained_delegation"
-        || vtype == "unconstrained_delegation"
-        || vtype == "rbcd"
-        || vtype == "child_to_parent"
-        || vtype == "forest_trust_escalation"
-        || vtype == "smb_signing_disabled"
-        || vtype == "ldap_signing_disabled"
-        || vtype == "ldap_signing_not_required"
-        || vtype == "ntlmv1_downgrade"
-        || vtype == "genericall"
-        || vtype == "genericwrite"
-        || vtype == "writedacl"
-        || vtype == "writeowner"
-        || vtype == "forcechangepassword"
-        || vtype == "self_membership"
-        || vtype == "write_membership"
-        || EXPLOITABLE_ESC_TYPES.contains(&vtype.as_str())
+    let exact = matches!(
+        vtype.as_str(),
+        "constrained_delegation"
+            | "unconstrained_delegation"
+            | "rbcd"
+            | "child_to_parent"
+            | "forest_trust_escalation"
+            | "smb_signing_disabled"
+            | "ldap_signing_disabled"
+            | "ldap_signing_not_required"
+            | "ntlmv1_downgrade"
+            | "genericall"
+            | "genericwrite"
+            | "writedacl"
+            | "writeowner"
+            | "forcechangepassword"
+            | "self_membership"
+            | "write_membership"
+            // Vuln types whose dedicated automations dispatch directly
+            // and would race the generic exploitation path. Added when
+            // their owning automations landed.
+            | "shadow_credentials"
+            | "sid_history_abuse"
+            | "seimpersonate"
+            | "ntlm_relay"
+            | "laps_abuse"
+            | "laps_reader"
+    );
+    if exact || EXPLOITABLE_ESC_TYPES.contains(&vtype.as_str()) {
+        return true;
+    }
+    // Prefix match for the family of GPO Abuse vuln types emitted by the
+    // ldap_acl_enumeration parser when the target is a groupPolicyContainer
+    // — `gpo_writeproperty_*`, `gpo_genericall_*`, etc. All owned by
+    // `auto_gpo_abuse`. Without this guard the generic exploitation
+    // workflow ALSO picks them up and dispatches a duplicate exploit task
+    // to the privesc role, doubling LLM cost on every gpo_* primitive.
+    vtype.starts_with("gpo_")
 }
 
 /// Cooldown before re-dispatching a failed exploit for the same vulnerability.
@@ -262,6 +283,32 @@ mod tests {
             "ldap_signing_not_required",
             "ntlmv1_downgrade",
             "esc1",
+            // Added when the dedicated automations landed.
+            "shadow_credentials",
+            "sid_history_abuse",
+            "seimpersonate",
+            "ntlm_relay",
+        ] {
+            assert!(
+                is_automation_owned_vuln(vtype),
+                "{vtype} should be automation-owned"
+            );
+        }
+    }
+
+    #[test]
+    fn gpo_prefix_vulns_are_automation_owned() {
+        // ldap_acl_enumeration emits `gpo_<right>_*` vuln_ids for ACEs on
+        // groupPolicyContainer objects; `auto_gpo_abuse` owns them. Without
+        // the prefix match the generic exploitation workflow would
+        // double-dispatch, wasting LLM budget per vuln.
+        for vtype in [
+            "gpo_abuse",
+            "gpo_writeproperty",
+            "gpo_genericall",
+            "gpo_writedacl",
+            "gpo_writeowner",
+            "gpo_allextendedrights",
         ] {
             assert!(
                 is_automation_owned_vuln(vtype),
@@ -272,7 +319,11 @@ mod tests {
 
     #[test]
     fn generic_exploit_vulns_still_allowed() {
-        for vtype in ["mssql_access", "zerologon", "gpo_abuse"] {
+        // `mssql_access` and `zerologon` register vulns via dedicated
+        // automations that only enumerate/check — actual exploitation
+        // still goes through the generic workflow (LLM-routed). The
+        // automation-owned filter must keep allowing them through.
+        for vtype in ["mssql_access", "zerologon"] {
             assert!(
                 !is_automation_owned_vuln(vtype),
                 "{vtype} should remain generic"


### PR DESCRIPTION
**Key Changes:**

- Refactored automation-owned vulnerability detection to include new types and GPO prefix matching
- Improved test coverage for new vulnerability types and GPO-prefixed vulns
- Prevented duplicate exploit dispatches for GPO-related vulnerabilities

**Added:**

- Extended test cases to cover new automation-owned vuln types and GPO-prefixed vulns, ensuring correct classification and preventing regressions

**Changed:**

- Expanded the list of automation-owned vulnerabilities in `is_automation_owned_vuln` to include new types such as `shadow_credentials`, `sid_history_abuse`, `seimpersonate`, `ntlm_relay`, `laps_abuse`, and `laps_reader`
- Introduced a prefix match for all vulnerabilities starting with `gpo_` to ensure they are exclusively owned by the dedicated automation, avoiding duplicate exploit tasks and unnecessary LLM cost
- Updated logic to use `matches!` for clearer and more maintainable matching of exact vulnerability types

**Removed:**

- Eliminated `gpo_abuse` from the list of generic exploit vulns in tests, reflecting its automation-owned status and ensuring the generic workflow no longer processes it