### PR TITLE
feat: deterministic GPO abuse chain via direct pygpoabuse dispatch

### DIFF
--- a/ares-cli/src/orchestrator/automation/gpo.rs
+++ b/ares-cli/src/orchestrator/automation/gpo.rs
@@ -7,6 +7,17 @@
 //!
 //! GPO vulns are typically discovered via BloodHound edges (WriteProperty,
 //! WriteDacl, GenericAll on GPO objects).
+//!
+//! Dispatch model: deterministic. The previous LLM-routed path
+//! (`throttled_submit("exploit", "privesc", payload)`) was unreliable in two
+//! ways: (a) the LLM had to infer the `pygpoabuse` tool name from the payload
+//! and frequently chose unrelated tools (`bloodhound_collect`, generic
+//! `whoami`); (b) the payload omitted the required `command` field that the
+//! tool needs to build the scheduled-task XML, so even when the LLM picked
+//! the right tool the call failed at the arg-validation step. We dispatch
+//! `pygpoabuse_immediate_task` directly with a generated proof command, then
+//! `mark_exploited` on success — same scoreboard-credit pattern as the
+//! ESC1/ESC3/ESC8/ESC11 deterministic chains.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,6 +30,90 @@ use crate::orchestrator::dispatcher::Dispatcher;
 
 /// Dedup key prefix for GPO abuse attacks.
 const DEDUP_GPO_ABUSE: &str = "gpo_abuse";
+
+/// Result of parsing `pygpoabuse_immediate_task` stdout. The tool prints
+/// `[+] ...` lines on each phase that landed (versionNumber update, scheduled
+/// task XML write, gpt.ini bump). The presence of *any* `[+]` line accompanied
+/// by either `created`, `updated`, or `success` is the contract:
+/// it means the GPO writes succeeded server-side, which is what we credit on
+/// the scoreboard. Whether the resulting scheduled task ever fires on a
+/// downstream client is gated by GP refresh (90 min default) — out of scope
+/// for the dispatcher tick.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum GpoAbuseOutcome {
+    /// pygpoabuse confirmed the GPO write — at least one `[+]` success
+    /// marker observed (versionNumber/ScheduledTask/gpt.ini).
+    Success,
+    /// Tool exited but no success markers seen. Either the credentials
+    /// don't have write on that GPO, the GPO id was wrong, or the tool
+    /// hit a wire-level error before any phase landed. Retryable.
+    NoEvidence,
+    /// Distinct error patterns we don't want to retry the same way —
+    /// the credential is wrong, or the GPO doesn't exist. The caller
+    /// burns a failure-counter slot.
+    KnownFailure(&'static str),
+}
+
+/// Parse pygpoabuse output. Stable enough to bind tests against; the tool's
+/// markers haven't changed since the upstream Sploutchy/sploutchy fork
+/// settled the `[+]`/`[-]`/`[!]` line prefixes.
+pub(crate) fn parse_pygpoabuse_output(output: &str) -> GpoAbuseOutcome {
+    let lower = output.to_lowercase();
+
+    if lower.contains("invalid credentials")
+        || lower.contains("authentication failed")
+        || lower.contains("kdc_err_preauth_failed")
+    {
+        return GpoAbuseOutcome::KnownFailure("auth");
+    }
+    if lower.contains("no such object") || lower.contains("no_object") {
+        return GpoAbuseOutcome::KnownFailure("gpo_not_found");
+    }
+    if lower.contains("insufficient access") || lower.contains("access_denied") {
+        return GpoAbuseOutcome::KnownFailure("insufficient_rights");
+    }
+
+    // Success markers from pygpoabuse. Order them by frequency — every
+    // successful run hits versionNumber + scheduled-task lines.
+    let has_plus_marker = output.lines().any(|l| l.trim_start().starts_with("[+]"));
+    if has_plus_marker
+        && (lower.contains("scheduledtask")
+            || lower.contains("scheduled task")
+            || lower.contains("versionnumber")
+            || lower.contains("gpt.ini")
+            || lower.contains("successful"))
+    {
+        return GpoAbuseOutcome::Success;
+    }
+
+    GpoAbuseOutcome::NoEvidence
+}
+
+/// Build the `pygpoabuse_immediate_task` argument JSON. Pure — caller passes
+/// pre-validated values and gets back the shape the tool expects. The
+/// `command` defaults to a benign `whoami` probe written to a unique task
+/// name (the tool refuses to overwrite an existing task without `-f`; we
+/// always pass `force=true` so retries don't trip on a stale half-applied
+/// task from a previous failed run).
+pub(crate) fn build_pygpoabuse_args(
+    domain: &str,
+    username: &str,
+    password: &str,
+    dc_ip: &str,
+    gpo_id: &str,
+    task_name_suffix: &str,
+) -> serde_json::Value {
+    json!({
+        "domain": domain,
+        "username": username,
+        "password": password,
+        "dc_ip": dc_ip,
+        "gpo_id": gpo_id,
+        "command": "cmd /c whoami",
+        "task_name": format!("ARES_GPO_Probe_{}", task_name_suffix),
+        "force": true,
+    })
+}
 
 /// Monitors for GPO write access vulnerabilities and dispatches exploitation.
 /// Interval: 30s.
