### PR TITLE
refactor: remove needless borrows and simplify map iteration

### DIFF
--- a/ares-cli/src/orchestrator/automation/credential_expansion.rs
+++ b/ares-cli/src/orchestrator/automation/credential_expansion.rs
@@ -412,7 +412,7 @@ pub async fn auto_credential_expansion(
                         let sd_dedup = format!(
                             "{}:{}:{}",
                             dc_ip,
-                            &item.resolved_domain,
+                            item.resolved_domain,
                             item.hash.username.to_lowercase()
                         );
                         let already = {

--- a/ares-cli/src/orchestrator/blue/chaining.rs
+++ b/ares-cli/src/orchestrator/blue/chaining.rs
@@ -353,7 +353,7 @@ async fn dispatch_chain_task(
         "chain_{}_{}_{}_{}",
         action.task_type,
         evidence_type,
-        &investigation_id.chars().take(8).collect::<String>(),
+        investigation_id.chars().take(8).collect::<String>(),
         &uuid::Uuid::new_v4().simple().to_string()[..8]
     );
 

--- a/ares-core/src/eval/workflow/runner.rs
+++ b/ares-core/src/eval/workflow/runner.rs
@@ -94,7 +94,7 @@ pub fn evaluate_scenario(scenario: &EvaluationScenario) -> Result<ScenarioEvalua
     // Build a minimal snapshot (no investigation data — scores reflect baseline)
     let snap = scorers::InvestigationSnapshot::default();
 
-    let eval_id = format!("eval-{}", &state.operation_id);
+    let eval_id = format!("eval-{}", state.operation_id);
     let result = scorers::evaluate(&eval_id, &snap, &ground_truth, false, "", 0.0);
 
     let gap_analysis = analyze_detection_gaps(&result);

--- a/ares-core/src/reports/redteam.rs
+++ b/ares-core/src/reports/redteam.rs
@@ -261,7 +261,7 @@ impl RedTeamReportGenerator {
             let key = h.hash_value.trim().to_lowercase();
             symmetric_groups.entry(key).or_default().push(i);
         }
-        for (_hv, idxs) in symmetric_groups.iter() {
+        for idxs in symmetric_groups.values() {
             if idxs.len() < 2 {
                 continue;
             }

--- a/ares-tools/src/blue/engines/data.rs
+++ b/ares-tools/src/blue/engines/data.rs
@@ -313,7 +313,7 @@ mod tests {
     #[test]
     fn climb_strategies_entries_have_template() {
         let strategies = climb_strategies();
-        for (_, entries) in strategies.iter() {
+        for entries in strategies.values() {
             for entry in entries {
                 assert!(!entry.template.is_empty());
                 assert!(!entry.target.is_empty());

--- a/ares-tools/src/blue/learning/mitre_db.rs
+++ b/ares-tools/src/blue/learning/mitre_db.rs
@@ -683,7 +683,7 @@ mod tests {
 
     #[test]
     fn all_evidence_map_techniques_exist_in_db() {
-        for (_, tech_ids) in EVIDENCE_MAP.iter() {
+        for tech_ids in EVIDENCE_MAP.values() {
             for tid in tech_ids {
                 // Either the technique or its parent should be in the DB
                 let parent = tid.split('.').next().unwrap_or(tid);


### PR DESCRIPTION
**Key Changes:**

- Eliminated redundant borrows in format! and string construction
- Iterated over map values directly to avoid unused bindings
- Simplified ID/key composition by removing superfluous references
- Aligned code with clippy suggestions for readability and consistency

**Changed:**

- Removed unnecessary reference operators in string formatting and ID assembly to address clippy’s needless_borrow and improve clarity:
  - Use item.resolved_domain directly in auto_credential_expansion - ares-cli/src/orchestrator/automation/credential_expansion.rs
  - Drop redundant & when collecting the investigation_id prefix in dispatch_chain_task - ares-cli/src/orchestrator/blue/chaining.rs
  - Simplify evaluation ID creation by passing state.operation_id without extra referencing in evaluate_scenario - ares-core/src/eval/workflow/runner.rs
- Replaced map tuple iteration with values() to avoid unused key bindings and clarify intent:
  - Iterate over symmetric_groups.values() in RedTeamReportGenerator’s grouping logic - ares-core/src/reports/redteam.rs
  - Iterate over strategies.values() in climb_strategies test - ares-tools/src/blue/engines/data.rs
  - Iterate over EVIDENCE_MAP.values() in MITRE DB consistency test - ares-tools/src/blue/learning/mitre_db.rs
