### PR TITLE
refactor: streamline mssql exploitation objectives and clarify stop conditions

### DIFF
--- a/ares-cli/src/orchestrator/automation/mssql_exploitation.rs
+++ b/ares-cli/src/orchestrator/automation/mssql_exploitation.rs
@@ -186,20 +186,27 @@ pub async fn auto_mssql_exploitation(
                     "domain": cred.domain,
                 },
                 "objectives": [
-                    "Enable xp_cmdshell and execute `whoami` to confirm code execution",
-                    "Immediately after `whoami` returns, run `whoami /priv` via xp_cmdshell and include the FULL privilege table in your tool_outputs verbatim — the orchestrator parses the table to detect SeImpersonatePrivilege Enabled and credit the SeImpersonate primitive on the scoreboard. Skipping this step leaves the seimpersonate token unclaimed even when the MSSQL service account holds the privilege.",
-                    "Try EXECUTE AS LOGIN = 'sa' if current user is not sysadmin",
-                    "Enumerate ALL impersonation privileges: SELECT distinct b.name FROM sys.server_permissions a INNER JOIN sys.server_principals b ON a.grantor_principal_id = b.principal_id WHERE a.permission_name = 'IMPERSONATE'",
-                    "For each impersonatable login, try EXECUTE AS LOGIN = '<login>' and check IS_SRVROLEMEMBER('sysadmin')",
-                    "Check database-level impersonation: SELECT * FROM sys.database_permissions WHERE permission_name = 'IMPERSONATE'",
-                    "Try EXECUTE AS USER = 'dbo' in each database (master, msdb, tempdb) for db_owner escalation",
-                    "Check if any database has TRUSTWORTHY = ON: SELECT name, is_trustworthy_on FROM sys.databases WHERE is_trustworthy_on = 1",
-                    "Extract credentials via xp_cmdshell (e.g., reg query for autologon, in-memory secrets)",
-                    "If SeImpersonatePrivilege is Enabled, the seimpersonate primitive is already scoreboard-credited by the orchestrator's parser; chasing PrintSpoofer/GodPotato escalation is optional and lower priority than enumerating impersonation paths in MSSQL itself",
-                    "Enumerate linked servers and test RPC execution on each link",
-                    "Check who is sysadmin: SELECT name FROM sys.server_principals WHERE IS_SRVROLEMEMBER('sysadmin', name) = 1",
-                    "For cross-forest linked-server pivots: enumerate SELECT s.name, s.is_rpc_out_enabled, l.uses_self_credential, l.remote_name FROM sys.servers s LEFT JOIN sys.linked_logins l ON s.server_id = l.server_id; — if `is_rpc_out_enabled=1` and `uses_self_credential=0`, use `mssql_openquery` (rides stored login mapping, bypasses double-hop)",
-                    "If `mssql_exec_linked` fails on a cross-forest link with auth errors, retry with `impersonate_user='sa'` to wrap the hop in `EXECUTE AS LOGIN`, or switch to `mssql_openquery`",
+                    // STOP CONDITION (must be first — agents have been observed
+                    // burning through MaxSteps because they tried every objective
+                    // before calling task_complete):
+                    //
+                    // Call `task_complete` AS SOON AS ANY of these landed —
+                    // partial wins beat exhaustive enumeration. The orchestrator
+                    // dispatches follow-on automations from the discoveries you
+                    // already published; you do NOT need to chase every remaining
+                    // primitive in this single task.
+                    "STOP CONDITION: call `task_complete` as soon as ANY of these landed: (a) sysadmin via EXECUTE AS LOGIN = 'sa' or another impersonatable login, (b) NT hash captured via xp_cmdshell + secretsdump/reg, (c) linked-server hop confirmed by remote SELECT rows, (d) any credential / hash published by parser. Stop enumerating after one win — the orchestrator chains follow-ups automatically. Burning all 75 steps chasing every objective is a regression in this task.",
+
+                    // Quick-win path (priority order — the agent should walk
+                    // these in order and call task_complete at the first hit):
+                    "1. Enable xp_cmdshell, run `whoami` to confirm code execution. If that returns SYSTEM or a privileged service account, call task_complete with the evidence.",
+                    "2. Run `whoami /priv` via xp_cmdshell and include the FULL privilege table verbatim in tool_outputs. The orchestrator parses SeImpersonatePrivilege Enabled and credits the seimpersonate primitive automatically. No further potato/PrintSpoofer escalation needed in this task.",
+                    "3. If current login is not sysadmin, try EXECUTE AS LOGIN = 'sa'. If it succeeds, call task_complete — that's a sysadmin pivot and the orchestrator will chain xp_cmdshell + secretsdump from there.",
+                    "4. Enumerate impersonatable logins ONCE: SELECT distinct b.name FROM sys.server_permissions a INNER JOIN sys.server_principals b ON a.grantor_principal_id = b.principal_id WHERE a.permission_name = 'IMPERSONATE'. For each (max 3 attempts), try EXECUTE AS LOGIN = '<login>' + IS_SRVROLEMEMBER('sysadmin'). First sysadmin hit → call task_complete.",
+                    "5. Enumerate linked servers ONCE: SELECT s.name, s.is_rpc_out_enabled, l.uses_self_credential, l.remote_name FROM sys.servers s LEFT JOIN sys.linked_logins l ON s.server_id = l.server_id. Try `mssql_exec_linked` (or `mssql_openquery` when uses_self_credential=0) against the first link with rpc_out_enabled=1. First confirmed remote SELECT → call task_complete.",
+
+                    // Secondary (only if all primary steps surfaced no win):
+                    "If steps 1–5 all surfaced no win, call task_complete with status describing exactly what failed (e.g. `not sysadmin, no impersonatable logins, links exist but all rpc_out_enabled=0`). DO NOT try TRUSTWORTHY DB owner chains, in-memory secret dumps, or extended enumeration — those are lower-priority and the orchestrator will dispatch them as separate tasks if needed.",
                 ],
             });
             if !item.linked_server.is_empty() {


### PR DESCRIPTION
**Key Changes:**

- Rewrote objectives to prioritize early wins and clarify when to stop enumeration
- Added explicit stop conditions to prevent agents from over-enumerating
- Organized steps into a clear, ordered quick-win path for agent execution

**Changed:**

- MSSQL exploitation objectives are now structured with a clear stop condition as the first item, instructing agents to call `task_complete` upon hitting any major win (sysadmin, NT hash, linked server hop, or credential/hash discovery), preventing wasteful exhaustive enumeration
- Quick-win objectives are now prioritized and sequenced, guiding agents to attempt actions in order and stop at the first successful result, with detailed instructions for each step including privilege checks, impersonation attempts, and linked server tests
- Lower-priority or extended enumeration steps (like TRUSTWORTHY DB owner chains or in-memory secret dumps) are deprioritized, directing agents to skip these in the initial automation and defer to orchestrator follow-up tasks if necessary
- Enhanced in-line commentary and step explanations within the objectives array to improve agent understanding and orchestration reliability