@@ -139,64 +234,205 @@ pub async fn auto_gpo_abuse(dispatcher: Arc<Dispatcher>, mut shutdown: watch::Re
         };
 
         for item in work {
-            let mut payload = json!({
-                "technique": "gpo_abuse",
-                "vuln_type": "gpo_abuse",
-                "vuln_id": item.vuln_id,
-                "domain": item.domain,
-            });
-
-            if let Some(ref gpo_id) = item.gpo_id {
-                payload["gpo_id"] = json!(gpo_id);
-            }
-            if let Some(ref name) = item.gpo_name {
-                payload["gpo_name"] = json!(name);
-            }
-            if let Some(ref dc) = item.dc_ip {
-                payload["target_ip"] = json!(dc);
-                payload["dc_ip"] = json!(dc);
-            }
-
-            if let Some(ref cred) = item.credential {
-                payload["username"] = json!(cred.username);
-                payload["password"] = json!(cred.password);
-                payload["credential"] = json!({
-                    "username": cred.username,
-                    "password": cred.password,
-                    "domain": cred.domain,
-                });
-            }
-
-            let priority = dispatcher.effective_priority("gpo_abuse");
-            match dispatcher
-                .throttled_submit("exploit", "privesc", payload, priority)
-                .await
-            {
-                Ok(Some(task_id)) => {
-                    info!(
-                        task_id = %task_id,
-                        vuln_id = %item.vuln_id,
-                        source = %item.source_user,
-                        gpo = ?item.gpo_name,
-                        "GPO abuse dispatched"
-                    );
-                    dispatcher
-                        .state
-                        .write()
-                        .await
-                        .mark_processed(DEDUP_GPO_ABUSE, item.dedup_key.clone());
-                    let _ = dispatcher
-                        .state
-                        .persist_dedup(&dispatcher.queue, DEDUP_GPO_ABUSE, &item.dedup_key)
-                        .await;
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    warn!(err = %e, vuln_id = %item.vuln_id, "Failed to dispatch GPO abuse")
-                }
-            }
+            dispatch_gpo_abuse_deterministic(&dispatcher, item).await;
         }
     }
