### PR TITLE
ci(renovate): switch github-actions automerge from branch to pr

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,6 @@
     ':semanticCommits',
     ':enablePreCommit',
     ':automergeDigest',
-    ':automergeBranch',
     'helpers:pinGitHubActionDigests',
   ],
   dependencyDashboardLabels: [
@@ -54,7 +53,7 @@
         'patch',
       ],
       automerge: true,
-      automergeType: 'branch',
+      automergeType: 'pr',
     },
     {
       description: 'Auto merge warpgate patch and minor updates',


### PR DESCRIPTION
## Summary

Renovate's `automergeType: 'branch'` strategy bypasses GitHub's platform auto-merge, so digest/version-bump PRs only get merged during a Renovate run (cron: Sun/Wed 00:00 UTC). When CI finishes after Renovate exits, the PR sits green for days until the next run.

Switching to `automergeType: 'pr'` lets the global `platformAutomerge: true` setting take effect — GitHub turns auto-merge on at PR creation and merges as soon as checks go green, independent of Renovate's cron.

## Changes

- Removed `:automergeBranch` preset from `extends` (was forcing `automergeType: 'branch'` globally).
- Changed the GitHub Actions `packageRule` from `automergeType: 'branch'` → `'pr'`.

## Test plan

- [ ] Wait for next renovate cron run (or manually `gh workflow run renovate.yaml`)
- [ ] Confirm new GitHub Actions PRs are opened with auto-merge enabled (visible in PR sidebar)
- [ ] Confirm they merge automatically once checks pass without waiting for next Renovate run