### PR TITLE
fix: route ntlmv1_downgrade vuln through generic exploitation (orphan)

### DIFF
--- a/ares-cli/src/orchestrator/exploitation.rs
+++ b/ares-cli/src/orchestrator/exploitation.rs
@@ -31,7 +31,18 @@ fn is_automation_owned_vuln(vtype: &str) -> bool {
             | "smb_signing_disabled"
             | "ldap_signing_disabled"
             | "ldap_signing_not_required"
-            | "ntlmv1_downgrade"
+            // NOTE: `ntlmv1_downgrade` was previously gated as automation-
+            // owned, but the planned dedicated automation never landed.
+            // The vuln was emitted by `auto_ntlmv1_downgrade` (detection
+            // only) and then dropped on the floor — every op accumulated
+            // unexploited ntlmv1_downgrade vulns at priority 3 and never
+            // attempted a coerce-and-downgrade chain. Routing it through
+            // the generic LLM-routed exploit workflow at least gives the
+            // primitive one attempt per dispatch; the assist-pattern-key
+            // fix (PR 312) prevents the retry storm on RequestAssistance.
+            // When a deterministic ntlmv1 chain (PetitPotam unauth → ntlm
+            // relay with --remove-mic --remove-target-pcheck → NTLMv1
+            // capture → crack.sh) lands, re-add this entry.
             | "genericall"
             | "genericwrite"
             | "writedacl"
@@ -281,7 +292,6 @@ mod tests {
             "smb_signing_disabled",
             "ldap_signing_disabled",
             "ldap_signing_not_required",
-            "ntlmv1_downgrade",
             "esc1",
             // Added when the dedicated automations landed.
             "shadow_credentials",
@@ -294,6 +304,26 @@ mod tests {
                 "{vtype} should be automation-owned"
             );
         }
+    }
+
+    #[test]
+    fn ntlmv1_downgrade_routes_through_generic_exploitation() {
+        // ntlmv1_downgrade has no dedicated exploitation automation —
+        // `auto_ntlmv1_downgrade` only detects + registers the vuln. Keeping
+        // it in the automation-owned list orphaned the vuln (discovered
+        // but never exploited). Live op evidence (op-20260513-105527):
+        // 2 ntlmv1_downgrade vulns at priority 3 sat ✗ unexploited for
+        // 33 minutes. The generic LLM-routed workflow at least gives it
+        // one attempt per dispatch; assist_pattern_key (PR 312) keeps a
+        // failed RequestAssistance from retrying through MAX_EXPLOIT_FAILURES.
+        assert!(
+            !is_automation_owned_vuln("ntlmv1_downgrade"),
+            "ntlmv1_downgrade must route through generic exploitation \
+             until a deterministic NTLMv1 coerce/downgrade/capture chain lands"
+        );
+        // Case-insensitive — the matcher lowercases before comparing.
+        assert!(!is_automation_owned_vuln("NTLMv1_Downgrade"));
+        assert!(!is_automation_owned_vuln("NTLMV1_DOWNGRADE"));
     }
 
     #[test]


### PR DESCRIPTION
**Key Changes:**

- Removed ntlmv1_downgrade from the list of automation-owned vulnerabilities
- Ensured ntlmv1_downgrade is handled by the generic LLM-routed exploit workflow
- Added targeted tests to verify ntlmv1_downgrade is no longer treated as automation-owned

**Added:**

- Introduced a test confirming ntlmv1_downgrade is not considered automation-owned and is case-insensitive in matching

**Changed:**

- Updated is_automation_owned_vuln to exclude ntlmv1_downgrade, allowing it to route through generic exploitation for at least one attempt per dispatch
- Provided explanatory comments on the reasoning and operational evidence behind this routing change

**Removed:**

- Removed ntlmv1_downgrade from the automation-owned vuln test cases to reflect the new workflow