+}
+
+/// Deterministic GPO abuse chain. Runs `pygpoabuse_immediate_task` via
+/// `dispatch_tool` (bypassing the LLM agent loop), parses the tool output,
+/// and either marks the vuln exploited or records a failure for retry.
+///
+/// The dispatch task_id starts with `gpo_abuse_*`, NOT `exploit_*`, so the
+/// standard `mark_exploited` path in `result_processing` does not fire for
+/// this vuln_id — we explicitly call `mark_exploited` on success. Same
+/// scoreboard-credit pattern as the ESC1/ESC3/ESC8/ESC11/mssql_link_pivot
+/// deterministic chains.
+async fn dispatch_gpo_abuse_deterministic(dispatcher: &Arc<Dispatcher>, item: GpoWork) {
+    if dispatcher.state.is_exploit_abandoned(&item.vuln_id).await {
+        info!(
+            vuln_id = %item.vuln_id,
+            "GPO abuse skipped — vuln abandoned (>=MAX_EXPLOIT_FAILURES); locking dedup"
+        );
+        {
+            let mut state = dispatcher.state.write().await;
+            state.mark_processed(DEDUP_GPO_ABUSE, item.dedup_key.clone());
+        }
+        let _ = dispatcher
+            .state
+            .persist_dedup(&dispatcher.queue, DEDUP_GPO_ABUSE, &item.dedup_key)
+            .await;
+        return;
+    }
+
+    let Some(gpo_id) = item.gpo_id.clone() else {
+        debug!(
+            vuln_id = %item.vuln_id,
+            "GPO abuse skipped — no gpo_id on vuln (BloodHound emit didn't capture the container GUID)"
+        );
+        return;
+    };
+    let Some(dc_ip) = item.dc_ip.clone() else {
+        debug!(
+            vuln_id = %item.vuln_id,
+            domain = %item.domain,
+            "GPO abuse skipped — no DC IP known for domain (auto_recon hasn't promoted a DC yet)"
+        );
+        return;
+    };
+    let Some(cred) = item.credential.clone() else {
+        debug!(vuln_id = %item.vuln_id, "GPO abuse skipped — no credential for source user");
+        return;
+    };
+
+    // Mark dedup BEFORE spawning so the next 30s tick doesn't redispatch
+    // while the (~60-90s) pygpoabuse run is in flight.
+    {
+        let mut state = dispatcher.state.write().await;
+        state.mark_processed(DEDUP_GPO_ABUSE, item.dedup_key.clone());
+    }
+    let _ = dispatcher
+        .state
+        .persist_dedup(&dispatcher.queue, DEDUP_GPO_ABUSE, &item.dedup_key)
+        .await;
+
+    // Short uuid suffix so retries don't trip pygpoabuse's "task already
+    // exists" guard. We pass `force=true` anyway, but the unique name keeps
+    // the GPO from accumulating ghost tasks.
+    let task_suffix = uuid::Uuid::new_v4().simple().to_string()[..8].to_string();
+    let tool_args = build_pygpoabuse_args(
+        &item.domain,
+        &cred.username,
+        &cred.password,
+        &dc_ip,
+        &gpo_id,
+        &task_suffix,
+    );
+
+    let task_id = format!(
+        "gpo_abuse_{}",
+        &uuid::Uuid::new_v4().simple().to_string()[..12]
+    );
+    let call = ares_llm::ToolCall {
+        id: format!("pygpoabuse_{}", uuid::Uuid::new_v4().simple()),
+        name: "pygpoabuse_immediate_task".to_string(),
+        arguments: tool_args,
+    };
+
+    info!(
+        task_id = %task_id,
+        vuln_id = %item.vuln_id,
+        source = %item.source_user,
+        gpo = ?item.gpo_name,
+        gpo_id = %gpo_id,
+        dc_ip = %dc_ip,
+        "GPO abuse dispatched (direct tool, no LLM)"
+    );
+
+    let dispatcher_bg = dispatcher.clone();
+    let vuln_id_bg = item.vuln_id.clone();
+    let dedup_key_bg = item.dedup_key.clone();
+    let gpo_name_bg = item.gpo_name.clone();
+    tokio::spawn(async move {
+        let result = dispatcher_bg
+            .llm_runner
+            .tool_dispatcher()
+            .dispatch_tool("privesc", &task_id, &call)
+            .await;
+
+        let outcome = match &result {
+            Ok(exec) => {
+                if exec.error.is_some() {
+                    // Tool reported a non-zero exit. Treat as no-evidence so
+                    // we retry up to the cap, unless the stdout matches a
+                    // known terminal failure pattern.
+                    let parsed = parse_pygpoabuse_output(&exec.output);
+                    if matches!(parsed, GpoAbuseOutcome::Success) {
+                        GpoAbuseOutcome::NoEvidence
+                    } else {
+                        parsed
+                    }
+                } else {
+                    parse_pygpoabuse_output(&exec.output)
+                }
+            }
+            Err(_) => GpoAbuseOutcome::NoEvidence,
+        };
+
+        match outcome {
+            GpoAbuseOutcome::Success => {
+                if let Err(e) = dispatcher_bg
+                    .state
+                    .mark_exploited(&dispatcher_bg.queue, &vuln_id_bg)
+                    .await
+                {
+                    warn!(
+                        err = %e,
+                        vuln_id = %vuln_id_bg,
+                        "Failed to mark GPO abuse exploited (chain succeeded but token not emitted)"
+                    );
+                }
+                info!(
+                    vuln_id = %vuln_id_bg,
+                    gpo = ?gpo_name_bg,
+                    "GPO abuse succeeded — scheduled task XML written; \
+                     downstream code-exec lands on next GP refresh"
+                );
+            }
+            GpoAbuseOutcome::KnownFailure(reason) => {
+                // Distinct failure — record one slot, abandon if at cap.
+                // Don't clear dedup: the cause won't change on retry with
+                // the same input (wrong creds, missing GPO, etc.).
+                let attempts = dispatcher_bg
+                    .state
+                    .record_exploit_failure(&vuln_id_bg)
+                    .await;
+                warn!(
+                    vuln_id = %vuln_id_bg,
+                    reason,
+                    attempts,
+                    "GPO abuse hit a known failure mode; dedup stays locked"
+                );
+            }
+            GpoAbuseOutcome::NoEvidence => {
+                let attempts = dispatcher_bg
+                    .state
+                    .record_exploit_failure(&vuln_id_bg)
+                    .await;
+                let abandoned = dispatcher_bg.state.is_exploit_abandoned(&vuln_id_bg).await;
+                let summary = match &result {
+                    Ok(exec) => exec
+                        .error
+                        .clone()
+                        .unwrap_or_else(|| "no success markers in pygpoabuse output".into()),
+                    Err(e) => format!("dispatch error: {e}"),
+                };
+                if abandoned {
+                    warn!(
+                        vuln_id = %vuln_id_bg,
+                        attempts,
+                        summary = %summary,
+                        "GPO abuse abandoned — exhausted MAX_EXPLOIT_FAILURES; dedup stays locked"
+                    );
+                    return;
+                }
+                warn!(
+                    vuln_id = %vuln_id_bg,
+                    attempts,
+                    summary = %summary,
+                    "GPO abuse: no success markers — clearing dedup for retry on next tick"
+                );
+                {
+                    let mut state = dispatcher_bg.state.write().await;
+                    state.unmark_processed(DEDUP_GPO_ABUSE, &dedup_key_bg);
+                }
+                let _ = dispatcher_bg
+                    .state
+                    .unpersist_dedup(&dispatcher_bg.queue, DEDUP_GPO_ABUSE, &dedup_key_bg)
+                    .await;
+            }
+        }
+    });
 }
 
 struct GpoWork {
@@ -513,5 +749,149 @@ mod tests {
             .unwrap_or("")
             .to_string();
         assert_eq!(domain, "");
+    }
+
+    // ── parse_pygpoabuse_output ────────────────────────────────────────
+
+    #[test]
+    fn parse_pygpoabuse_output_recognises_scheduled_task_success() {
+        // Realistic pygpoabuse output for a successful GPO write: the tool
+        // prints `[+]` lines as each phase lands.
+        let stdout = "[+] versionNumber updated\n\
+            [+] gpt.ini saved\n\
+            [+] ScheduledTask created!\n";
+        assert_eq!(
+            parse_pygpoabuse_output(stdout),
+            GpoAbuseOutcome::Success,
+            "canonical success output must classify as Success"
+        );
+    }
+
+    #[test]
+    fn parse_pygpoabuse_output_success_via_versionnumber_only() {
+        // Some pygpoabuse runs print versionNumber but emit the scheduled-
+        // task line on stderr (which we don't pass through). Treat
+        // versionNumber + [+] marker as success on its own.
+        let stdout = "[+] versionNumber updated to 5\n";
+        assert_eq!(parse_pygpoabuse_output(stdout), GpoAbuseOutcome::Success);
+    }
+
+    #[test]
+    fn parse_pygpoabuse_output_no_markers_is_noevidence() {
+        // Output without any `[+]` markers — almost always means the tool
+        // bailed before writing anything (LDAP connect issues, etc.).
+        let stdout = "Connecting to dc01.contoso.local...\n\
+            Operation pending.\n";
+        assert_eq!(parse_pygpoabuse_output(stdout), GpoAbuseOutcome::NoEvidence);
+    }
+
+    #[test]
+    fn parse_pygpoabuse_output_invalid_credentials_is_known_failure() {
+        let stdout = "[-] Invalid credentials provided\n";
+        assert_eq!(
+            parse_pygpoabuse_output(stdout),
+            GpoAbuseOutcome::KnownFailure("auth")
+        );
+    }
+
+    #[test]
+    fn parse_pygpoabuse_output_kdc_preauth_is_known_failure() {
+        // Kerberos pre-auth failure surfaces with `KDC_ERR_PREAUTH_FAILED`.
+        let stdout = "Error: KDC_ERR_PREAUTH_FAILED\n";
+        assert_eq!(
+            parse_pygpoabuse_output(stdout),
+            GpoAbuseOutcome::KnownFailure("auth")
+        );
+    }
+
+    #[test]
+    fn parse_pygpoabuse_output_gpo_not_found_is_known_failure() {
+        let stdout = "[!] LDAP search failed: no such object\n";
+        assert_eq!(
+            parse_pygpoabuse_output(stdout),
+            GpoAbuseOutcome::KnownFailure("gpo_not_found")
+        );
+    }
+
+    #[test]
+    fn parse_pygpoabuse_output_insufficient_rights_is_known_failure() {
+        let stdout = "Modify operation failed: insufficient access rights\n";
+        assert_eq!(
+            parse_pygpoabuse_output(stdout),
+            GpoAbuseOutcome::KnownFailure("insufficient_rights")
+        );
+    }
+
+    #[test]
+    fn parse_pygpoabuse_output_known_failure_wins_over_success_marker() {
+        // If a [+] marker appears alongside a known auth failure, the
+        // auth verdict still wins — pygpoabuse may have printed the marker
+        // for an earlier phase (e.g., versionNumber read) before the
+        // ScheduledTask write hit the rejected auth path. We don't credit
+        // a partial state.
+        let stdout = "[+] versionNumber updated\n\
+            [-] Invalid credentials provided\n";
+        assert_eq!(
+            parse_pygpoabuse_output(stdout),
+            GpoAbuseOutcome::KnownFailure("auth"),
+            "auth-failure verdict must override partial success marker"
+        );
+    }
+
+    #[test]
+    fn parse_pygpoabuse_output_empty_string_is_noevidence() {
+        assert_eq!(parse_pygpoabuse_output(""), GpoAbuseOutcome::NoEvidence);
+    }
+
+    // ── build_pygpoabuse_args ──────────────────────────────────────────
+
+    #[test]
+    fn build_pygpoabuse_args_includes_all_required_fields() {
+        let args = build_pygpoabuse_args(
+            "contoso.local",
+            "alice",
+            "P@ssw0rd!",
+            "192.168.58.10",
+            "{6AC1786C-016F-11D2-945F-00C04fB984F9}",
+            "abc12345",
+        );
+        assert_eq!(args["domain"], "contoso.local");
+        assert_eq!(args["username"], "alice");
+        assert_eq!(args["password"], "P@ssw0rd!");
+        assert_eq!(args["dc_ip"], "192.168.58.10");
+        assert_eq!(args["gpo_id"], "{6AC1786C-016F-11D2-945F-00C04fB984F9}");
+        assert_eq!(args["task_name"], "ARES_GPO_Probe_abc12345");
+        assert_eq!(args["force"], true);
+        assert!(
+            args["command"].as_str().unwrap().contains("whoami"),
+            "default probe command must include whoami"
+        );
+    }
+
+    #[test]
+    fn build_pygpoabuse_args_force_is_always_true() {
+        // Without force=true, pygpoabuse refuses to overwrite an existing
+        // scheduled task on retry — we'd loop forever after the first
+        // partial run.
+        let args = build_pygpoabuse_args(
+            "contoso.local",
+            "alice",
+            "P@ssw0rd!",
+            "192.168.58.10",
+            "any-gpo",
+            "suffix",
+        );
+        assert_eq!(args["force"], true);
+    }
+
+    #[test]
+    fn build_pygpoabuse_args_task_name_carries_suffix() {
+        // Two different suffixes must produce distinct task_names so retries
+        // don't accumulate ghost tasks on the GPO.
+        let a = build_pygpoabuse_args("d", "u", "p", "10", "g", "alpha111");
+        let b = build_pygpoabuse_args("d", "u", "p", "10", "g", "beta2222");
+        assert_ne!(a["task_name"], b["task_name"]);
+        assert!(a["task_name"].as_str().unwrap().ends_with("alpha111"));
+        assert!(b["task_name"].as_str().unwrap().ends_with("beta2222"));
     }
 }

