### PR TITLE
fix: honor blue-specific llm model configuration

### DIFF
--- a/ares-cli/src/worker/mod.rs
+++ b/ares-cli/src/worker/mod.rs
@@ -121,9 +121,16 @@ pub async fn run() -> anyhow::Result<()> {
         }
         #[cfg(feature = "blue")]
         config::WorkerMode::BlueTask => {
-            // Blue team mode requires an LLM provider
-            let model_spec = std::env::var("ARES_LLM_MODEL")
-                .unwrap_or_else(|_| "anthropic/claude-sonnet-4-20250514".to_string());
+            // Blue team mode requires an LLM provider. Prefer the blue-specific
+            // override, then fall back to the shared model var. Matches the
+            // orchestrator's blue-only mode (see orchestrator/mod.rs).
+            let model_spec = std::env::var("ARES_BLUE_LLM_MODEL")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .or_else(|| std::env::var("ARES_LLM_MODEL").ok().filter(|s| !s.is_empty()))
+                .ok_or_else(|| anyhow::anyhow!(
+                    "No LLM model configured for blue worker — set ARES_BLUE_LLM_MODEL or ARES_LLM_MODEL"
+                ))?;
             let (provider, model_name) = match ares_llm::create_provider(&model_spec) {
                 Ok(p) => p,
                 Err(e) => {


### PR DESCRIPTION
## Summary
- Blue workers now prefer `ARES_BLUE_LLM_MODEL`, then fall back to `ARES_LLM_MODEL`, mirroring the orchestrator's blue-only mode.
- Removed the hardcoded `anthropic/claude-sonnet-4-20250514` default that caused blue workers to ask for `ANTHROPIC_API_KEY` when the var was unset.
- Worker errors explicitly when neither var is configured instead of silently falling back to a Claude model.

## Test plan
- [x] `cargo check -p ares-cli --features blue`
- [ ] Deploy to K8s and run a blue-team operation; confirm workers pick up `ARES_BLUE_LLM_MODEL` and no longer request `ANTHROPIC_API_KEY`