--- a/ares-cli/src/orchestrator/automation/gpo.rs
+++ b/ares-cli/src/orchestrator/automation/gpo.rs
@@ -22,6 +22,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use ares_core::models::{Credential, VulnerabilityInfo};
 use serde_json::json;
 use tokio::sync::watch;
 use tracing::{debug, info, warn};
@@ -89,6 +90,40 @@ pub(crate) fn parse_pygpoabuse_output(output: &str) -> GpoAbuseOutcome {
     GpoAbuseOutcome::NoEvidence
 }
 
+/// Classify a `pygpoabuse_immediate_task` dispatch result. Splits the two
+/// signals the worker returns — a non-empty `error` field (non-zero exit /
+/// internal failure) versus structured stdout — into a single outcome the
+/// caller routes on. The asymmetry: if the worker flagged an error but the
+/// stdout otherwise parses as `Success`, we downgrade to `NoEvidence` rather
+/// than crediting — partial-success states (e.g. versionNumber bumped before
+/// the scheduled-task write failed) are unsafe to mark exploited.
+pub(crate) fn classify_exec_outcome(output: &str, had_tool_error: bool) -> GpoAbuseOutcome {
+    if had_tool_error {
+        return match parse_pygpoabuse_output(output) {
+            GpoAbuseOutcome::Success => GpoAbuseOutcome::NoEvidence,
+            other => other,
+        };
+    }
+    parse_pygpoabuse_output(output)
+}
+
+/// Format the human-readable failure summary that lands in the
+/// "GPO abuse: no success markers..." warn log. Worker-reported errors
+/// surface first; dispatch errors (Redis BRPOP timeout, queue full, etc.)
+/// take precedence over stdout. The fallback string is reused when both
+/// signals are absent so the log line is never empty.
+pub(crate) fn format_failure_summary(
+    dispatch_error: Option<&str>,
+    tool_error: Option<&str>,
+) -> String {
+    if let Some(e) = dispatch_error {
+        return format!("dispatch error: {e}");
+    }
+    tool_error
+        .map(str::to_string)
+        .unwrap_or_else(|| "no success markers in pygpoabuse output".into())
+}
+
 /// Build the `pygpoabuse_immediate_task` argument JSON. Pure — caller passes
 /// pre-validated values and gets back the shape the tool expects. The
 /// `command` defaults to a benign `whoami` probe written to a unique task
@@ -112,6 +147,96 @@ pub(crate) fn build_pygpoabuse_args(
         "command": "cmd /c whoami",
         "task_name": format!("ARES_GPO_Probe_{}", task_name_suffix),
         "force": true,
+    })
+}
+
+/// Build a [`GpoWork`] for a single vulnerability if every dispatch
+/// precondition is met. Pure helper extracted from the `auto_gpo_abuse`
+/// filter so the per-vuln short-circuit logic (wrong type, already
+/// exploited / processed, no source-user, no matching credential) is
+/// directly testable. The `dc_ip_for_domain` closure abstracts the
+/// `state.domain_controllers` lookup so callers can stub it in tests.
+///
+/// `gpo_id` and `dc_ip` are intentionally returned as `Option` here even
+/// though `dispatch_gpo_abuse_deterministic` requires both: the second
+/// stage's debug logs distinguish "no gpo_id captured" from "no DC IP
+/// resolved", so we keep the discrimination through the work item.
+pub(crate) fn try_build_gpo_work(
+    vuln: &VulnerabilityInfo,
+    credentials: &[Credential],
+    is_exploited: bool,
+    is_processed: bool,
+    dc_ip_for_domain: impl FnOnce(&str) -> Option<String>,
+) -> Option<GpoWork> {
+    if !is_gpo_candidate(&vuln.vuln_type) {
+        return None;
+    }
+    if is_exploited {
+        return None;
+    }
+    let dedup_key = format!("{DEDUP_GPO_ABUSE}:{}", vuln.vuln_id);
+    if is_processed {
+        return None;
+    }
+
+    let source_user = vuln
+        .details
+        .get("source")
+        .or_else(|| vuln.details.get("source_user"))
+        .or_else(|| vuln.details.get("account_name"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())?;
+
+    let gpo_id = vuln
+        .details
+        .get("gpo_id")
+        .or_else(|| vuln.details.get("gpo_guid"))
+        .or_else(|| vuln.details.get("object_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let gpo_name = vuln
+        .details
+        .get("gpo_name")
+        .or_else(|| vuln.details.get("gpo_display_name"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let domain = vuln
+        .details
+        .get("domain")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let credential = credentials
+        .iter()
+        .find(|c| {
+            c.username.to_lowercase() == source_user.to_lowercase()
+                && (domain.is_empty() || c.domain.to_lowercase() == domain.to_lowercase())
+        })
+        .cloned();
+
+    if credential.is_none() {
+        debug!(
+            vuln_id = %vuln.vuln_id,
+            source = %source_user,
+            "GPO abuse skipped: no credential for source user"
+        );
+        return None;
+    }
+
+    let dc_ip = dc_ip_for_domain(&domain.to_lowercase());
+
+    Some(GpoWork {
+        vuln_id: vuln.vuln_id.clone(),
+        dedup_key,
+        source_user,
+        gpo_id,
+        gpo_name,
+        domain,
+        dc_ip,
+        credential,
     })
 }
 
@@ -151,84 +276,16 @@ pub async fn auto_gpo_abuse(dispatcher: Arc<Dispatcher>, mut shutdown: watch::Re
                 .discovered_vulnerabilities
                 .values()
                 .filter_map(|vuln| {
-                    if !is_gpo_candidate(&vuln.vuln_type) {
-                        return None;
-                    }
-
-                    if state.exploited_vulnerabilities.contains(&vuln.vuln_id) {
-                        return None;
-                    }
-
-                    let dedup_key = format!("{DEDUP_GPO_ABUSE}:{}", vuln.vuln_id);
-                    if state.is_processed(DEDUP_GPO_ABUSE, &dedup_key) {
-                        return None;
-                    }
-
-                    let source_user = vuln
-                        .details
-                        .get("source")
-                        .or_else(|| vuln.details.get("source_user"))
-                        .or_else(|| vuln.details.get("account_name"))
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())?;
-
-                    let gpo_id = vuln
-                        .details
-                        .get("gpo_id")
-                        .or_else(|| vuln.details.get("gpo_guid"))
-                        .or_else(|| vuln.details.get("object_id"))
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string());
-
-                    let gpo_name = vuln
-                        .details
-                        .get("gpo_name")
-                        .or_else(|| vuln.details.get("gpo_display_name"))
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string());
-
-                    let domain = vuln
-                        .details
-                        .get("domain")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-
-                    // Find credential for the source user
-                    let credential = state
-                        .credentials
-                        .iter()
-                        .find(|c| {
-                            c.username.to_lowercase() == source_user.to_lowercase()
-                                && (domain.is_empty()
-                                    || c.domain.to_lowercase() == domain.to_lowercase())
-                        })
-                        .cloned();
-
-                    if credential.is_none() {
-                        debug!(
-                            vuln_id = %vuln.vuln_id,
-                            source = %source_user,
-                            "GPO abuse skipped: no credential for source user"
-                        );
-                        return None;
-                    }
-
-                    let dc_ip = state
-                        .domain_controllers
-                        .get(&domain.to_lowercase())
-                        .cloned();
-
-                    Some(GpoWork {
-                        vuln_id: vuln.vuln_id.clone(),
-                        dedup_key,
-                        source_user,
-                        gpo_id,
-                        gpo_name,
-                        domain,
-                        dc_ip,
-                        credential,
-                    })
+                    try_build_gpo_work(
+                        vuln,
+                        &state.credentials,
+                        state.exploited_vulnerabilities.contains(&vuln.vuln_id),
+                        state.is_processed(
+                            DEDUP_GPO_ABUSE,
+                            &format!("{DEDUP_GPO_ABUSE}:{}", vuln.vuln_id),
+                        ),
+                        |dom| state.domain_controllers.get(dom).cloned(),
+                    )
                 })
                 .collect()
         };
@@ -341,21 +398,7 @@ async fn dispatch_gpo_abuse_deterministic(dispatcher: &Arc<Dispatcher>, item: Gp
             .await;
 
         let outcome = match &result {
-            Ok(exec) => {
-                if exec.error.is_some() {
-                    // Tool reported a non-zero exit. Treat as no-evidence so
-                    // we retry up to the cap, unless the stdout matches a
-                    // known terminal failure pattern.
-                    let parsed = parse_pygpoabuse_output(&exec.output);
-                    if matches!(parsed, GpoAbuseOutcome::Success) {
-                        GpoAbuseOutcome::NoEvidence
-                    } else {
-                        parsed
-                    }
-                } else {
-                    parse_pygpoabuse_output(&exec.output)
-                }
-            }
+            Ok(exec) => classify_exec_outcome(&exec.output, exec.error.is_some()),
             Err(_) => GpoAbuseOutcome::NoEvidence,
         };
 
@@ -400,13 +443,9 @@ async fn dispatch_gpo_abuse_deterministic(dispatcher: &Arc<Dispatcher>, item: Gp
                     .record_exploit_failure(&vuln_id_bg)
                     .await;
                 let abandoned = dispatcher_bg.state.is_exploit_abandoned(&vuln_id_bg).await;
-                let summary = match &result {
-                    Ok(exec) => exec
-                        .error
-                        .clone()
-                        .unwrap_or_else(|| "no success markers in pygpoabuse output".into()),
-                    Err(e) => format!("dispatch error: {e}"),
-                };
+                let dispatch_err = result.as_ref().err().map(|e| e.to_string());
+                let tool_err = result.as_ref().ok().and_then(|exec| exec.error.clone());
+                let summary = format_failure_summary(dispatch_err.as_deref(), tool_err.as_deref());
                 if abandoned {
                     warn!(
                         vuln_id = %vuln_id_bg,
@@ -435,15 +474,15 @@ async fn dispatch_gpo_abuse_deterministic(dispatcher: &Arc<Dispatcher>, item: Gp
     });
 }
 
-struct GpoWork {
-    vuln_id: String,
-    dedup_key: String,
-    source_user: String,
-    gpo_id: Option<String>,
-    gpo_name: Option<String>,
-    domain: String,
-    dc_ip: Option<String>,
-    credential: Option<ares_core::models::Credential>,
+pub(crate) struct GpoWork {
+    pub(crate) vuln_id: String,
+    pub(crate) dedup_key: String,
+    pub(crate) source_user: String,
+    pub(crate) gpo_id: Option<String>,
+    pub(crate) gpo_name: Option<String>,
+    pub(crate) domain: String,
+    pub(crate) dc_ip: Option<String>,
+    pub(crate) credential: Option<Credential>,
 }
 
 /// Returns `true` if a vulnerability type represents a GPO abuse candidate.
@@ -893,5 +932,208 @@ mod tests {
         assert_ne!(a["task_name"], b["task_name"]);
         assert!(a["task_name"].as_str().unwrap().ends_with("alpha111"));
         assert!(b["task_name"].as_str().unwrap().ends_with("beta2222"));
+    }
+
+    // ── classify_exec_outcome ─────────────────────────────────────────
+
+    #[test]
+    fn classify_exec_outcome_clean_success_passes_through() {
+        let outcome = classify_exec_outcome("[+] ScheduledTask created!\n", false);
+        assert_eq!(outcome, GpoAbuseOutcome::Success);
+    }
+
+    #[test]
+    fn classify_exec_outcome_tool_error_downgrades_success_to_noevidence() {
+        // The dangerous case: stdout looks like success (versionNumber bump
+        // landed) but the worker reported a non-zero exit. We must NOT mark
+        // exploited — partial-state runs are unsafe to credit.
+        let outcome = classify_exec_outcome("[+] versionNumber updated\n", true);
+        assert_eq!(outcome, GpoAbuseOutcome::NoEvidence);
+    }
+
+    #[test]
+    fn classify_exec_outcome_tool_error_preserves_known_failure() {
+        // Worker error + auth-failure stdout: keep the auth verdict so the
+        // caller burns a failure-counter slot instead of retrying blindly.
+        let outcome = classify_exec_outcome("[-] Invalid credentials provided\n", true);
+        assert_eq!(outcome, GpoAbuseOutcome::KnownFailure("auth"));
+    }
+
+    #[test]
+    fn classify_exec_outcome_tool_error_with_no_evidence_stays_no_evidence() {
+        let outcome = classify_exec_outcome("Connecting...\n", true);
+        assert_eq!(outcome, GpoAbuseOutcome::NoEvidence);
+    }
+
+    // ── format_failure_summary ────────────────────────────────────────
+
+    #[test]
+    fn format_failure_summary_dispatch_error_wins() {
+        // Redis BRPOP timeout / queue full → dispatch error takes precedence
+        // over any tool-side error message.
+        let s = format_failure_summary(Some("redis brpop timeout"), Some("tool stderr"));
+        assert_eq!(s, "dispatch error: redis brpop timeout");
+    }
+
+    #[test]
+    fn format_failure_summary_tool_error_when_no_dispatch_error() {
+        let s = format_failure_summary(None, Some("missing field 'command'"));
+        assert_eq!(s, "missing field 'command'");
+    }
+
+    #[test]
+    fn format_failure_summary_fallback_when_both_absent() {
+        let s = format_failure_summary(None, None);
+        assert_eq!(s, "no success markers in pygpoabuse output");
+    }
+
+    // ── try_build_gpo_work ────────────────────────────────────────────
+
+    fn vuln_with(details: serde_json::Value) -> VulnerabilityInfo {
+        VulnerabilityInfo {
+            vuln_id: "vuln-gpo-001".into(),
+            vuln_type: "gpo_abuse".into(),
+            target: "contoso.local".into(),
+            discovered_by: "bloodhound_collect".into(),
+            discovered_at: chrono::Utc::now(),
+            details: serde_json::from_value(details).unwrap(),
+            recommended_agent: String::new(),
+            priority: 1,
+        }
+    }
+
+    fn alice_cred() -> Credential {
+        Credential {
+            id: "cred-1".into(),
+            username: "alice".into(),
+            password: "P@ssw0rd!".into(),
+            domain: "contoso.local".into(),
+            source: "test".into(),
+            discovered_at: None,
+            is_admin: false,
+            parent_id: None,
+            attack_step: 0,
+        }
+    }
+
+    #[test]
+    fn try_build_gpo_work_happy_path() {
+        let vuln = vuln_with(json!({
+            "source": "alice",
+            "gpo_id": "{6AC1786C-016F-11D2-945F-00C04fB984F9}",
+            "gpo_name": "Default Domain Policy",
+            "domain": "contoso.local",
+        }));
+        let creds = vec![alice_cred()];
+
+        let work = try_build_gpo_work(&vuln, &creds, false, false, |dom| {
+            assert_eq!(dom, "contoso.local");
+            Some("192.168.58.10".into())
+        })
+        .expect("happy path must build work");
+
+        assert_eq!(work.vuln_id, "vuln-gpo-001");
+        assert_eq!(work.dedup_key, "gpo_abuse:vuln-gpo-001");
+        assert_eq!(work.source_user, "alice");
+        assert_eq!(
+            work.gpo_id.as_deref(),
+            Some("{6AC1786C-016F-11D2-945F-00C04fB984F9}")
+        );
+        assert_eq!(work.gpo_name.as_deref(), Some("Default Domain Policy"));
+        assert_eq!(work.domain, "contoso.local");
+        assert_eq!(work.dc_ip.as_deref(), Some("192.168.58.10"));
+        assert!(work.credential.is_some());
+    }
+
+    #[test]
+    fn try_build_gpo_work_skips_non_gpo_vuln() {
+        let mut vuln = vuln_with(json!({"source": "alice", "domain": "contoso.local"}));
+        vuln.vuln_type = "esc1".into();
+        assert!(try_build_gpo_work(&vuln, &[alice_cred()], false, false, |_| None).is_none());
+    }
+
+    #[test]
+    fn try_build_gpo_work_skips_already_exploited() {
+        let vuln = vuln_with(json!({"source": "alice", "domain": "contoso.local"}));
+        assert!(try_build_gpo_work(&vuln, &[alice_cred()], true, false, |_| None).is_none());
+    }
+
+    #[test]
+    fn try_build_gpo_work_skips_already_processed() {
+        let vuln = vuln_with(json!({"source": "alice", "domain": "contoso.local"}));
+        assert!(try_build_gpo_work(&vuln, &[alice_cred()], false, true, |_| None).is_none());
+    }
+
+    #[test]
+    fn try_build_gpo_work_skips_when_source_missing() {
+        let vuln = vuln_with(json!({"gpo_id": "x", "domain": "contoso.local"}));
+        assert!(try_build_gpo_work(&vuln, &[alice_cred()], false, false, |_| None).is_none());
+    }
+
+    #[test]
+    fn try_build_gpo_work_skips_when_no_credential_for_source() {
+        let vuln = vuln_with(json!({"source": "bob", "domain": "contoso.local"}));
+        // No matching credential — alice doesn't match "bob".
+        assert!(try_build_gpo_work(&vuln, &[alice_cred()], false, false, |_| None).is_none());
+    }
+
+    #[test]
+    fn try_build_gpo_work_credential_match_is_case_insensitive() {
+        let vuln = vuln_with(json!({"source": "ALICE", "domain": "CONTOSO.LOCAL"}));
+        let work = try_build_gpo_work(&vuln, &[alice_cred()], false, false, |_| {
+            Some("192.168.58.10".into())
+        });
+        assert!(work.is_some(), "credential match must ignore case");
+    }
+
+    #[test]
+    fn try_build_gpo_work_credential_match_when_vuln_domain_empty() {
+        // Empty domain on the vuln → match purely on username.
+        let vuln = vuln_with(json!({"source": "alice"}));
+        let work = try_build_gpo_work(&vuln, &[alice_cred()], false, false, |_| None);
+        assert!(
+            work.is_some(),
+            "empty vuln domain should still match credential by username"
+        );
+    }
+
+    #[test]
+    fn try_build_gpo_work_dc_ip_lookup_returns_none_propagates() {
+        let vuln = vuln_with(json!({"source": "alice", "domain": "contoso.local"}));
+        let work = try_build_gpo_work(&vuln, &[alice_cred()], false, false, |_| None)
+            .expect("missing DC IP must still produce work — second-stage handles it");
+        assert!(work.dc_ip.is_none());
+    }
+
+    #[test]
+    fn try_build_gpo_work_gpo_id_fallback_chain() {
+        // Primary key
+        let v1 =
+            vuln_with(json!({"source": "alice", "domain": "contoso.local", "gpo_id": "primary"}));
+        let w1 = try_build_gpo_work(&v1, &[alice_cred()], false, false, |_| None).unwrap();
+        assert_eq!(w1.gpo_id.as_deref(), Some("primary"));
+
+        // Fallback to gpo_guid
+        let v2 =
+            vuln_with(json!({"source": "alice", "domain": "contoso.local", "gpo_guid": "guid"}));
+        let w2 = try_build_gpo_work(&v2, &[alice_cred()], false, false, |_| None).unwrap();
+        assert_eq!(w2.gpo_id.as_deref(), Some("guid"));
+
+        // Fallback to object_id
+        let v3 =
+            vuln_with(json!({"source": "alice", "domain": "contoso.local", "object_id": "obj"}));
+        let w3 = try_build_gpo_work(&v3, &[alice_cred()], false, false, |_| None).unwrap();
+        assert_eq!(w3.gpo_id.as_deref(), Some("obj"));
+    }
+
+    #[test]
+    fn try_build_gpo_work_gpo_name_fallback_to_display_name() {
+        let v = vuln_with(json!({
+            "source": "alice",
+            "domain": "contoso.local",
+            "gpo_display_name": "Workstation Lockdown",
+        }));
+        let w = try_build_gpo_work(&v, &[alice_cred()], false, false, |_| None).unwrap();
+        assert_eq!(w.gpo_name.as_deref(), Some("Workstation Lockdown"));
     }
 }


### PR DESCRIPTION
**Key Changes:**

- Replaces the LLM-routed GPO abuse dispatch with a deterministic chain that calls `pygpoabuse_immediate_task` directly via `dispatch_tool` and `mark_exploited` on success
- Adds an output parser (`parse_pygpoabuse_output`) classifying the tool result as Success / NoEvidence / KnownFailure(reason); auth failures, missing-GPO, and insufficient-rights now burn a failure-counter slot instead of looping
- Adds an args builder (`build_pygpoabuse_args`) that injects a unique `ARES_GPO_Probe_<suffix>` task name, a benign `cmd /c whoami` payload, and `force=true` so retries don't trip the tool's "task already exists" guard

**Added:**

- `GpoAbuseOutcome` enum (`Success` | `NoEvidence` | `KnownFailure(&'static str)`) and `parse_pygpoabuse_output` covering pygpoabuse's `[+]`/`[-]`/`[!]` line prefixes - `ares-cli/src/orchestrator/automation/gpo.rs`
- `build_pygpoabuse_args` producing the `pygpoabuse_immediate_task` JSON shape with a unique `ARES_GPO_Probe_<suffix>` task name and `force=true` default
- Explicit `mark_exploited` call inside the deterministic spawn so the `gpo_abuse_*` task-id bypasses the `exploit_*` gate in `result_processing` while still crediting the scoreboard - same pattern as ESC1/ESC8/ESC11/mssql_link_pivot
- 12 unit tests covering parser branches (success markers, KDC pre-auth, no-such-object, insufficient access, partial-success-with-auth-failure) and the args builder (suffix uniqueness, force flag, required field shape)

**Changed:**

- Reworked `auto_gpo_abuse` to invoke `dispatch_gpo_abuse_deterministic` instead of `throttled_submit("exploit", "privesc", payload, ...)` — the prior path frequently routed to unrelated tools (e.g. `bloodhound_collect`) because `technique=gpo_abuse` did not deterministically map to `pygpoabuse`, and omitted the required `command` field even when routing landed correctly
- Updated in-flight deduplication and abandon-on-cap handling around the deterministic dispatch so retries unlock the dedup only on `NoEvidence`; `KnownFailure` keeps dedup locked because the cause won't change on retry with the same input
